### PR TITLE
Added: IPv6, UDP and UNIX sockets

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -1,0 +1,58 @@
+require "spec"
+require "socket"
+
+describe "UNIXSocket" do
+  it "sends and receives messages" do
+    path = "/tmp/crystal-test-unix-sock"
+
+    UNIXServer.open(path) do |server|
+      UNIXSocket.open(path) do |client|
+        server.accept do |sock|
+          client << "ping"
+          sock.read(4).should eq("ping")
+          sock << "pong"
+          client.read(4).should eq("pong")
+        end
+      end
+    end
+  end
+
+  it "creates a pair of sockets" do
+    UNIXSocket.pair("/tmp/sock") do |left, right|
+      left << "ping"
+      right.read(4).should eq("ping")
+      right << "pong"
+      left.read(4).should eq("pong")
+    end
+  end
+end
+
+describe "TCPSocket" do
+  it "sends and receives messages" do
+    TCPServer.open("::", 12345) do |server|
+      TCPSocket.open("localhost", 12345) do |client|
+        sock = server.accept
+        client << "ping"
+        sock.read(4).should eq("ping")
+        sock << "pong"
+        client.read(4).should eq("pong")
+      end
+    end
+  end
+end
+
+describe "UDPSocket" do
+  it "sends and receives messages" do
+    server = UDPSocket.new(C::AF_INET6)
+    server.bind("::", 12346)
+
+    client = UDPSocket.new(C::AF_INET)
+    client.connect("localhost", 12346)
+
+    client << "message"
+    server.read(7).should eq("message")
+
+    client.close
+    server.close
+  end
+end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -10,7 +10,7 @@ lib C
     next : Addrinfo*
   end
 
-  fun freeaddrinfo(addr : Addrinfo*) : Int32
+  fun freeaddrinfo(addr : Addrinfo*) : Void
   fun gai_strerror(code : Int32) : UInt8*
   fun getaddrinfo(name : UInt8*, service : UInt8*, hints : Addrinfo*, pai : Addrinfo**) : Int32
   fun getnameinfo(addr : SockAddr*, addrlen : Int32, host : UInt8*, hostlen : Int32, serv : UInt8*, servlen : Int32, flags : Int32) : Int32

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -1,0 +1,33 @@
+lib C
+  struct Addrinfo
+    flags : Int32
+    family : Int32
+    socktype : Int32
+    protocol : Int32
+    addrlen : Int32
+    addr : SockAddr*
+    canonname : UInt8*
+    next : Addrinfo*
+  end
+
+  fun freeaddrinfo(addr : Addrinfo*) : Int32
+  fun gai_strerror(code : Int32) : UInt8*
+  fun getaddrinfo(name : UInt8*, service : UInt8*, hints : Addrinfo*, pai : Addrinfo**) : Int32
+  fun getnameinfo(addr : SockAddr*, addrlen : Int32, host : UInt8*, hostlen : Int32, serv : UInt8*, servlen : Int32, flags : Int32) : Int32
+
+  AI_PASSIVE = 0x0001
+  AI_CANONNAME = 0x0002
+  AI_NUMERICHOST = 0x0004
+  AI_V4MAPPED = 0x0008
+  AI_ALL = 0x0010
+  AI_ADDRCONFIG = 0x0020
+
+  NI_MAXHOST = 1025
+  NI_MAXSERV = 32
+
+  NI_NUMERICHOST = 1
+  NI_NUMERICSERV = 2
+  NI_NOFQDN = 4
+  NI_NAMEREQD = 8
+  NI_DGRAM = 16
+end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -1,0 +1,18 @@
+class IPSocket < Socket
+  private def getaddrinfo(host, port, family, socktype, protocol = C::IPPROTO_IP)
+    hints = C::Addrinfo.new
+    hints.family = (family || C::AF_UNSPEC).to_i32
+    hints.socktype = socktype
+    hints.protocol = protocol
+    hints.flags = 0
+
+    ret = C.getaddrinfo(host, port.to_s, pointerof(hints), out addrinfo)
+    raise SocketError.new("getaddrinfo: #{String.new(C.gai_strerror(ret))}") if ret == -1
+
+    begin
+      yield addrinfo.value
+    ensure
+      C.freeaddrinfo(addrinfo)
+    end
+  end
+end

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -20,7 +20,7 @@ lib C
     struct SockAddrUn
       len : UInt8
       family : UInt8
-      path : StaticArray(UInt8, 104)
+      path : UInt8*
     end
 
     struct SockAddr

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -8,9 +8,27 @@ lib C
       zero : Int64
     end
 
+    struct SockAddrUn
+      len : UInt8
+      family : UInt8
+      path : StaticArray(UInt8, 108)
+    end
+
+    struct SockAddr
+      len : UInt8
+      family : UInt8
+      data : StaticArray(UInt8, 16)*
+    end
+
+    AF_UNSPEC = 0_u8
+    AF_UNIX = 1_u8
     AF_INET = 2_u8
+    AF_INET6 = 10_u8
 
     fun socket(domain : UInt8, t : Int32, protocol : Int32) : Int32
+    fun socketpair(domain : UInt8, t : Int32, protocol : Int32, sockets : StaticArray(Int32, 2)*) : Int32
+    fun inet_pton(af : UInt8, src : UInt8*, dst : Void*) : Int32
+    fun inet_ntop(af : UInt8, src : Void*, dst : UInt8*, size : Int32) : UInt8*
   else
     struct SockAddrIn
       family : UInt16
@@ -19,9 +37,33 @@ lib C
       zero : Int64
     end
 
+    struct SockAddrIn6
+      family : UInt16
+      port : Int16
+      flowinfo : Int32
+      addr : StaticArray(UInt8, 16)
+      scope_id : UInt32
+    end
+
+    struct SockAddrUn
+      family : UInt16
+      path : UInt8*
+    end
+
+    struct SockAddr
+      family : UInt16
+      data : StaticArray(UInt8, 16)*
+    end
+
+    AF_UNSPEC = 0_u16
+    AF_UNIX = 1_u16
     AF_INET = 2_u16
+    AF_INET6 = 10_u16
 
     fun socket(domain : UInt16, t : Int32, protocol : Int32) : Int32
+    fun socketpair(domain : UInt16, t : Int32, protocol : Int32, sockets : StaticArray(Int32, 2)*) : Int32
+    fun inet_pton(af : UInt16, src : UInt8*, dst : Void*) : Int32
+    fun inet_ntop(af : UInt16, src : Void*, dst : UInt8*, size : Int32) : UInt8*
   end
 
   struct HostEnt
@@ -33,20 +75,64 @@ lib C
   end
 
   fun htons(n : Int32) : Int16
-  fun bind(fd : Int32, addr : SockAddrIn*, addr_len : Int32) : Int32
+  fun bind(fd : Int32, addr : SockAddr*, addr_len : Int32) : Int32
   fun listen(fd : Int32, backlog : Int32) : Int32
-  fun accept(fd : Int32, addr : SockAddrIn*, addr_len : Int32*) : Int32
-  fun connect(fd : Int32, addr : SockAddrIn*, addr_len : Int32) : Int32
+  fun accept(fd : Int32, addr : SockAddr*, addr_len : Int32*) : Int32
+  fun connect(fd : Int32, addr : SockAddr*, addr_len : Int32) : Int32
   fun gethostbyname(name : UInt8*) : HostEnt*
+  fun getsockname(fd : Int32, addr : SockAddr*, addr_len : Int32*) : Int32
+  fun getpeername(fd : Int32, addr : SockAddr*, addr_len : Int32*) : Int32
   fun setsockopt(sock : Int32, level : Int32, opt : Int32, optval : Void*, optlen : Int32) : Int32
 
   SOCK_STREAM = 1
+  SOCK_DGRAM = 2
+  SOCK_RAW = 3
+
+  IPPROTO_IP = 0
+  IPPROTO_TCP = 6
+  IPPROTO_UDP = 17
+  IPPROTO_RAW = 255
+
   SOL_SOCKET = 0xffff
 
   ifdef darwin
     SO_REUSEADDR = 0x0004
   else
     SO_REUSEADDR = 0x0002
+
+  INET_ADDRSTRLEN = 16
+  INET6_ADDRSTRLEN = 46
+end
+
+class SocketError < Exception
+end
+
+class Socket < FileDescriptorIO
+  def afamily(family)
+    case family
+    when C::AF_INET6 then C::AF_INET6
+    when C::AF_INET  then C::AF_INET
+    when C::AF_UNIX  then C::AF_UNIX
+    else                  C::AF_UNSPEC
+    end
+  end
+
+  def inspect(io)
+    io << "#<#{self.class}:fd #{@fd}>"
+  end
+
+  def self.inet_ntop(sa : C::SockAddrIn6)
+    ip_address = GC.malloc_atomic(C::INET6_ADDRSTRLEN.to_u32) as UInt8*
+    addr = sa.addr
+    C.inet_ntop(C::AF_INET6, pointerof(addr) as Void*, ip_address, C::INET6_ADDRSTRLEN)
+    String.new(ip_address)
+  end
+
+  def self.inet_ntop(sa : C::SockAddrIn)
+    ip_address = GC.malloc_atomic(C::INET_ADDRSTRLEN.to_u32) as UInt8*
+    addr = sa.addr
+    C.inet_ntop(C::AF_INET, pointerof(addr) as Void*, ip_address, C::INET_ADDRSTRLEN)
+    String.new(ip_address)
   end
 end
 

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -117,12 +117,7 @@ end
 
 class Socket < FileDescriptorIO
   def afamily(family)
-    case family
-    when C::AF_INET6 then C::AF_INET6
-    when C::AF_INET  then C::AF_INET
-    when C::AF_UNIX  then C::AF_UNIX
-    else                  C::AF_UNSPEC
-    end
+    C::AF_UNSPEC.class.cast(family)
   end
 
   def inspect(io)

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -8,16 +8,25 @@ lib C
       zero : Int64
     end
 
+    struct SockAddrIn6
+      len : UInt8
+      family : UInt8
+      port : Int16
+      flowinfo : Int32
+      addr : StaticArray(UInt8, 16)
+      scope_id : UInt32
+    end
+
     struct SockAddrUn
       len : UInt8
       family : UInt8
-      path : StaticArray(UInt8, 108)
+      path : StaticArray(UInt8, 104)
     end
 
     struct SockAddr
       len : UInt8
       family : UInt8
-      data : StaticArray(UInt8, 16)*
+      data : StaticArray(UInt8, 14)*
     end
 
     AF_UNSPEC = 0_u8
@@ -52,7 +61,7 @@ lib C
 
     struct SockAddr
       family : UInt16
-      data : StaticArray(UInt8, 16)*
+      data : StaticArray(UInt8, 14)*
     end
 
     AF_UNSPEC = 0_u16

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -34,6 +34,9 @@ lib C
     AF_INET = 2_u8
     AF_INET6 = 10_u8
 
+    SOL_SOCKET = 0xffff
+    SO_REUSEADDR = 0x0004
+
     fun socket(domain : UInt8, t : Int32, protocol : Int32) : Int32
     fun socketpair(domain : UInt8, t : Int32, protocol : Int32, sockets : StaticArray(Int32, 2)*) : Int32
     fun inet_pton(af : UInt8, src : UInt8*, dst : Void*) : Int32
@@ -69,6 +72,9 @@ lib C
     AF_INET = 2_u16
     AF_INET6 = 10_u16
 
+    SOL_SOCKET = 1
+    SO_REUSEADDR = 2
+
     fun socket(domain : UInt16, t : Int32, protocol : Int32) : Int32
     fun socketpair(domain : UInt16, t : Int32, protocol : Int32, sockets : StaticArray(Int32, 2)*) : Int32
     fun inet_pton(af : UInt16, src : UInt8*, dst : Void*) : Int32
@@ -101,13 +107,6 @@ lib C
   IPPROTO_TCP = 6
   IPPROTO_UDP = 17
   IPPROTO_RAW = 255
-
-  SOL_SOCKET = 0xffff
-
-  ifdef darwin
-    SO_REUSEADDR = 0x0004
-  else
-    SO_REUSEADDR = 0x0002
 
   INET_ADDRSTRLEN = 16
   INET6_ADDRSTRLEN = 46

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -26,7 +26,7 @@ lib C
     struct SockAddr
       len : UInt8
       family : UInt8
-      data : StaticArray(UInt8, 14)*
+      data : StaticArray(UInt8, 14)
     end
 
     AF_UNSPEC = 0_u8
@@ -64,7 +64,7 @@ lib C
 
     struct SockAddr
       family : UInt16
-      data : StaticArray(UInt8, 14)*
+      data : StaticArray(UInt8, 14)
     end
 
     AF_UNSPEC = 0_u16

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -21,6 +21,10 @@ class TCPServer < TCPSocket
     end
   end
 
+  def self.new(port : Int, backlog = 128)
+    new("::", port, backlog)
+  end
+
   def self.open(host, port, backlog = 128)
     server = new(host, port, backlog)
     begin

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -1,28 +1,40 @@
-class TCPServer
-  def initialize(port, backlog = 128)
-    @sock = C.socket(C::AF_INET, C::SOCK_STREAM, 0)
+require "./tcp_socket"
 
-    optval = 1
-    C.setsockopt(@sock, C::SOL_SOCKET, C::SO_REUSEADDR, pointerof(optval) as Void*, sizeof(Int32))
+class TCPServer < TCPSocket
+  def initialize(host, port, backlog = 128)
+    getaddrinfo(host, port, nil, C::SOCK_STREAM, C::IPPROTO_TCP) do |ai|
+      sock = C.socket(afamily(ai.family), ai.socktype, ai.protocol)
+      raise Errno.new("Error opening socket") if sock <= 0
 
-    addr = C::SockAddrIn.new
-    addr.family = C::AF_INET
-    addr.addr = 0_u32
-    addr.port = C.htons(port)
-    if C.bind(@sock, pointerof(addr), 16) != 0
-      raise Errno.new("Error binding TCP server at #{port}")
+      optval = 1
+      C.setsockopt(sock, C::SOL_SOCKET, C::SO_REUSEADDR, pointerof(optval) as Void*, sizeof(Int32))
+
+      if C.bind(sock, ai.addr as C::SockAddr*, ai.addrlen) != 0
+        raise Errno.new("Error binding TCP server at #{host}#{port}")
+      end
+
+      if C.listen(sock, backlog) != 0
+        raise Errno.new("Error listening TCP server at #{host}#{port}")
+      end
+
+      super sock
     end
+  end
 
-    if C.listen(@sock, backlog) != 0
-      raise Errno.new("Error listening TCP server at #{port}")
+  def self.open(host, port, backlog = 128)
+    server = new(host, port, backlog)
+    begin
+      yield server
+    ensure
+      server.close
     end
   end
 
   def accept
-    client_addr = C::SockAddrIn.new
-    client_addr_len = 16
-    client_fd = C.accept(@sock, pointerof(client_addr), pointerof(client_addr_len))
-    FileDescriptorIO.new(client_fd)
+    client_addr :: C::SockAddrIn6
+    client_addr_len = sizeof(C::SockAddrIn6)
+    client_fd = C.accept(fd, pointerof(client_addr) as C::SockAddr*, pointerof(client_addr_len))
+    TCPSocket.new(client_fd)
   end
 
   def accept

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -1,0 +1,25 @@
+require "./ip_socket"
+
+class UDPSocket < IPSocket
+  def initialize(family = C::AF_INET)
+    super C.socket(family, C::SOCK_DGRAM, C::IPPROTO_UDP).tap do |sock|
+      raise Errno.new("Error opening socket") if sock <= 0
+    end
+  end
+
+  def bind(host, port)
+    getaddrinfo(host, port, nil, C::SOCK_STREAM, C::IPPROTO_TCP) do |ai|
+      if C.bind(fd, ai.addr, ai.addrlen) != 0
+        raise Errno.new("Error binding TCP server at #{host}#{port}")
+      end
+    end
+  end
+
+  def connect(host, port)
+    getaddrinfo(host, port, nil, C::SOCK_STREAM, C::IPPROTO_TCP) do |ai|
+      if C.connect(fd, ai.addr, ai.addrlen) != 0
+        raise Errno.new("Error binding TCP server at #{host}#{port}")
+      end
+    end
+  end
+end

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -8,7 +8,7 @@ class UDPSocket < IPSocket
   end
 
   def bind(host, port)
-    getaddrinfo(host, port, nil, C::SOCK_STREAM, C::IPPROTO_TCP) do |ai|
+    getaddrinfo(host, port, nil, C::SOCK_DGRAM, C::IPPROTO_UDP) do |ai|
       if C.bind(fd, ai.addr, ai.addrlen) != 0
         raise Errno.new("Error binding TCP server at #{host}#{port}")
       end
@@ -16,7 +16,7 @@ class UDPSocket < IPSocket
   end
 
   def connect(host, port)
-    getaddrinfo(host, port, nil, C::SOCK_STREAM, C::IPPROTO_TCP) do |ai|
+    getaddrinfo(host, port, nil, C::SOCK_DGRAM, C::IPPROTO_UDP) do |ai|
       if C.connect(fd, ai.addr, ai.addrlen) != 0
         raise Errno.new("Error binding TCP server at #{host}#{port}")
       end

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -9,6 +9,9 @@ class UDPSocket < IPSocket
 
   def bind(host, port)
     getaddrinfo(host, port, nil, C::SOCK_DGRAM, C::IPPROTO_UDP) do |ai|
+      optval = 1
+      C.setsockopt(fd, C::SOL_SOCKET, C::SO_REUSEADDR, pointerof(optval) as Void*, sizeof(Int32))
+
       if C.bind(fd, ai.addr, ai.addrlen) != 0
         raise Errno.new("Error binding TCP server at #{host}#{port}")
       end

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -1,0 +1,45 @@
+require "./unix_socket"
+
+class UNIXServer < UNIXSocket
+  def initialize(@path : String, socktype = C::SOCK_STREAM, backlog = 128)
+    File.delete(path) if File.exists?(path)
+
+    sock = C.socket(C::AF_UNIX, socktype, 0)
+    raise Errno.new("Error opening socket") if sock <= 0
+
+    addr = C::SockAddrUn.new
+    addr.family = C::AF_UNIX
+    addr.path = path.to_unsafe
+    if C.bind(sock, pointerof(addr) as C::SockAddr*, sizeof(C::SockAddrUn)) != 0
+      raise Errno.new("Error binding UNIX server at #{path}")
+    end
+
+    if C.listen(sock, backlog) != 0
+      raise Errno.new("Error listening UNIX server at #{path}")
+    end
+
+    super sock
+  end
+
+  def accept
+    client_fd = C.accept(@fd, out client_addr, out client_addrlen)
+    UNIXSocket.new(client_fd)
+  end
+
+  def accept
+    sock = accept
+    begin
+      yield sock
+    ensure
+      sock.close
+    end
+  end
+
+  def close
+    super
+  ensure
+    if path = @path
+      File.delete(path) if File.exists?(path)
+    end
+  end
+end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -1,0 +1,48 @@
+class UNIXSocket < Socket
+  getter :path
+
+  def initialize(@path : String, socktype = C::SOCK_STREAM)
+    sock = C.socket(C::AF_UNIX, socktype, 0)
+    raise Errno.new("Error opening socket") if sock <= 0
+
+    addr = C::SockAddrUn.new
+    addr.family = C::AF_UNIX
+    addr.path = path.to_unsafe
+    if C.connect(sock, pointerof(addr) as C::SockAddr*, sizeof(C::SockAddrUn)) != 0
+      raise Errno.new("Error connecting to '#{path}'")
+    end
+
+    super sock
+  end
+
+  def initialize(fd : Int32)
+    super fd
+  end
+
+  def self.open(path, socktype = C::SOCK_STREAM)
+    sock = new(path, socktype)
+    begin
+      yield sock
+    ensure
+      sock.close
+    end
+  end
+
+  def self.pair(path, socktype = C::SOCK_STREAM)
+    fds = StaticArray(Int32, 2).new { 0_i32 }
+    if C.socketpair(C::AF_UNIX, socktype, 0, pointerof(fds)) != 0
+      raise Errno.new("socketpair:")
+    end
+    fds.map { |fd| UNIXSocket.new(fd) }
+  end
+
+  def self.pair(path, socktype = C::SOCK_STREAM)
+    left, right = pair(path, socktype)
+    begin
+      yield left, right
+    ensure
+      left.close
+      right.close
+    end
+  end
+end


### PR DESCRIPTION
I refactored and extended the socket stdlib. It somehow models the Ruby library. I skipped the Socket methods (like connect, bind, listen) since the C methods are directly accessible. Classes are organized as follows:

```yaml
- FileDescriptorIO
  - Socket
    - IPSocket
      - TCPSocket
        - TCPServer
      - UDPSocket
    - UNIXSocket
      - UNIXServer
```

~~I changed the signature of `TCPServer.new` because I couldn't get `initialize(port, backlog = 128)` to compile along with `initialize(host, port, backlog = 128)`. I didn't try hard, so maybe it's doable.~~

I also added IPv6 support by replacing gethostbyname for getaddrinfo. This is working fine on my Linux computer, but Darwin uses different sockaddr structs, so maybe I broke support for Macs (I can't check). I tried to have an Addrinfo class/struct but didn't get anything working to create sockets from (I got segfaults, invalid af family errors, etc. I blame pointer casts). I'll push another pull request later.

Note: using `"::"` as a host for TCPServer#new or UDPSocket#bind as the extra benefit of binding to all IPv4 and IPv6 addresses with a single server.