### PR TITLE
[String] Adds size method for strings

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -968,6 +968,7 @@ class String
 
     @length = count
   end
+  alias_method :size, :length
 
   def ascii_only?
     @bytesize == 0 || length == @bytesize


### PR DESCRIPTION
This is something ruby supports and probaly the most used method to find
the length of a string.