### PR TITLE
[Specs] Adds the concept of lexer objects

### DIFF
--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -24,6 +24,13 @@ module LexerObjects
       end
     end
 
+    def next_unicode_tokens_should_be(expected_unicode_codes)
+      codes = Array.wrap(expected_unicode_codes)
+      @token = lexer.next_string_token(token.delimiter_state)
+      token.type.should eq(:STRING)
+      (token.value as String).chars.map(&.ord).should eq(codes)
+    end
+
     def next_string_token_should_be(expected_string)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:STRING)
@@ -56,20 +63,22 @@ module LexerObjects
       token.type.should eq(:"}")
     end
 
-    def token_should_be_at(line = 1, column = 1)
-      token.line_number.should eq(line)
-      token.column_number.should eq(column)
+    def token_should_be_at(line = nil, column = nil)
+      token.line_number.should eq(line) if line
+      token.column_number.should eq(column) if column
     end
 
-    def next_token_should_be_at(line = 1, column = 1)
+    def next_token_should_be_at(line = nil, column = nil)
       @token = lexer.next_token
       token_should_be_at(line: line, column: column)
     end
 
-    def string_should_end_correctly
+    def string_should_end_correctly(eof = true)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:DELIMITER_END)
-      should_have_reached_eof
+      if eof
+        should_have_reached_eof
+      end
     end
 
     def should_have_reached_eof

--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -24,11 +24,16 @@ module LexerObjects
       end
     end
 
-    def next_unicode_tokens_should_be(expected_unicode_codes)
-      codes = Array.wrap(expected_unicode_codes)
+    def next_unicode_tokens_should_be(expected_unicode_codes : Array)
       @token = lexer.next_string_token(token.delimiter_state)
       token.type.should eq(:STRING)
-      (token.value as String).chars.map(&.ord).should eq(codes)
+      (token.value as String).chars.map(&.ord).should eq(expected_unicode_codes)
+    end
+
+    def next_unicode_tokens_should_be(expected_unicode_codes)
+      @token = lexer.next_string_token(token.delimiter_state)
+      token.type.should eq(:STRING)
+      (token.value as String).char_at(0).ord.should eq(expected_unicode_codes)
     end
 
     def next_string_token_should_be(expected_string)

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -1,365 +1,172 @@
 require "../../spec_helper"
+require "./lexer_objects/strings"
 
 describe "Lexer string" do
   it "lexes simple string" do
     lexer = Lexer.new(%("hello"))
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-    token.delimiter_state.end.should eq('"')
-    token.delimiter_state.nest.should eq('"')
-    token.delimiter_state.open_count.should eq(0)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
-
-    token = lexer.next_token
-    token.type.should eq(:EOF)
+    tester.string_should_be_delimited_by('"', '"')
+    tester.next_string_token_should_be("hello")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with newline" do
     lexer = Lexer.new("\"hello\\nworld\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\n")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("world")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello")
+    tester.next_string_token_should_be("\n")
+    tester.next_string_token_should_be("world")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with slash" do
     lexer = Lexer.new("\"hello\\\\world\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\\")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("world")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello")
+    tester.next_string_token_should_be("\\")
+    tester.next_string_token_should_be("world")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with slash quote" do
     lexer = Lexer.new("\"\\\"\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\"")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("\"")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with slash t" do
     lexer = Lexer.new("\"\\t\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\t")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("\t")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with interpolation" do
     lexer = Lexer.new("\"hello \#{world}\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello ")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:INTERPOLATION_START)
-
-    token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("world")
-
-    token = lexer.next_token
-    token.type.should eq(:"}")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello ")
+    tester.string_should_have_an_interpolation_of("world")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with numeral" do
     lexer = Lexer.new("\"hello#world\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("#")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("world")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello")
+    tester.next_string_token_should_be("#")
+    tester.next_string_token_should_be("world")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with literal newline" do
     lexer = Lexer.new("\"hello\nworld\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\n")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("world")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
-
-    token = lexer.next_token
-    token.line_number.should eq(2)
-    token.column_number.should eq(7)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello")
+    tester.next_string_token_should_be("\n")
+    tester.next_string_token_should_be("world")
+    tester.string_should_end_correctly
+    tester.next_token_should_be_at(line: 2, column: 7)
   end
 
   it "lexes string with only newline" do
     lexer = Lexer.new("\"\n\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("\n")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("\n")
+    tester.string_should_end_correctly
   end
 
   it "lexes double numeral" do
     lexer = Lexer.new("\"##\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("#")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("#")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("#")
+    tester.next_string_token_should_be("#")
+    tester.string_should_end_correctly
   end
 
   it "lexes string with interpolation with double numeral" do
     lexer = Lexer.new("\"hello \#\#{world}\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello ")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("#")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:INTERPOLATION_START)
-
-    token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("world")
-
-    token = lexer.next_token
-    token.type.should eq(:"}")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("hello ")
+    tester.next_string_token_should_be("#")
+    tester.string_should_have_an_interpolation_of("world")
+    tester.string_should_end_correctly
   end
 
   it "lexes slash with no-escape char" do
     lexer = Lexer.new("\"\\h\"")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("h")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
+    tester.string_should_start_correctly
+    tester.next_string_token_should_be("h")
+    tester.string_should_end_correctly
   end
 
   it "lexes simple string with %(" do
     lexer = Lexer.new("%(hello)")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
-    token.delimiter_state.end.should eq(')')
-    token.delimiter_state.nest.should eq('(')
-
-    delimiter_state = token.delimiter_state
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-
-    token = lexer.next_string_token(delimiter_state)
-    token.type.should eq(:DELIMITER_END)
-
-    token = lexer.next_token
-    token.type.should eq(:EOF)
+    tester.string_should_be_delimited_by('(', ')')
+    tester.next_string_token_should_be("hello")
+    tester.string_should_end_correctly
   end
 
   [['(', ')'], ['[', ']'], ['{', '}'], ['<', '>']].each do |pair|
     it "lexes simple string with nested %#{pair[0]}" do
       lexer = Lexer.new("%#{pair[0]}hello #{pair[0]}world#{pair[1]}#{pair[1]}")
+      tester = LexerObjects::Strings.new(lexer)
 
-      token = lexer.next_token
-      token.type.should eq(:DELIMITER_START)
-      token.delimiter_state.nest.should eq(pair[0])
-      token.delimiter_state.end.should eq(pair[1])
-      token.delimiter_state.open_count.should eq(0)
-
-      delimiter_state = token.delimiter_state
-
-      token = lexer.next_string_token(delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq("hello ")
-
-      token = lexer.next_string_token(delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq(pair[0].to_s)
-      token.delimiter_state.open_count.should eq(1)
-
-      delimiter_state = token.delimiter_state
-
-      token = lexer.next_string_token(delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq("world")
-
-      token = lexer.next_string_token(delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq(pair[1].to_s)
-      token.delimiter_state.open_count.should eq(0)
-
-      delimiter_state = token.delimiter_state
-
-      token = lexer.next_string_token(delimiter_state)
-      token.type.should eq(:DELIMITER_END)
-
-      token = lexer.next_token
-      token.type.should eq(:EOF)
+      tester.string_should_be_delimited_by(pair[0], pair[1])
+      tester.next_string_token_should_be("hello ")
+      tester.next_string_token_should_be_opening
+      tester.next_string_token_should_be("world")
+      tester.next_string_token_should_be_closing
+      tester.string_should_end_correctly
     end
   end
 
   it "lexes heredoc" do
     string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK.\n  HERE\nHERESY"
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq(string)
-
-    token = lexer.next_token
-    token.type.should eq(:EOF)
+    tester.next_token_should_be(:STRING, string)
+    tester.should_have_reached_eof
   end
 
   it "assigns correct location after heredoc (#346)" do
     string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK.\n  HERE"
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE\n1")
+    tester = LexerObjects::Strings.new(lexer)
 
-    token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq(string)
-    token.location.line_number.should eq(1)
-    token.location.column_number.should eq(1)
-
-    token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.location.line_number.should eq(6)
-    token.location.column_number.should eq(5)
-
-    token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.location.line_number.should eq(7)
-    token.location.column_number.should eq(1)
-
-    token = lexer.next_token
-    token.type.should eq(:EOF)
+    tester.next_token_should_be(:STRING, string)
+    tester.token_should_be_at(line: 1, column: 1)
+    tester.next_token_should_be(:NEWLINE)
+    tester.token_should_be_at(line: 6, column: 5)
+    tester.next_token_should_be(:NUMBER)
+    tester.token_should_be_at(line: 7, column: 1)
+    tester.should_have_reached_eof
   end
 
   it "raises on unterminated heredoc" do


### PR DESCRIPTION
**Warning:** *This is an experiment. I will complete the changes once/if this is accepted* 

Lexer objects are based on the concept of page objects for integration
tests. They abstract the intricacies of testing the lexer, and provide a
DSL like syntax for the actual tests.

This serves the purposes of reducing boilerplate in tests, improving
tests readability, removing duplicate knowledge throughout the tests and
thus following SRP.

I extracted the lexer object into it's own class and file, because I
feel it will have different reasons to change than the actual tests.