### PR TITLE
[WIP] Add IO.select

### DIFF
--- a/spec/std/io_spec.cr
+++ b/spec/std/io_spec.cr
@@ -1,0 +1,42 @@
+require "spec"
+
+private def with_pipe
+  read, write = IO.pipe
+  yield read, write
+ensure
+  read.close if read rescue nil
+  write.close if write rescue nil
+end
+
+describe "IO" do
+  describe ".select" do
+    it "returns the available readable ios" do
+      with_pipe do |read, write|
+        write.puts "hey"
+        write.close
+        IO.select({read}).includes?(read).should be_true
+      end
+    end
+
+    it "returns the available writable ios" do
+      with_pipe do |read, write|
+        IO.select(nil, {write}).includes?(write).should be_true
+      end
+    end
+
+    it "returns the ios with an error condition" do
+      with_pipe do |read, write|
+        Thread.new do
+          IO.select(nil, nil, {write}).includes?(write).should be_true
+        end
+        write.close
+      end
+    end
+
+    it "times out" do
+      with_pipe do |read, write|
+        IO.select({read}, nil, nil, 0.00001).should be_nil
+      end
+    end
+  end
+end

--- a/src/io/fd_set.cr
+++ b/src/io/fd_set.cr
@@ -1,5 +1,13 @@
-struct Process::FdSet
+struct IO::FdSet
   NFDBITS = sizeof(Int32) * 8
+
+  def self.from_ios(ios)
+    fdset = new
+    ios.each do |io|
+      fdset.set io
+    end
+    fdset
+  end
 
   def initialize
     @fdset :: Int32[32]
@@ -14,7 +22,7 @@ struct Process::FdSet
   end
 
   def to_unsafe
-    pointerof(@fdset)
+    pointerof(@fdset) as Void*
   end
 end
 

--- a/src/libc.cr
+++ b/src/libc.cr
@@ -8,9 +8,11 @@ lib LibC
   ifdef x86_64
     alias IntT = Int64
     alias UIntT = UInt64
+    alias LongT = Int64
   else
     alias IntT = Int32
     alias UIntT = UInt32
+    alias LongT = Int32
   end
 
   alias PtrDiffT = IntT

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -6,9 +6,15 @@ lib LibC
     tv_nsec : LibC::TimeT
   end
 
+  ifdef darwin
+    alias UsecT = Int32
+  else
+    alias UsecT = LongT
+  end
+
   struct TimeVal
     tv_sec  : LibC::TimeT
-    tv_usec : Int32
+    tv_usec : LibC::UsecT
   end
 
   struct TimeZone


### PR DESCRIPTION
Currently the timeout is broken due to a suspected compiler bug,
see comments.

The API differs a bit from Ruby. It returns an Array with all IOs that are ready. This is so that the calller can prioritize which ready IO it wants to handle first.