### PR TITLE
RNG namespace for number generators

### DIFF
--- a/spec/std/rng/isaac_spec.cr
+++ b/spec/std/rng/isaac_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
-require "random/isaac"
+require "rng/isaac"
 
-describe "Random::ISAAC" do
+describe "RNG::ISAAC" do
   it "generates random numbers as generated official implementation" do
     numbers = [
       0xc9d3bc51, 0x5bc24339, 0x23e22e3a, 0x5659b89a, 0x21c6dcfd, 0x168e10a4, 0x1df755f6, 0x99d3a910,
@@ -340,9 +340,9 @@ describe "Random::ISAAC" do
       1952999273, 1954114848, 779384933,
     ]
 
-    m = Random::ISAAC.new seed
+    m = RNG::ISAAC.new seed
     numbers.each do |n|
-      m.next_number.should eq(n)
+      m.next_int.should eq(n)
     end
   end
 end

--- a/spec/std/rng/mt19937_spec.cr
+++ b/spec/std/rng/mt19937_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
+require "rng/mt19937"
 
-describe "Random::MT19937" do
+describe "RNG::MT19937" do
   it "generates random numbers as generated official implementation" do
 
     # 1000 generated rundom numbers by official C implementation
@@ -209,9 +210,9 @@ describe "Random::MT19937" do
         2643151863, 3896204135, 2416995901, 1397735321, 3460025646,
     ]
 
-    m = Random::MT19937.new [0x123, 0x234, 0x345, 0x456]
+    m = RNG::MT19937.new [0x123, 0x234, 0x345, 0x456]
     numbers.each do |n|
-      m.next_number.should eq(n)
+      m.next_int.should eq(n)
     end
   end
 end

--- a/src/random.cr
+++ b/src/random.cr
@@ -1,57 +1,21 @@
-require "random/mt19937"
+require "rng/mt19937"
 
-class Random
-  def initialize(engine_class, seed)
-    @engine = engine_class.new(seed)
+module Random
+  DEFAULT = RNG::MT19937.new
+
+  def rand
+    DEFAULT.rand
   end
 
-  def initialize(engine_class = MT19937)
-    @engine = engine_class.new
-  end
-
-  def rand()
-    # Divided by 2^32-1
-    @engine.next_number * (1.0/4294967295.0)
-  end
-
-  def rand(x : Int)
-    if x > 0
-      @engine.next_number % x
-    else
-      raise ArgumentError.new "incorrect rand value: #{x}"
-    end
-  end
-
-  def rand(x : Range(Int32, Int32))
-    span = x.end - x.begin
-    span += 1 unless x.excludes_end?
-    if span > 0
-      x.begin + rand(span)
-    else
-      raise ArgumentError.new "incorrect rand value: #{x}"
-    end
-  end
-
-  DEFAULT_RANDOM = Random.new
-
-  def self.new_seed()
-    Intrinsics.read_cycle_counter.to_u32
-  end
-
-  def self.rand()
-    DEFAULT_RANDOM.rand
-  end
-
-  def self.rand(x)
-    DEFAULT_RANDOM.rand(x)
+  def rand(x)
+    DEFAULT.rand(x)
   end
 end
 
-def rand()
-  Random.rand
+def rand
+  Random::DEFAULT.rand
 end
 
 def rand(x)
-  Random.rand(x)
+  Random::DEFAULT.rand(x)
 end
-

--- a/src/rng/isaac.cr
+++ b/src/rng/isaac.cr
@@ -2,12 +2,14 @@
 # You may use this code in any way you wish, and it is free.  No warrantee.
 # http://burtleburtle.net/bob/rand/isaacafa.html
 
-class Random
-  class ISAAC
+require "rng"
+
+class RNG
+  class ISAAC < RNG
     getter :rsl
     private getter :counter, :aa, :bb, :cc
 
-    def initialize(seeds = StaticArray(UInt32, 8).new { Random.new_seed })
+    def initialize(seeds = StaticArray(UInt32, 8).new { RNG.new_seed })
       @rsl = StaticArray(UInt32, 256).new { 0_u32 }
       @mm = StaticArray(UInt32, 256).new { 0_u32 }
       @counter = 0
@@ -15,7 +17,7 @@ class Random
       init_by_array(seeds)
     end
 
-    def next_number
+    def next_int
       if (@counter -= 1) == -1
         isaac
         @counter = 255

--- a/src/rng/mt19937.cr
+++ b/src/rng/mt19937.cr
@@ -1,12 +1,14 @@
-class Random
-  class MT19937
+require "rng"
+
+class RNG
+  class MT19937 < RNG
     N = 624
     M = 397
     MATRIX_A = 0x9908b0dfu32
     UPPER_MASK = 0x80000000u32
     LOWER_MASK = 0x7fffffffu32
 
-    def initialize(seeds = StaticArray(UInt32, 4).new { Random.new_seed })
+    def initialize(seeds = StaticArray(UInt32, 4).new { RNG.new_seed })
       @mt = StaticArray(UInt32, 624).new(0u32)
       @mti = N + 1
       init_by_array(seeds)
@@ -69,7 +71,7 @@ class Random
       @mt[0] = 0x80000000u32
     end
 
-    def next_number()
+    def next_int
       if @mti >= N
         if @mti == N + 1
           init_genrand(5489u32)

--- a/src/rng/rng.cr
+++ b/src/rng/rng.cr
@@ -1,0 +1,30 @@
+class RNG
+  def next_float
+    # Divided by 2^32-1
+    next_int * (1.0/4294967295.0)
+  end
+
+  alias_method :rand, :next_float
+
+  def rand(x : Int)
+    if x > 0
+      next_int % x
+    else
+      raise ArgumentError.new "incorrect rand value: #{x}"
+    end
+  end
+
+  def rand(x : Range(Int32, Int32))
+    span = x.end - x.begin
+    span += 1 unless x.excludes_end?
+    if span > 0
+      x.begin + rand(span)
+    else
+      raise ArgumentError.new "incorrect rand value: #{x}"
+    end
+  end
+
+  def self.new_seed
+    Intrinsics.read_cycle_counter.to_u32
+  end
+end


### PR DESCRIPTION
Implements some changes as discussed in #330 

The number generators are now under the RNG namespace and inherit from the RNG base class. I moved the `rand` methods to this base class, which means that Random is nothing but an indirection module for RNG::MT19937. There are no more `Random.new(engine[, seed])` but the more direct `RNG::MT19937.new [seed]` and `RNG::ISAAC.new [seed]`.

I'm not sure I got things as @scidom and @asterite suggested. Maybe the RNG base class should be Random instead?