### PR TITLE
Add some convenience methods

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -33,6 +33,14 @@ describe "Float" do
     assert { 2.9.ceil.should eq(3) }
   end
 
+  describe "fdiv" do
+    assert { 1.0.fdiv(1).should eq 1.0 }
+    assert { 1.0.fdiv(2).should eq 0.5 }
+    assert { 1.0.fdiv(0.5).should eq 2.0 }
+    assert { 0.0.fdiv(1).should eq 0.0 }
+    assert { 1.0.fdiv(0).should eq 1.0/0.0 }
+  end
+
   describe "to_s" do
     it "does to_s for f32 and f64" do
       12.34.to_s.should eq("12.34")

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -72,6 +72,14 @@ describe "Int" do
     assert { 5.divmod(3).should eq({1, 2}) }
   end
 
+  describe "fdiv" do
+    assert { 1.fdiv(1).should eq 1.0 }
+    assert { 1.fdiv(2).should eq 0.5 }
+    assert { 1.fdiv(0.5).should eq 2.0 }
+    assert { 0.fdiv(1).should eq 0.0 }
+    assert { 1.fdiv(0).should eq 1.0/0.0 }
+  end
+
   describe "~" do
     assert { (~1).should eq(-2) }
     assert { (~1_u32).should eq(4294967294) }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -43,6 +43,15 @@ describe "String" do
     it "gets with single char" do
       ";"[0 .. -2].should eq("")
     end
+
+    describe "with a regex" do
+      assert { "FooBar"[/o+/].should eq "oo" }
+      assert { "FooBar"[/([A-Z])/, 1].should eq "F" }
+      assert { "FooBar"[/x/]?.should be_nil }
+      assert { "FooBar"[/x/, 1]?.should be_nil }
+      assert { "FooBar"[/(x)/, 1]?.should be_nil }
+      assert { "FooBar"[/o(o)/, 2]?.should be_nil }
+    end
   end
 
   describe "byte_slice" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -678,6 +678,10 @@ describe "String" do
     end
   end
 
+  it "has match" do
+    "FooBar".match(/oo/).should_not be_nil
+  end
+
   it "has size (same as length)" do
     "テスト".size.should eq(3)
   end

--- a/src/float.cr
+++ b/src/float.cr
@@ -18,6 +18,10 @@ struct Float
   def finite?
     !nan? && !infinite?
   end
+
+  def fdiv(other)
+    self / other
+  end
 end
 
 struct Float32

--- a/src/int.cr
+++ b/src/int.cr
@@ -15,6 +15,10 @@ struct Int
     unsafe_div x
   end
 
+  def fdiv(other)
+    to_f / other
+  end
+
   def %(x : Int)
     if x == 0
       raise DivisionByZero.new

--- a/src/string.cr
+++ b/src/string.cr
@@ -160,6 +160,23 @@ class String
     end
   end
 
+  def [](regex : Regex)
+    self[regex]?.not_nil!
+  end
+
+  def [](regex : Regex, group)
+    self[regex, group]?.not_nil!
+  end
+
+  def []?(regex : Regex)
+    self[regex, 0]?
+  end
+
+  def []?(regex : Regex, group)
+    match = match(regex)
+    match[group] if match && group <= match.length
+  end
+
   def byte_slice(start : Int, count : Int)
     return "" if count <= 0
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -802,6 +802,11 @@ class String
     end
   end
 
+
+  def match(regex : Regex)
+    regex.match self
+  end
+
   def scan(pattern)
     byte_offset = 0
 


### PR DESCRIPTION
### Int#fdiv, Float#fdiv
In some cases this alias can enhance readability by reducing
additional syntax that's not part of the actual computation:

```ruby
5.0/(1+1) == 5.fdiv(1+1)
1/n.to_f  == 1.fdiv(n)
(3/5.0)*2 == 3.fdiv(5)*2
```

And so on.

### String#match

Just an alias to Regex#match really. I shoudn't care about the order
of this call, whatever comes to mind first. This reduces frustation
by having to swap the argument order when you did it the "wrong" way
around.

### String#\[](Regexp), String#[]?(Regexp)

This is useful to extract a part from a string very quickly:

```ruby
input[/\d+/].to_i
input[/mailto:([^ ]+)/, 1]
```

These raise, variants that return nil exist as String#[]?(Regexp)