### PR TITLE
Renames LocalDependency to PathDependency

### DIFF
--- a/spec/std/crystal/path_dependency_spec.cr
+++ b/spec/std/crystal/path_dependency_spec.cr
@@ -15,6 +15,20 @@ module Crystal
 
         dependency.name.should eq("name")
       end
+
+      %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
+        it "guesses name from project name like #{repo_name}" do
+          dependency = PathDependency.new("owner/#{repo_name}")
+
+          dependency.name.should eq("repo")
+        end
+
+        it "doesn't guess name from project name when specifying name" do
+          dependency = PathDependency.new("owner/#{repo_name}", "name")
+
+          dependency.name.should eq("name")
+        end
+      end
     end
   end
 end

--- a/spec/std/crystal/path_dependency_spec.cr
+++ b/spec/std/crystal/path_dependency_spec.cr
@@ -1,17 +1,17 @@
 require "spec"
-require "crystal/project/local_dependency"
+require "crystal/project/path_dependency"
 
 module Crystal
-  describe "LocalDependency" do
+  describe "PathDependency" do
     describe "#initialize" do
       it "uses the directory's name as the dependency name" do
-        dependency = LocalDependency.new("../path")
+        dependency = PathDependency.new("../path")
 
         dependency.name.should eq("path")
       end
 
-      it "customizes local dependency name" do
-        dependency = LocalDependency.new("../path", "name")
+      it "customizes path dependency name" do
+        dependency = PathDependency.new("../path", "name")
 
         dependency.name.should eq("name")
       end

--- a/spec/std/crystal/project_spec.cr
+++ b/spec/std/crystal/project_spec.cr
@@ -19,12 +19,12 @@ module Crystal
         project = Project.new
         project.eval do
           deps do
-            local "../path"
+            path "../path"
           end
         end
 
         project.dependencies.length.should eq(1)
-        project.dependencies[0].should be_a(LocalDependency)
+        project.dependencies[0].should be_a(PathDependency)
       end
     end
   end

--- a/src/crystal/project/dependency.cr
+++ b/src/crystal/project/dependency.cr
@@ -4,5 +4,13 @@ abstract class Crystal::Dependency
   property name
 
   def initialize(@name)
+    case @name
+    when /^crystal(?:_|-)(.*)$/
+      @name = $1
+    when /^(.*)(?:\_|-)crystal$/
+      @name = $1
+    when /^(.*)\.cr$/
+      @name = $1
+    end
   end
 end

--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -14,8 +14,8 @@ struct Crystal::Project::DSL
       @project.dependencies << GitHubDependency.new(repository, name)
     end
 
-    def local(path, name = nil : String)
-      @project.dependencies << LocalDependency.new(path, name)
+    def path(path, name = nil : String)
+      @project.dependencies << PathDependency.new(path, name)
     end
   end
 end

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -10,20 +10,12 @@ module Crystal
 
       @author = $1
       @repository = $2
-      @target_dir = ".deps/#{@author}-#{@repository}"
-
-      unless name
-        case @repository
-        when /^crystal(?:_|-)(.*)$/
-          name = $1
-        when /^(.*)(?:_|-)crystal$/
-          name = $1
-        when /^(.*)\.cr$/
-          name = $1
-        end
-      end
 
       super(name || @repository)
+    end
+
+    def target_dir
+      ".deps/#{@author}-#{@repository}"
     end
 
     def install

--- a/src/crystal/project/path_dependency.cr
+++ b/src/crystal/project/path_dependency.cr
@@ -1,3 +1,6 @@
+require "crystal/project/dependency"
+require "crystal/project/project_error"
+
 module Crystal
   class PathDependency < Dependency
     def initialize(@path, name = nil)
@@ -5,20 +8,11 @@ module Crystal
         raise ProjectError.new("Invalid path name: #{path}")
       end
 
-      @name = name || $2
+      super(name || $2)
+    end
 
-      unless @name
-        case @directory_name
-        when /^crystal($:_|-)(.*)$/
-          @name = $1
-        when /^(.*)(?:_|-)crystal$/
-          @name = $1
-        when /^(.*)\.cr$/
-          @name = $1
-        end
-      end
-
-      @target_dir = "libs/#{@name}"
+    def target_dir
+      "libs/#{name}"
     end
 
     def install

--- a/src/crystal/project/path_dependency.cr
+++ b/src/crystal/project/path_dependency.cr
@@ -1,5 +1,5 @@
 module Crystal
-  class LocalDependency < Dependency
+  class PathDependency < Dependency
     def initialize(@path, name = nil)
       unless @path =~ /(.*\/)*(.*)/
         raise ProjectError.new("Invalid path name: #{path}")


### PR DESCRIPTION
This is the fix proposed after merging https://github.com/manastech/crystal/pull/342

* Renames `local` to `path` in the dependencies DSL
* Renames LocalDependency to PathDependency, to match that change
* `@locked_version` still fallsback to `local`. I guess `path` didn't make much in this context
* Moves the logic of removing crystal preffixes/suffixes to the superclass, removing duplication

I also duplicated the specs that check the removal of those suffixes. They're now in both subclasses. I could move them to a `dependency_spec.cr` where I would test the superclass directly, but that wouldn't garantee that the superclasses would still call that constructor. But I'm open for suggestions here