### PR TITLE
[Hashes] Adds a comparator and changes the initializers a bit

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -227,6 +227,28 @@ describe "Hash" do
     h.has_key?(1).should be_true
   end
 
+  it "initializes with comparator" do
+    h = Hash(String, Int32).new(Hash::CaseInsensitiveComparator)
+    h["foo"] = 1
+    h["foo"].should eq(1)
+    h["FoO"].should eq(1)
+  end
+
+  it "initializes with block and comparator" do
+    h1 = Hash(String, Array(Int32)).new(Hash::CaseInsensitiveComparator) { |h, k| h[k] = [] of Int32 }
+    h1["foo"].should eq([] of Int32)
+    h1["bar"] = [2]
+    h1["BAR"].should eq([2])
+  end
+
+  it "initializes with default value and comparator" do
+    h = Hash(String, Int32).new(10, Hash::CaseInsensitiveComparator)
+    h["x"].should eq(10)
+    h.has_key?("x").should be_false
+    h["foo"] = 5
+    h["FoO"].should eq(5)
+  end
+
   it "merges" do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}
@@ -281,10 +303,17 @@ describe "Hash" do
   end
 
   it "works with custom comparator" do
-    h = Hash(String, Int32).new(nil, nil, Hash::CaseInsensitiveComparator)
+    h = Hash(String, Int32).new(Hash::CaseInsensitiveComparator)
     h["FOO"] = 1
     h["foo"].should eq(1)
     h["Foo"].should eq(1)
+  end
+
+  it "works with indifferent access comparator" do
+    h = Hash(String, String).new(Hash::IndifferentAccessComparator)
+    h["foo"] = "bar"
+    h["foo"].should eq("bar")
+    h[:foo].should eq("bar")
   end
 
   it "gets key index" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -309,13 +309,6 @@ describe "Hash" do
     h["Foo"].should eq(1)
   end
 
-  it "works with indifferent access comparator" do
-    h = Hash(String, String).new(Hash::IndifferentAccessComparator)
-    h["foo"] = "bar"
-    h["foo"].should eq("bar")
-    h[:foo].should eq("bar")
-  end
-
   it "gets key index" do
     h = {1 => 2, 3 => 4}
     h.key_index(3).should eq(1)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -27,21 +27,43 @@ class Hash(K, V)
     end
   end
 
+  module IndifferentAccessComparator
+    def self.hash(sym : Symbol)
+      sym.to_s.downcase.hash
+    end
+
+    def self.equals?(str : String, sym : Symbol)
+      str == sym.to_s
+    end
+
+    def self.hash(object)
+      object.hash
+    end
+
+    def self.equals?(o1, o2)
+      o1 == o2
+    end
+  end
+
   getter length
 
-  def initialize(default_value = nil, block = nil : (Hash(K, V), K -> V)?, @comp = StandardComparator)
+  def initialize(block = nil : (Hash(K, V), K -> V)?, @comp = StandardComparator)
     @buckets = Pointer(Entry(K, V)?).malloc(11)
     @buckets_length = 11
     @length = 0
     @block = block
   end
 
-  def self.new(default_value : V)
-    new { default_value }
+  def self.new(comp = StandardComparator, &block : (Hash(K, V), K -> V))
+    new block, comp
   end
 
-  def self.new(&block : Hash(K, V), K -> V)
-    new nil, block
+  def self.new(default_value : V, comp = StandardComparator)
+    new(comp) { default_value }
+  end
+
+  def self.new(comparator)
+    new nil, comparator
   end
 
   def []=(key : K, value : V)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -27,24 +27,6 @@ class Hash(K, V)
     end
   end
 
-  module IndifferentAccessComparator
-    def self.hash(sym : Symbol)
-      sym.to_s.downcase.hash
-    end
-
-    def self.equals?(str : String, sym : Symbol)
-      str == sym.to_s
-    end
-
-    def self.hash(object)
-      object.hash
-    end
-
-    def self.equals?(o1, o2)
-      o1 == o2
-    end
-  end
-
   getter length
 
   def initialize(block = nil : (Hash(K, V), K -> V)?, @comp = StandardComparator)


### PR DESCRIPTION
Adds the IndifferentAccessComparator, that allows to also use symbols as
keys, even when the Hash was created with Strings as keys.

The default value in the actual initialize method was not being used at
all (probably a left over), so I remove it. I also added a few other
ways to initialize hashes, so that you most likely will be able to
initialize it any way you want without having to pass nils, just to
comply with the arity.