### PR TITLE
Add #min_of, #max_of #minmax_of to Enumerable

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -60,12 +60,24 @@ describe "Enumerable" do
     assert { [1, 2, 3].min_by { |x| -x }.should eq(3) }
   end
 
+  describe "min_of" do
+    assert { [1, 2, 3].min_of { |x| -x }.should eq(-3) }
+  end
+
   describe "max_by" do
     assert { [-1, -2, -3].max_by { |x| -x }.should eq(-3) }
   end
 
+  describe "max_of" do
+    assert { [-1, -2, -3].max_of { |x| -x }.should eq(3) }
+  end
+
   describe "minmax_by" do
     assert { [-1, -2, -3].minmax_by { |x| -x }.should eq({-1, -3}) }
+  end
+
+  describe "minmax_of" do
+    assert { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
   end
 
   describe "take" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -179,20 +179,35 @@ module Enumerable(T)
   end
 
   def max_by(&block : T -> U)
-    min :: U
+    max :: U
     obj :: T
     found = false
 
     each_with_index do |elem, i|
       value = yield elem
-      if i == 0 || value > min
-        min = value
+      if i == 0 || value > max
+        max = value
         obj = elem
       end
       found = true
     end
 
     found ? obj : raise EmptyEnumerable.new
+  end
+
+  def max_of(&block : T -> U)
+    max :: U
+    found = false
+
+    each_with_index do |elem, i|
+      value = yield elem
+      if i == 0 || value > max
+        max = value
+      end
+      found = true
+    end
+
+    found ? max : raise EmptyEnumerable.new
   end
 
   def min
@@ -226,6 +241,25 @@ module Enumerable(T)
     found ? {objmin, objmax} : raise EmptyEnumerable.new
   end
 
+  def minmax_of(&block : T -> U)
+    min :: U
+    max :: U
+    found = false
+
+    each_with_index do |elem, i|
+      value = yield elem
+      if i == 0 || value < min
+        min = value
+      end
+      if i == 0 || value > max
+        max = value
+      end
+      found = true
+    end
+
+    found ? {min, max} : raise EmptyEnumerable.new
+  end
+
   def min_by(&block : T -> U)
     min :: U
     obj :: T
@@ -241,6 +275,21 @@ module Enumerable(T)
     end
 
     found ? obj : raise EmptyEnumerable.new
+  end
+
+  def min_of(&block : T -> U)
+    min :: U
+    found = false
+
+    each_with_index do |elem, i|
+      value = yield elem
+      if i == 0 || value < min
+        min = value
+      end
+      found = true
+    end
+
+    found ? min : raise EmptyEnumerable.new
   end
 
   def none?(&block : T -> U)


### PR DESCRIPTION
There's a common pattern to do something like

```ruby
array.map(&.something).max
array.max_by(&.something).something
```

Both having various drawbacks of extra array
allocations or not DRY code.

These methods should solve that problem.