### PR TITLE
Fix: pthread_exit leaks memory

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -33,7 +33,7 @@ end
 
 # Boehm GC requires to use GC_pthread_create and GC_pthread_join instead of pthread_create and pthread_join
 lib PThread
-  fun create = GC_pthread_create(thread : Thread*, attr : Void*, start : Void* ->, arg : Void*)
+  fun create = GC_pthread_create(thread : Thread*, attr : Void*, start : Void* ->, arg : Void*) : Int32
   fun join = GC_pthread_join(thread : Thread, value : Void**) : Int32
 end
 

--- a/src/thread/lib_pthread.cr
+++ b/src/thread/lib_pthread.cr
@@ -15,7 +15,7 @@ lib PThread
   type Cond = Int64[6]
   type CondAttr = Void*
 
-  fun create = pthread_create(thread : Thread*, attr : Void*, start : Void* ->, arg : Void*)
+  fun create = pthread_create(thread : Thread*, attr : Void*, start : Void* ->, arg : Void*) : Int32
   fun exit = pthread_exit(value : Void*)
   fun join = pthread_join(thread : Thread, value : Void**) : Int32
 


### PR DESCRIPTION
As per the man page and this [stackoverflow](http://stackoverflow.com/questions/3844678/pthread-exit-vs-return/), `pthread_exit` may be run before `pthread_cleaned_push` have been popped up, which may result in memory leaks —Valgrind indeed complains about it on Linux. Returning from the thread instead, ends up calling `pthread_exit` but with a cleaned memory.

That also fixes #352 since we no longer have `pthread_exit` forcing an unwind.

Again: I'm not sure this is the best solution. Yet specs do pass, etc.