### PR TITLE
[Lexer] Adds support for extra delimiters in %w and %i

### DIFF
--- a/spec/compiler/lexer/lexer_string_array_spec.cr
+++ b/spec/compiler/lexer/lexer_string_array_spec.cr
@@ -1,22 +1,26 @@
 require "../../spec_helper"
 
+private def it_should_be_valid_string_array_lexer(lexer)
+  token = lexer.next_token
+  token.type.should eq(:STRING_ARRAY_START)
+
+  token = lexer.next_string_array_token
+  token.type.should eq(:STRING)
+  token.value.should eq("one")
+
+  token = lexer.next_string_array_token
+  token.type.should eq(:STRING)
+  token.value.should eq("two")
+
+  token = lexer.next_string_array_token
+  token.type.should eq(:STRING_ARRAY_END)
+end
+
 describe "Lexer string array" do
   it "lexes simple string array" do
     lexer = Lexer.new("%w(one two)")
 
-    token = lexer.next_token
-    token.type.should eq(:STRING_ARRAY_START)
-
-    token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
-    token.value.should eq("one")
-
-    token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
-    token.value.should eq("two")
-
-    token = lexer.next_string_array_token
-    token.type.should eq(:STRING_ARRAY_END)
+    it_should_be_valid_string_array_lexer(lexer)
   end
 
   it "lexes string array with new line" do
@@ -49,4 +53,29 @@ describe "Lexer string array" do
     token.line_number.should eq(2)
     token.column_number.should eq(6)
   end
+
+  context "using { as delimiter" do
+    it "lexes simple string array" do
+      lexer = Lexer.new("%w{one two}")
+
+      it_should_be_valid_string_array_lexer(lexer)
+    end
+  end
+
+  context "using [ as delimiter" do
+    it "lexes simple string array" do
+      lexer = Lexer.new("%w[one two]")
+
+      it_should_be_valid_string_array_lexer(lexer)
+    end
+  end
+
+  context "using < as delimiter" do
+    it "lexes simple string array" do
+      lexer = Lexer.new("%w<one two>")
+
+      it_should_be_valid_string_array_lexer(lexer)
+    end
+  end
+
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -595,6 +595,7 @@ describe "Parser" do
   it_parses "A = 1", Assign.new("A".path, 1.int32)
 
   it_parses "puts %w(one two)", Call.new(nil, "puts", (["one".string, "two".string] of ASTNode).array)
+  it_parses "puts %w{one two}", Call.new(nil, "puts", (["one".string, "two".string] of ASTNode).array)
   it_parses "puts %i(one two)", Call.new(nil, "puts", (["one".symbol, "two".symbol] of ASTNode).array)
   it_parses "puts {{1}}", Call.new(nil, "puts", MacroExpression.new(1.int32))
   it_parses "puts {{*1}}", Call.new(nil, "puts", MacroExpression.new(1.int32.splat))

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -261,9 +261,23 @@ module Crystal
         when '<'
           delimited_pair :string, '<', '>'
         when 'i'
-          if peek_next_char == '('
+          case peek_next_char
+          when '('
             next_char
             next_char :SYMBOL_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:symbol_array, '(', ')', 0)
+          when '{'
+            next_char
+            next_char :SYMBOL_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:symbol_array, '{', '}', 0)
+          when '['
+            next_char
+            next_char :SYMBOL_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:symbol_array, '[', ']', 0)
+          when '<'
+            next_char
+            next_char :SYMBOL_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:symbol_array, '<', '>', 0)
           else
             @token.type = :"%"
           end
@@ -294,9 +308,23 @@ module Crystal
             raise "unknown %x char"
           end
         when 'w'
-          if peek_next_char == '('
+          case peek_next_char
+          when '('
             next_char
             next_char :STRING_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:string_array, '(', ')', 0)
+          when '{'
+            next_char
+            next_char :STRING_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:string_array, '{', '}', 0)
+          when '['
+            next_char
+            next_char :STRING_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:string_array, '[', ']', 0)
+          when '<'
+            next_char
+            next_char :STRING_ARRAY_START
+            @token.delimiter_state = Token::DelimiterState.new(:string_array, '<', '>', 0)
           else
             @token.type = :"%"
           end
@@ -1991,14 +2019,14 @@ module Crystal
         end
       end
 
-      if current_char == ')'
+      if current_char == @token.delimiter_state.end
         next_char
         @token.type = :STRING_ARRAY_END
         return @token
       end
 
       start = current_pos
-      while !current_char.whitespace? && current_char != '\0' && current_char != ')'
+      while !current_char.whitespace? && current_char != '\0' && current_char != @token.delimiter_state.end
         next_char
       end
 


### PR DESCRIPTION
All of the pairs [], {}, () and <> can be used to delimit string and
symbol array with the %w and %i notation, respectively.

Closes #356.