### PR TITLE
Adds support for local dependencies in Projectfile

### DIFF
--- a/spec/std/crystal/github_dependency_spec.cr
+++ b/spec/std/crystal/github_dependency_spec.cr
@@ -1,0 +1,40 @@
+require "spec"
+require "crystal/project/github_dependency"
+
+module Crystal
+  describe "GitHubDependency" do
+    describe "#initialize" do
+      it "uses the repository's name as the dependency name" do
+        dependency = GitHubDependency.new("owner/repo")
+
+        dependency.name.should eq("repo")
+      end
+
+      it "customizes GitHub dependency name" do
+        dependency = GitHubDependency.new("owner/repo", "name")
+
+        dependency.name.should eq("name")
+      end
+
+      it "raises error with invalid GitHub project definition" do
+        expect_raises ProjectError, /Invalid GitHub repository definition: invalid-repo/ do
+          GitHubDependency.new("invalid-repo")
+        end
+      end
+
+      %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
+        it "guesses name from project name like #{repo_name}" do
+          dependency = GitHubDependency.new("owner/#{repo_name}")
+
+          dependency.name.should eq("repo")
+        end
+
+        it "doesn't guess name from project name when specifying name" do
+          dependency = GitHubDependency.new("owner/#{repo_name}", "name")
+
+          dependency.name.should eq("name")
+        end
+      end
+    end
+  end
+end

--- a/spec/std/crystal/local_dependency_spec.cr
+++ b/spec/std/crystal/local_dependency_spec.cr
@@ -1,0 +1,20 @@
+require "spec"
+require "crystal/project/local_dependency"
+
+module Crystal
+  describe "LocalDependency" do
+    describe "#initialize" do
+      it "uses the directory's name as the dependency name" do
+        dependency = LocalDependency.new("../path")
+
+        dependency.name.should eq("path")
+      end
+
+      it "customizes local dependency name" do
+        dependency = LocalDependency.new("../path", "name")
+
+        dependency.name.should eq("name")
+      end
+    end
+  end
+end

--- a/spec/std/crystal/project_spec.cr
+++ b/spec/std/crystal/project_spec.cr
@@ -13,50 +13,18 @@ module Crystal
         end
         project.dependencies.length.should eq(1)
         project.dependencies[0].should be_a(GitHubDependency)
-        project.dependencies[0].name.should eq("repo")
       end
 
-      it "customize GitHub dependency name" do
+      it "adds local dependencies" do
         project = Project.new
         project.eval do
           deps do
-            github "owner/repo", name: "name"
+            local "../path"
           end
-        end
-        project.dependencies[0].name.should eq("name")
-      end
-
-      it "raises error with invalid GitHub project definition" do
-        project = Project.new
-        expect_raises ProjectError, /Invalid GitHub repository definition: invalid-repo/ do
-          project.eval do
-            deps do
-              github "invalid-repo"
-            end
-          end
-        end
-      end
-
-      %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
-        it "guesses name from project name like #{repo_name}" do
-          project = Project.new
-          project.eval do
-            deps do
-              github "owner/#{repo_name}"
-            end
-          end
-          project.dependencies[0].name.should eq("repo")
         end
 
-        it "doesn't guess name from project name when specifying name" do
-          project = Project.new
-          project.eval do
-            deps do
-              github "owner/#{repo_name}", name: "name"
-            end
-          end
-          project.dependencies[0].name.should eq("name")
-        end
+        project.dependencies.length.should eq(1)
+        project.dependencies[0].should be_a(LocalDependency)
       end
     end
   end

--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -13,5 +13,9 @@ struct Crystal::Project::DSL
     def github(repository, name = nil : String)
       @project.dependencies << GitHubDependency.new(repository, name)
     end
+
+    def local(path, name = nil : String)
+      @project.dependencies << LocalDependency.new(path, name)
+    end
   end
 end

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -1,6 +1,9 @@
+require "crystal/project/dependency"
+require "crystal/project/project_error"
+
 module Crystal
   class GitHubDependency < Dependency
-    def initialize(repo, name)
+    def initialize(repo, name = nil : String?)
       unless repo =~ /(.*)\/(.*)/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end

--- a/src/crystal/project/local_dependency.cr
+++ b/src/crystal/project/local_dependency.cr
@@ -23,7 +23,7 @@ module Crystal
 
     def install
       unless Dir.exists?(@target_dir)
-        exec "ln -sf #{@path} #{@target_dir}"
+        exec "ln -sf ../#{@path}/src #{@target_dir}"
       end
 
       @locked_version = current_version

--- a/src/crystal/project/local_dependency.cr
+++ b/src/crystal/project/local_dependency.cr
@@ -1,0 +1,50 @@
+module Crystal
+  class LocalDependency < Dependency
+    def initialize(@path, name = nil)
+      unless @path =~ /(.*\/)*(.*)/
+        raise ProjectError.new("Invalid path name: #{path}")
+      end
+
+      @name = name || $2
+
+      unless @name
+        case @directory_name
+        when /^crystal($:_|-)(.*)$/
+          @name = $1
+        when /^(.*)(?:_|-)crystal$/
+          @name = $1
+        when /^(.*)\.cr$/
+          @name = $1
+        end
+      end
+
+      @target_dir = "libs/#{@name}"
+    end
+
+    def install
+      unless Dir.exists?(@target_dir)
+        exec "ln -sf #{@path} #{@target_dir}"
+      end
+
+      @locked_version = current_version
+    end
+
+    def update
+      exec "rm -rf libs/#{@path}"
+      install
+    end
+
+    def current_version
+      exec("([ -d \"#{@path}/.git\" ] && git -C #{@path} rev-parse HEAD) || echo -n 'local'")
+    end
+
+    private def exec(cmd)
+      result = `#{cmd}`
+      unless $?.success?
+        puts "Error executing command: #{cmd}"
+        exit 1
+      end
+      result
+    end
+  end
+end

--- a/src/crystal/project/project.cr
+++ b/src/crystal/project/project.cr
@@ -1,4 +1,5 @@
 require "json"
+require "crystal/project/project_error"
 
 class Crystal::Project
   property dependencies
@@ -61,9 +62,6 @@ class Crystal::Project
     @dependencies.find { |dep| dep.name == name } ||
       raise ProjectError.new("Could not find dependency '#{name}'")
   end
-end
-
-class Crystal::ProjectError < Exception
 end
 
 require "./*"

--- a/src/crystal/project/project_error.cr
+++ b/src/crystal/project/project_error.cr
@@ -1,0 +1,2 @@
+class Crystal::ProjectError < Exception
+end


### PR DESCRIPTION
This implements the possibility to require dependencies from our file system, in addition to GIthub.
It's useful at least for development purposes, since it allows us to work on multiple packages locally.

example:

```crystal
deps do
  github 'user/repo' # the usual

  local '../my-custom-lib'
  local '../another-lib', 'custom-name'
end
```

I tried to follow the same approach from the github dependency code. Here's a summary of the decisions I went with:

* the directory name will resolve to the name of the last directory specified. So `../path/to/directory` will be linked at `./libs/directory`. A second parameter can be used to override this, just like with github
* it also removes "crystal" preffixes/suffixes from the name
* it links directly to `libs`, and doesn't go through `.deps`. I figured this wasn't necessary since we're not cloning anything
* if the directory is also a git repo, it uses the ref for the version. Otherwise it fallsback to the string "local". I didn't really know what to do here, but I figured we should allow for non-git directories to be used

Other than that, I also refactored the specs a bit, separating the ones from GithubDependency to it's own file (and testing the class directly instead of using `Project`). I also added my own tests for the new type


I got a bit ahead of myself here, and ended up doing a bit of refactoring. If I went too far, I'll be happy to roll back some of the changes and just stick to the feature itself