### PR TITLE
Thread.start raises SIGSEGV on Linux 64 bits

### DIFF
--- a/src/raise.cr
+++ b/src/raise.cr
@@ -76,6 +76,8 @@ fun __crystal_personality(version : Int32, actions : Int32, exception_class : UI
   start = ABI.unwind_get_region_start(context)
   ip = ABI.unwind_get_ip(context)
   throw_offset = ip - 1 - start
+  return ABI::URC_CONTINUE_UNWIND if throw_offset == -1
+
   lsd = ABI.unwind_get_language_specific_data(context)
   # puts "Personality - actions : #{actions}, start: #{start}, ip: #{ip}, throw_offset: #{throw_offset}"
 


### PR DESCRIPTION
AFAIK `pthread_exit` raises an exception and forces an unwind, which is catched by `__crystal_personality`. Trying to handle it, results in a SIGSEGV because `ABI.unwind_get_language_specific_data(context)` returns a pointer to 0x0.

I'm not sure this patch is adequate, or that I got the problem, but all the specs still pass, and raising within a thread raises the exception in the main thread when the thread is joined.

fixes #352 