### PR TITLE
Fix a few documentation typos.

### DIFF
--- a/_gitbook/builtin_types/value.md
+++ b/_gitbook/builtin_types/value.md
@@ -2,7 +2,7 @@
 
 `Value` is the base class of the primitive types (`Nil`, `Bool`, `Char`, integers and floats), `Symbol`, `Pointer`, `Tuple`, `StaticArray` and all structs.
 
-As the name suggest, a `Value` is passed by value: when you pass it to methods ot return it from methods, a copy of the value is actually passed. This is not important for `nil`, bools, integers, floats, symbols, pointers and tuples, because they are immutable, but with mutable structs or with static arrays you have to be careful:
+As the name suggest, a `Value` is passed by value: when you pass it to methods or return it from methods, a copy of the value is actually passed. This is not important for `nil`, bools, integers, floats, symbols, pointers and tuples, because they are immutable, but with mutable structs or with static arrays you have to be careful:
 
 ```ruby
 struct Point

--- a/_gitbook/syntax_and_semantics/and.md
+++ b/_gitbook/syntax_and_semantics/and.md
@@ -1,6 +1,6 @@
 # &&
 
-An `&&` (and) evaluates its left hand side. If its *truthy*, it evaluates its right hand side and has that value. Otherwise it has the value of the left hand side. Its type is the union of the types of both sides.
+An `&&` (and) evaluates its left hand side. If it's *truthy*, it evaluates its right hand side and has that value. Otherwise it has the value of the left hand side. Its type is the union of the types of both sides.
 
 You can think an `&&` as syntax sugar of an `if`:
 

--- a/_gitbook/syntax_and_semantics/classes_and_methods.md
+++ b/_gitbook/syntax_and_semantics/classes_and_methods.md
@@ -1,6 +1,6 @@
 # Classes and methods
 
-A class is a blueprint from which individual objects are created. As an example, lets consider a `Person` class. You declare a class like this:
+A class is a blueprint from which individual objects are created. As an example, consider a `Person` class. You declare a class like this:
 
 ``` ruby
 class Person

--- a/_gitbook/syntax_and_semantics/global_variables.md
+++ b/_gitbook/syntax_and_semantics/global_variables.md
@@ -6,4 +6,4 @@ Global variables start with a dollar sign (`$`). They are declared when you firs
 $year = 2014
 ```
 
-Their type is the combined type of all expressions that were assigned to them. Additionally, if you program reads a global variable before it was ever assigned a value it will also have the `Nil` type.
+Their type is the combined type of all expressions that were assigned to them. Additionally, if your program reads a global variable before it was ever assigned a value it will also have the `Nil` type.

--- a/_gitbook/syntax_and_semantics/instace_variables_type_inference.md
+++ b/_gitbook/syntax_and_semantics/instace_variables_type_inference.md
@@ -1,4 +1,4 @@
-# Instace variables type inference
+# Instance variables type inference
 
 Did you notice that in all of the previous examples we never said the types of a `Person`'s `@name` and `@age`? This is because the compiler inferred them for us.
 

--- a/_gitbook/syntax_and_semantics/local_variables.md
+++ b/_gitbook/syntax_and_semantics/local_variables.md
@@ -9,7 +9,7 @@ age = 1
 
 Their type is inferred from their usage, not only from their initializer. In general, they are just value holders associated with the type that the programmer expects them to have according to their location and usage on the program.
 
-For example, reassinging a variable with a different expression makes it have that expression’s type:
+For example, reassigning a variable with a different expression makes it have that expression’s type:
 
 ``` ruby
 var = "Hello"

--- a/_gitbook/syntax_and_semantics/methods_and_instance_variables.md
+++ b/_gitbook/syntax_and_semantics/methods_and_instance_variables.md
@@ -48,7 +48,7 @@ class Person
 end
 ```
 
-If you redefine a method, the last once will take precedence.
+If you redefine a method, the last definition will take precedence.
 
 ``` ruby
 class Person

--- a/_gitbook/syntax_and_semantics/multiple_assignment.md
+++ b/_gitbook/syntax_and_semantics/multiple_assignment.md
@@ -12,7 +12,7 @@ name  = temp1
 age   = temp2
 ```
 
-Note that because expressions are assigned to temporary variables it is possible to exchange variables’s contents in a single line:
+Note that because expressions are assigned to temporary variables it is possible to exchange variables’ contents in a single line:
 
 ``` ruby
 a = 1

--- a/_gitbook/syntax_and_semantics/or.md
+++ b/_gitbook/syntax_and_semantics/or.md
@@ -1,6 +1,6 @@
 # ||
 
-An `||` (or) evaluates its left hand side. If its *falsey*, it evaluates its right hand side and has that value. Otherwise it has the value of the left hand side. Its type is the union of the types of both sides.
+An `||` (or) evaluates its left hand side. If it's *falsey*, it evaluates its right hand side and has that value. Otherwise it has the value of the left hand side. Its type is the union of the types of both sides.
 
 You can think an `||` as syntax sugar of an `if`:
 

--- a/_gitbook/syntax_and_semantics/requiring_files.md
+++ b/_gitbook/syntax_and_semantics/requiring_files.md
@@ -4,7 +4,7 @@ Writing a program in a single file is OK for little snippets and small benchmark
 
 To make the compiler process other files you use `require "..."`. It accepts a single argument, a string literal, and it can come in many flavors.
 
-Once a file is required, the compiler remembers its absolute path and later requires of that same file will be ignored.
+Once a file is required, the compiler remembers its absolute path and later `require`s of that same file will be ignored.
 
 ## require "filename"
 
@@ -54,12 +54,12 @@ require "../src/project"
 
 In both cases you can use nested names and they will be looked up in nested directories:
 
-* require "foo/bar/baz" will lookup "foo/bar/baz.cr" or "foo/bar/baz/baz.cr" in the require path.
-* require "./foo/bar/baz" will lookup "foo/bar/baz.cr" or "foo/bar/baz/baz.cr" relative to the current file.
+* `require "foo/bar/baz"` will lookup "foo/bar/baz.cr" or "foo/bar/baz/baz.cr" in the require path.
+* `require "./foo/bar/baz"` will lookup "foo/bar/baz.cr" or "foo/bar/baz/baz.cr" relative to the current file.
 
 You can also use "../" to access parent directories relative to the current file, so `require "../../foo/bar"` works as well.
 
 In all of these cases you can use the special `*` and `**` suffixes:
 
-* require "foo/*" will require all ".cr" files below the "foo" directory, but not below directories inside "foo".
-* require "foo/**" will require all ".cr" files below the "foo" directory, and below directories inside "foo", recursively.
+* `require "foo/*"` will require all ".cr" files below the "foo" directory, but not below directories inside "foo".
+* `require "foo/**"` will require all ".cr" files below the "foo" directory, and below directories inside "foo", recursively.

--- a/_gitbook/syntax_and_semantics/until.md
+++ b/_gitbook/syntax_and_semantics/until.md
@@ -1,6 +1,6 @@
 # until
 
-An `until` executes its body until its condition is *truthy*. An `until` is just syntax sugar for a while with the condition negated:
+An `until` executes its body until its condition is *truthy*. An `until` is just syntax sugar for a `while` with the condition negated:
 
 ``` ruby
 until some_condition

--- a/_gitbook/syntax_and_semantics/while.md
+++ b/_gitbook/syntax_and_semantics/while.md
@@ -10,7 +10,7 @@ end
 
 In the above form, the condition is first tested and, if *truthy*, the body is executed. That is, the body might never be executed.
 
-To execute the body at least once and then continue executing it while the condition is *truthy*, write the while as a prefix:
+To execute the body at least once and then continue executing it while the condition is *truthy*, write the while as a suffix:
 
 ``` ruby
 do_this while some_condition
@@ -25,7 +25,7 @@ begin
 end while some_condition
 ```
 
-A while's type is always `Nil`.
+A `while`'s type is always `Nil`.
 
 Similar to an `if`, if a `while`'s condition is a variable, the variable is guaranteed to not be `nil` inside the body. If the condition is an `var.is_a?(Type)` test, `var` is guaranteed to be of type Type inside the body. And if the condition is a `var.responds_to?(:method)`, `var` is guaranteed to be of a type that responds to that method.
 


### PR DESCRIPTION
I was reading the Crystal documentation (which is very clear!) and fixed a few small typos along the way. 

I'm not familiar with gitbook. My 'rake build' didn't generate modified documentation. Included are only source changes to the underlying markdown.