### PR TITLE
Consistent naming of libs even in tests

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -812,12 +812,12 @@ describe "Code gen: block" do
 
   it "codegens block with return and yield and no return" do
     run("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
       def foo(key)
-        foo(key) { C.exit }
+        foo(key) { LibC.exit }
       end
 
       def foo(key)
@@ -1119,7 +1119,7 @@ describe "Code gen: block" do
 
   it "codegens bug with yield not_nil! that is never not nil" do
     run(%(
-      lib C
+      lib LibC
         fun exit(Int32) : NoReturn
       end
 
@@ -1131,7 +1131,7 @@ describe "Code gen: block" do
 
       struct Nil
         def not_nil!
-          C.exit(1)
+          LibC.exit(1)
         end
 
         def to_i

--- a/spec/compiler/codegen/c_enum_spec.cr
+++ b/spec/compiler/codegen/c_enum_spec.cr
@@ -1,22 +1,22 @@
 require "../../spec_helper"
 
-CodeGenCEnumString = "lib Foo; enum Bar; X, Y, Z = 10, W; end end"
+CodeGenCEnumString = "lib LibFoo; enum Bar; X, Y, Z = 10, W; end end"
 
 describe "Code gen: c enum" do
   it "codegens enum value" do
-    run("#{CodeGenCEnumString}; Foo::Bar::X").to_i.should eq(0)
+    run("#{CodeGenCEnumString}; LibFoo::Bar::X").to_i.should eq(0)
   end
 
   it "codegens enum value 2" do
-    run("#{CodeGenCEnumString}; Foo::Bar::Y").to_i.should eq(1)
+    run("#{CodeGenCEnumString}; LibFoo::Bar::Y").to_i.should eq(1)
   end
 
   it "codegens enum value 3" do
-    run("#{CodeGenCEnumString}; Foo::Bar::Z").to_i.should eq(10)
+    run("#{CodeGenCEnumString}; LibFoo::Bar::Z").to_i.should eq(10)
   end
 
   it "codegens enum value 4" do
-    run("#{CodeGenCEnumString}; Foo::Bar::W").to_i.should eq(11)
+    run("#{CodeGenCEnumString}; LibFoo::Bar::W").to_i.should eq(11)
   end
 
   [
@@ -33,20 +33,20 @@ describe "Code gen: c enum" do
   ].each do |test_case|
     it "codegens enum with #{test_case[0]} " do
       run("
-        lib Foo
+        lib LibFoo
           enum Bar
             X = #{test_case[0]}
           end
         end
 
-        Foo::Bar::X
+        LibFoo::Bar::X
         ").to_i.should eq(test_case[1])
     end
   end
 
   it "codegens enum that refers to another enum constant" do
     run("
-      lib Foo
+      lib LibFoo
         enum Bar
           A = 1
           B = A + 1
@@ -54,13 +54,13 @@ describe "Code gen: c enum" do
         end
       end
 
-      Foo::Bar::C
+      LibFoo::Bar::C
       ").to_i.should eq(3)
   end
 
   it "codegens enum that refers to another constant" do
     run("
-      lib Foo
+      lib LibFoo
         X = 10
         enum Bar
           A = X
@@ -69,7 +69,7 @@ describe "Code gen: c enum" do
         end
       end
 
-      Foo::Bar::C
+      LibFoo::Bar::C
       ").to_i.should eq(12)
   end
 end

--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -1,31 +1,31 @@
 require "../../spec_helper"
 
-CodeGenStructString = "lib Foo; struct Bar; x : Int32; y : Float32; end; end"
+CodeGenStructString = "lib LibFoo; struct Bar; x : Int32; y : Float32; end; end"
 
 describe "Code gen: struct" do
   it "codegens struct property default value" do
-    run("#{CodeGenStructString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
+    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
   end
 
   it "codegens struct property setter" do
-    run("#{CodeGenStructString}; bar = Foo::Bar.new; bar.y = 2.5_f32; bar.y").to_f32.should eq(2.5)
+    run("#{CodeGenStructString}; bar = LibFoo::Bar.new; bar.y = 2.5_f32; bar.y").to_f32.should eq(2.5)
   end
 
   it "codegens struct property setter via pointer" do
-    run("#{CodeGenStructString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
+    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
   end
 
   it "codegens struct property setter via pointer" do
-    run("#{CodeGenStructString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
+    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
   end
 
   it "codegens set struct value with constant" do
-    run("#{CodeGenStructString}; CONST = 1; bar = Foo::Bar.new; bar.x = CONST; bar.x").to_i.should eq(1)
+    run("#{CodeGenStructString}; CONST = 1; bar = LibFoo::Bar.new; bar.x = CONST; bar.x").to_i.should eq(1)
   end
 
   it "codegens union inside struct" do
     run("
-      lib Foo
+      lib LibFoo
         union Bar
           x : Int32
           y : Int64
@@ -36,7 +36,7 @@ describe "Code gen: struct" do
         end
       end
 
-      a = Pointer(Foo::Baz).malloc(1_u64)
+      a = Pointer(LibFoo::Baz).malloc(1_u64)
       a.value.lala.x = 10
       a.value.lala.x
       ").to_i.should eq(10)
@@ -44,7 +44,7 @@ describe "Code gen: struct" do
 
   it "codegens struct get inside struct" do
     run("
-      lib C
+      lib LibC
         struct Bar
           y : Int32
         end
@@ -55,7 +55,7 @@ describe "Code gen: struct" do
         end
       end
 
-      foo = Pointer(C::Foo).malloc(1_u64)
+      foo = Pointer(LibC::Foo).malloc(1_u64)
       ((foo as Int32*) + 1_i64).value = 2
 
       foo.value.bar.y
@@ -64,7 +64,7 @@ describe "Code gen: struct" do
 
   it "codegens struct set inside struct" do
     run("
-      lib C
+      lib LibC
         struct Bar
           y : Int32
         end
@@ -75,8 +75,8 @@ describe "Code gen: struct" do
         end
       end
 
-      foo = Pointer(C::Foo).malloc(1_u64)
-      bar = C::Bar.new
+      foo = Pointer(LibC::Foo).malloc(1_u64)
+      bar = LibC::Bar.new
       bar.y = 2
       foo.value.bar = bar
 
@@ -86,13 +86,13 @@ describe "Code gen: struct" do
 
   it "codegens pointer malloc of struct" do
     run("
-      lib C
+      lib LibC
         struct Foo
           x : Int32
         end
       end
 
-      p = Pointer(C::Foo).malloc(1_u64)
+      p = Pointer(LibC::Foo).malloc(1_u64)
       p.value.x = 1
       p.value.x
       ").to_i.should eq(1)
@@ -100,7 +100,7 @@ describe "Code gen: struct" do
 
   it "passes struct to method (1)" do
     run("
-      lib C
+      lib LibC
         struct Foo
           x : Int32
         end
@@ -111,7 +111,7 @@ describe "Code gen: struct" do
         f
       end
 
-      f1 = C::Foo.new
+      f1 = LibC::Foo.new
       f1.x = 1
 
       f2 = foo(f1)
@@ -122,7 +122,7 @@ describe "Code gen: struct" do
 
   it "passes struct to method (2)" do
     run("
-      lib C
+      lib LibC
         struct Foo
           x : Int32
         end
@@ -133,7 +133,7 @@ describe "Code gen: struct" do
         f
       end
 
-      f1 = C::Foo.new
+      f1 = LibC::Foo.new
       f1.x = 1
 
       f2 = foo(f1)
@@ -143,7 +143,7 @@ describe "Code gen: struct" do
 
   it "codegens struct access with -> and then ." do
     run("
-      lib C
+      lib LibC
         struct ScalarEvent
           x : Int32
         end
@@ -157,14 +157,14 @@ describe "Code gen: struct" do
         end
       end
 
-      e = Pointer(C::Event).malloc(1_u64)
+      e = Pointer(LibC::Event).malloc(1_u64)
       e.value.data.scalar.x
       ").to_i.should eq(0)
   end
 
   it "yields struct via ->" do
     run("
-      lib C
+      lib LibC
         struct ScalarEvent
           x : Int32
         end
@@ -179,7 +179,7 @@ describe "Code gen: struct" do
       end
 
       def foo
-        e = Pointer(C::Event).malloc(1_u64)
+        e = Pointer(LibC::Event).malloc(1_u64)
         yield e.value.data
       end
 
@@ -191,31 +191,31 @@ describe "Code gen: struct" do
 
   it "codegens assign struct to union" do
     run("
-      lib Foo
+      lib LibFoo
         struct Coco
           x : Int32
         end
       end
 
-      x = Foo::Coco.new
+      x = LibFoo::Coco.new
       c = x || 0
-      c.is_a?(Foo::Coco)
+      c.is_a?(LibFoo::Coco)
     ").to_b.should be_true
   end
 
   it "codegens passing pointerof(struct) to fun" do
     run("
-      lib C
+      lib LibC
         struct Foo
           a : Int32
         end
       end
 
-      fun foo(x : C::Foo*) : Int32
+      fun foo(x : LibC::Foo*) : Int32
         x.value.a
       end
 
-      f = C::Foo.new
+      f = LibC::Foo.new
       f.a = 1
 
       foo pointerof(f)
@@ -226,13 +226,13 @@ describe "Code gen: struct" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         struct Foo
           x : ->
         end
       end
 
-      foo = C::Foo.new
+      foo = LibC::Foo.new
       foo.x = -> { }
       ))
   end
@@ -241,20 +241,20 @@ describe "Code gen: struct" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         struct Foo
           x : ->
         end
       end
 
-      foo = Pointer(C::Foo).malloc(1)
+      foo = Pointer(LibC::Foo).malloc(1)
       foo.value.x = -> { }
       ))
   end
 
-  it "allows forward delcarations" do
+  it "allows forward declarations" do
     run(%(
-      lib C
+      lib LibC
         struct A; end
         struct B; end
 
@@ -269,10 +269,10 @@ describe "Code gen: struct" do
         end
       end
 
-      a = C::A.new
+      a = LibC::A.new
       a.y = 1
 
-      b = Pointer(C::B).malloc(1_u64)
+      b = Pointer(LibC::B).malloc(1_u64)
       b.value.y = 2
       a.x = b
 
@@ -282,20 +282,20 @@ describe "Code gen: struct" do
 
   it "allows using named arguments for new" do
     run(%(
-      lib C
+      lib LibC
         struct Point
           x, y : Int32
         end
       end
 
-      point = C::Point.new x: 1, y: 2
+      point = LibC::Point.new x: 1, y: 2
       point.x + point.y
       )).to_i.should eq(3)
   end
 
   it "returns big struct" do
     build(%(
-      lib C
+      lib LibC
         struct Big
           x : Int64
           y : Int64
@@ -305,7 +305,7 @@ describe "Code gen: struct" do
         fun foo(y : Int32) : Big
       end
 
-      s = C.foo(1)
+      s = LibC.foo(1)
       ))
   end
 end

--- a/spec/compiler/codegen/c_union_spec.cr
+++ b/spec/compiler/codegen/c_union_spec.cr
@@ -1,35 +1,35 @@
 require "../../spec_helper"
 
-CodeGenUnionString = "lib Foo; union Bar; x : Int32; y : Int64; z : Float32; end; end"
+CodeGenUnionString = "lib LibFoo; union Bar; x : Int32; y : Int64; z : Float32; end; end"
 
 describe "Code gen: c union" do
   it "codegens union property default value" do
-    run("#{CodeGenUnionString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
+    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
   end
 
   it "codegens union property default value 2" do
-    run("#{CodeGenUnionString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.z").to_f32.should eq(0)
+    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z").to_f32.should eq(0)
   end
 
   it "codegens union property setter 1" do
-    run("#{CodeGenUnionString}; bar = Foo::Bar.new; bar.x = 42; bar.x").to_i.should eq(42)
+    run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.x = 42; bar.x").to_i.should eq(42)
   end
 
   it "codegens union property setter 2" do
-    run("#{CodeGenUnionString}; bar = Foo::Bar.new; bar.z = 42.0_f32; bar.z").to_f32.should eq(42.0)
+    run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.z = 42.0_f32; bar.z").to_f32.should eq(42.0)
   end
 
   it "codegens union property setter 1 via pointer" do
-    run("#{CodeGenUnionString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.x = 42; bar.value.x").to_i.should eq(42)
+    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 42; bar.value.x").to_i.should eq(42)
   end
 
   it "codegens union property setter 2 via pointer" do
-    run("#{CodeGenUnionString}; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.z = 42.0_f32; bar.value.z").to_f32.should eq(42.0)
+    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z = 42.0_f32; bar.value.z").to_f32.should eq(42.0)
   end
 
   it "codegens struct inside union" do
     run("
-      lib Foo
+      lib LibFoo
         struct Baz
           lele : Int64
           lala : Int32
@@ -42,8 +42,8 @@ describe "Code gen: c union" do
         end
       end
 
-      a = Pointer(Foo::Bar).malloc(1_u64)
-      a.value.z = Foo::Baz.new
+      a = Pointer(LibFoo::Bar).malloc(1_u64)
+      a.value.z = LibFoo::Baz.new
       a.value.z.lala = 10
       a.value.z.lala
       ").to_i.should eq(10)
@@ -51,13 +51,13 @@ describe "Code gen: c union" do
 
   it "codegens assign c union to union" do
     run("
-      lib Foo
+      lib LibFoo
         union Bar
           x : Int32
         end
       end
 
-      bar = Foo::Bar.new
+      bar = LibFoo::Bar.new
       bar.x = 10
       x = bar || nil
       if x
@@ -72,13 +72,13 @@ describe "Code gen: c union" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         union Foo
           x : ->
         end
       end
 
-      foo = C::Foo.new
+      foo = LibC::Foo.new
       foo.x = -> { }
       ))
   end

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -547,13 +547,13 @@ describe "Code gen: class" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         type Foo = Int64[8]
       end
 
       class Bar
         def initialize
-          @foo :: C::Foo
+          @foo :: LibC::Foo
         end
       end
 

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -78,7 +78,7 @@ describe "Codegen: const" do
   end
 
   it "define a constant in lib" do
-    run("lib Foo; A = 1; end; Foo::A").to_i.should eq(1)
+    run("lib LibFoo; A = 1; end; LibFoo::A").to_i.should eq(1)
   end
 
   it "invokes block in const" do

--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -19,10 +19,10 @@ describe "Code gen: def" do
 
   it "call external function 'putchar'" do
     run("
-      lib C
+      lib LibC
         fun putchar(c : Char) : Char
       end
-      C.putchar '\\0'
+      LibC.putchar '\\0'
       ").to_i.should eq(0)
   end
 
@@ -32,12 +32,12 @@ describe "Code gen: def" do
 
   it "uses var after external" do
     run("
-      lib C
+      lib LibC
         fun putchar(c : Char) : Char
       end
 
       a = 1
-      C.putchar '\\0'
+      LibC.putchar '\\0'
       a
       ").to_i.should eq(1)
   end

--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -232,29 +232,29 @@ describe "Code gen: fun" do
 
   it "allows fun type of enum type" do
     run("
-      lib Foo
+      lib LibFoo
         enum MyEnum
           X = 1
         end
       end
 
-      ->(x : Foo::MyEnum) {
+      ->(x : LibFoo::MyEnum) {
         x
-      }.call(Foo::MyEnum::X)
+      }.call(LibFoo::MyEnum::X)
       ").to_i.should eq(1)
   end
 
   it "allows fun type of enum type with base type" do
     run("
-      lib Foo
+      lib LibFoo
         enum MyEnum : UInt16
           X = 1
         end
       end
 
-      ->(x : Foo::MyEnum) {
+      ->(x : LibFoo::MyEnum) {
         x
-      }.call(Foo::MyEnum::X)
+      }.call(LibFoo::MyEnum::X)
       ").to_i.should eq(1)
   end
 
@@ -312,22 +312,22 @@ describe "Code gen: fun" do
 
   it "builds fun type from fun" do
     build("
-      lib C
+      lib LibC
         fun foo : ->
       end
 
-      x = C.foo
+      x = LibC.foo
       x.call
       ")
   end
 
   it "builds nilable fun type from fun" do
     build("
-      lib C
+      lib LibC
         fun foo : (->)?
       end
 
-      x = C.foo
+      x = LibC.foo
       if x
         x.call
       end

--- a/spec/compiler/codegen/lib_spec.cr
+++ b/spec/compiler/codegen/lib_spec.cr
@@ -3,32 +3,32 @@ require "../../spec_helper"
 describe "Code gen: lib" do
   pending "codegens lib var set and get" do
     run("
-      lib C
+      lib LibC
         $errno : Int32
       end
 
-      C.errno = 1
-      C.errno
+      LibC.errno = 1
+      LibC.errno
       ").to_i.should eq(1)
   end
 
   it "call to void function" do
     run("
-      lib C
+      lib LibC
         fun srandom(x : UInt32) : Void
       end
 
       def foo
-        C.srandom(0_u32)
+        LibC.srandom(0_u32)
       end
 
       foo
     ")
   end
 
-  it "allows passing type to C if it has a coverter with to_unsafe" do
+  it "allows passing type to LibC if it has a coverter with to_unsafe" do
     build("
-      lib C
+      lib LibC
         fun foo(x : Int32) : Int32
       end
 
@@ -38,15 +38,15 @@ describe "Code gen: lib" do
         end
       end
 
-      C.foo Foo.new
+      LibC.foo Foo.new
       ")
   end
 
-  it "allows passing type to C if it has a coverter with to_unsafe (bug)" do
+  it "allows passing type to LibC if it has a coverter with to_unsafe (bug)" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         fun foo(x : UInt8*)
       end
 
@@ -54,7 +54,7 @@ describe "Code gen: lib" do
         yield 1
       end
 
-      C.foo(foo &.to_s)
+      LibC.foo(foo &.to_s)
       ))
   end
 
@@ -62,12 +62,12 @@ describe "Code gen: lib" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         $x : ->
       end
 
-      C.x = ->{}
-      C.x.call
+      LibC.x = ->{}
+      LibC.x.call
       ))
   end
 
@@ -77,11 +77,11 @@ describe "Code gen: lib" do
         A
       end
 
-      lib C
+      lib LibC
         fun foo(x : Foo)
       end
 
-      C.foo(Foo::A)
+      LibC.foo(Foo::A)
       ))
   end
 
@@ -91,11 +91,11 @@ describe "Code gen: lib" do
         A
       end
 
-      lib C
+      lib LibC
         fun foo : Foo
       end
 
-      C.foo
+      LibC.foo
       ))
   end
 end

--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: no return" do
   it "codegens if with NoReturn on then and union on else" do
-    run("lib C; fun exit(c : Int32) : NoReturn; end; (if 1 == 2; C.exit(1); else; 1 || 2.5; end).to_i").to_i.should eq(1)
+    run("lib LibC; fun exit(c : Int32) : NoReturn; end; (if 1 == 2; LibC.exit(1); else; 1 || 2.5; end).to_i").to_i.should eq(1)
   end
 
   it "codegens Pointer(NoReturn).malloc" do
@@ -13,11 +13,11 @@ describe "Code gen: no return" do
     build(%(
       require "prelude"
 
-      lib C
+      lib LibC
         fun exit2 : NoReturn
       end
 
-      if (a = C.exit2) && a.length == 3
+      if (a = LibC.exit2) && a.length == 3
       end
       ))
   end

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -95,16 +95,16 @@ describe "Code gen: pointer" do
 
   it "sets value of pointer to struct" do
     run("
-      lib C
+      lib LibC
         struct Color
           r, g, b, a : UInt8
         end
       end
 
-      color = Pointer(C::Color).malloc(1_u64)
+      color = Pointer(LibC::Color).malloc(1_u64)
       color.value.r = 10_u8
 
-      color2 = Pointer(C::Color).malloc(1_u64)
+      color2 = Pointer(LibC::Color).malloc(1_u64)
       color2.value.r = 20_u8
 
       color.value = color2.value

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -66,11 +66,11 @@ describe "Code gen: void" do
 
   it "codegens no return assignment" do
     build("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
-      a = C.exit
+      a = LibC.exit
       a
       ")
   end

--- a/spec/compiler/normalize/ifdef_spec.cr
+++ b/spec/compiler/normalize/ifdef_spec.cr
@@ -10,6 +10,6 @@ describe "Normalize: ifdef" do
   end
 
   it "keeps then if condition is true inside lib" do
-    assert_normalize "lib Foo; ifdef foo; type A = B; else; type A = D; end; end", "lib Foo\n  type A : B\nend", flags: "foo"
+    assert_normalize "lib LibFoo; ifdef foo; type A = B; else; type A = D; end; end", "lib LibFoo\n  type A : B\nend", flags: "foo"
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -548,44 +548,44 @@ describe "Parser" do
 
   it_parses "Foo::Bar", ["Foo", "Bar"].path
 
-  it_parses "lib C\nend", LibDef.new("C")
-  it_parses "lib C\nfun getchar\nend", LibDef.new("C", [FunDef.new("getchar")] of ASTNode)
-  it_parses "lib C\nfun getchar(...)\nend", LibDef.new("C", [FunDef.new("getchar", varargs: true)] of ASTNode)
-  it_parses "lib C\nfun getchar : Int\nend", LibDef.new("C", [FunDef.new("getchar", return_type: "Int".path)] of ASTNode)
-  it_parses "lib C\nfun getchar : (->)?\nend", LibDef.new("C", [FunDef.new("getchar", return_type: Union.new([Fun.new, "Nil".path(true)] of ASTNode))] of ASTNode)
-  it_parses "lib C\nfun getchar(Int, Float)\nend", LibDef.new("C", [FunDef.new("getchar", [Arg.new("", restriction: "Int".path), Arg.new("", restriction: "Float".path)])] of ASTNode)
-  it_parses "lib C\nfun getchar(a : Int, b : Float)\nend", LibDef.new("C", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)])] of ASTNode)
-  it_parses "lib C\nfun getchar(a : Int)\nend", LibDef.new("C", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path)])] of ASTNode)
-  it_parses "lib C\nfun getchar(a : Int, b : Float) : Int\nend", LibDef.new("C", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)], "Int".path)] of ASTNode)
-  it_parses "lib C; fun getchar(a : Int, b : Float) : Int; end", LibDef.new("C", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)], "Int".path)] of ASTNode)
-  it_parses "lib C; fun foo(a : Int*); end", LibDef.new("C", [FunDef.new("foo", [Arg.new("a", restriction: "Int".path.pointer_of)])] of ASTNode)
-  it_parses "lib C; fun foo(a : Int**); end", LibDef.new("C", [FunDef.new("foo", [Arg.new("a", restriction: "Int".path.pointer_of.pointer_of)])] of ASTNode)
-  it_parses "lib C; fun foo : Int*; end", LibDef.new("C", [FunDef.new("foo", return_type: "Int".path.pointer_of)] of ASTNode)
-  it_parses "lib C; fun foo : Int**; end", LibDef.new("C", [FunDef.new("foo", return_type: "Int".path.pointer_of.pointer_of)] of ASTNode)
-  it_parses "lib C; fun foo(a : ::B, ::C -> ::D); end", LibDef.new("C", [FunDef.new("foo", [Arg.new("a", restriction: Fun.new([Path.global("B"), Path.global("C")] of ASTNode, Path.global("D")))])] of ASTNode)
-  it_parses "lib C; type A = B; end", LibDef.new("C", [TypeDef.new("A", "B".path)] of ASTNode)
-  it_parses "lib C; type A = B*; end", LibDef.new("C", [TypeDef.new("A", "B".path.pointer_of)] of ASTNode)
-  it_parses "lib C; type A = B**; end", LibDef.new("C", [TypeDef.new("A", "B".path.pointer_of.pointer_of)] of ASTNode)
-  it_parses "lib C; type A = B.class; end", LibDef.new("C", [TypeDef.new("A", Metaclass.new("B".path))] of ASTNode)
-  it_parses "lib C; struct Foo; end end", LibDef.new("C", [StructDef.new("Foo")] of ASTNode)
-  it_parses "lib C; struct Foo; x : Int; y : Float; end end", LibDef.new("C", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path), Arg.new("y", restriction: "Float".path)])] of ASTNode)
-  it_parses "lib C; struct Foo; x : Int*; end end", LibDef.new("C", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path.pointer_of)])] of ASTNode)
-  it_parses "lib C; struct Foo; x : Int**; end end", LibDef.new("C", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path.pointer_of.pointer_of)])] of ASTNode)
-  it_parses "lib C; struct Foo; x, y, z : Int; end end", LibDef.new("C", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path), Arg.new("y", restriction: "Int".path), Arg.new("z", restriction: "Int".path)])] of ASTNode)
-  it_parses "lib C; union Foo; end end", LibDef.new("C", [UnionDef.new("Foo")] of ASTNode)
-  it_parses "lib C; enum Foo; A\nB, C\nD = 1; end end", LibDef.new("C", [EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)] of ASTNode)
-  it_parses "lib C; enum Foo; A = 1, B; end end", LibDef.new("C", [EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Arg.new("B")] of ASTNode)] of ASTNode)
-  it_parses "lib C; Foo = 1; end", LibDef.new("C", [Assign.new("Foo".path, 1.int32)] of ASTNode)
-  it_parses "lib C\nfun getch = GetChar\nend", LibDef.new("C", [FunDef.new("getch", real_name: "GetChar")] of ASTNode)
-  it_parses %(lib C\nfun getch = "get.char"\nend), LibDef.new("C", [FunDef.new("getch", real_name: "get.char")] of ASTNode)
-  it_parses %(lib C\nfun getch = "get.char" : Int32\nend), LibDef.new("C", [FunDef.new("getch", return_type: "Int32".path, real_name: "get.char")] of ASTNode)
-  it_parses %(lib C\nfun getch = "get.char"(x : Int32)\nend), LibDef.new("C", [FunDef.new("getch", [Arg.new("x", restriction: "Int32".path)], real_name: "get.char")] of ASTNode)
-  it_parses "lib C\n$errno : Int32\n$errno2 : Int32\nend", LibDef.new("C", [ExternalVar.new("errno", "Int32".path), ExternalVar.new("errno2", "Int32".path)] of ASTNode)
-  it_parses "lib C\n$errno : B, C -> D\nend", LibDef.new("C", [ExternalVar.new("errno", Fun.new(["B".path, "C".path] of ASTNode, "D".path))] of ASTNode)
-  it_parses "lib C\n$errno = Foo : Int32\nend", LibDef.new("C", [ExternalVar.new("errno", "Int32".path, "Foo")] of ASTNode)
-  it_parses "lib C\nalias Foo = Bar\nend", LibDef.new("C", [Alias.new("Foo", "Bar".path)] of ASTNode)
+  it_parses "lib LibC\nend", LibDef.new("LibC")
+  it_parses "lib LibC\nfun getchar\nend", LibDef.new("LibC", [FunDef.new("getchar")] of ASTNode)
+  it_parses "lib LibC\nfun getchar(...)\nend", LibDef.new("LibC", [FunDef.new("getchar", varargs: true)] of ASTNode)
+  it_parses "lib LibC\nfun getchar : Int\nend", LibDef.new("LibC", [FunDef.new("getchar", return_type: "Int".path)] of ASTNode)
+  it_parses "lib LibC\nfun getchar : (->)?\nend", LibDef.new("LibC", [FunDef.new("getchar", return_type: Union.new([Fun.new, "Nil".path(true)] of ASTNode))] of ASTNode)
+  it_parses "lib LibC\nfun getchar(Int, Float)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("", restriction: "Int".path), Arg.new("", restriction: "Float".path)])] of ASTNode)
+  it_parses "lib LibC\nfun getchar(a : Int, b : Float)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)])] of ASTNode)
+  it_parses "lib LibC\nfun getchar(a : Int)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path)])] of ASTNode)
+  it_parses "lib LibC\nfun getchar(a : Int, b : Float) : Int\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)], "Int".path)] of ASTNode)
+  it_parses "lib LibC; fun getchar(a : Int, b : Float) : Int; end", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)], "Int".path)] of ASTNode)
+  it_parses "lib LibC; fun foo(a : Int*); end", LibDef.new("LibC", [FunDef.new("foo", [Arg.new("a", restriction: "Int".path.pointer_of)])] of ASTNode)
+  it_parses "lib LibC; fun foo(a : Int**); end", LibDef.new("LibC", [FunDef.new("foo", [Arg.new("a", restriction: "Int".path.pointer_of.pointer_of)])] of ASTNode)
+  it_parses "lib LibC; fun foo : Int*; end", LibDef.new("LibC", [FunDef.new("foo", return_type: "Int".path.pointer_of)] of ASTNode)
+  it_parses "lib LibC; fun foo : Int**; end", LibDef.new("LibC", [FunDef.new("foo", return_type: "Int".path.pointer_of.pointer_of)] of ASTNode)
+  it_parses "lib LibC; fun foo(a : ::B, ::C -> ::D); end", LibDef.new("LibC", [FunDef.new("foo", [Arg.new("a", restriction: Fun.new([Path.global("B"), Path.global("C")] of ASTNode, Path.global("D")))])] of ASTNode)
+  it_parses "lib LibC; type A = B; end", LibDef.new("LibC", [TypeDef.new("A", "B".path)] of ASTNode)
+  it_parses "lib LibC; type A = B*; end", LibDef.new("LibC", [TypeDef.new("A", "B".path.pointer_of)] of ASTNode)
+  it_parses "lib LibC; type A = B**; end", LibDef.new("LibC", [TypeDef.new("A", "B".path.pointer_of.pointer_of)] of ASTNode)
+  it_parses "lib LibC; type A = B.class; end", LibDef.new("LibC", [TypeDef.new("A", Metaclass.new("B".path))] of ASTNode)
+  it_parses "lib LibC; struct Foo; end end", LibDef.new("LibC", [StructDef.new("Foo")] of ASTNode)
+  it_parses "lib LibC; struct Foo; x : Int; y : Float; end end", LibDef.new("LibC", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path), Arg.new("y", restriction: "Float".path)])] of ASTNode)
+  it_parses "lib LibC; struct Foo; x : Int*; end end", LibDef.new("LibC", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path.pointer_of)])] of ASTNode)
+  it_parses "lib LibC; struct Foo; x : Int**; end end", LibDef.new("LibC", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path.pointer_of.pointer_of)])] of ASTNode)
+  it_parses "lib LibC; struct Foo; x, y, z : Int; end end", LibDef.new("LibC", [StructDef.new("Foo", [Arg.new("x", restriction: "Int".path), Arg.new("y", restriction: "Int".path), Arg.new("z", restriction: "Int".path)])] of ASTNode)
+  it_parses "lib LibC; union Foo; end end", LibDef.new("LibC", [UnionDef.new("Foo")] of ASTNode)
+  it_parses "lib LibC; enum Foo; A\nB, C\nD = 1; end end", LibDef.new("LibC", [EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)] of ASTNode)
+  it_parses "lib LibC; enum Foo; A = 1, B; end end", LibDef.new("LibC", [EnumDef.new("Foo".path, [Arg.new("A", 1.int32), Arg.new("B")] of ASTNode)] of ASTNode)
+  it_parses "lib LibC; Foo = 1; end", LibDef.new("LibC", [Assign.new("Foo".path, 1.int32)] of ASTNode)
+  it_parses "lib LibC\nfun getch = GetChar\nend", LibDef.new("LibC", [FunDef.new("getch", real_name: "GetChar")] of ASTNode)
+  it_parses %(lib LibC\nfun getch = "get.char"\nend), LibDef.new("LibC", [FunDef.new("getch", real_name: "get.char")] of ASTNode)
+  it_parses %(lib LibC\nfun getch = "get.char" : Int32\nend), LibDef.new("LibC", [FunDef.new("getch", return_type: "Int32".path, real_name: "get.char")] of ASTNode)
+  it_parses %(lib LibC\nfun getch = "get.char"(x : Int32)\nend), LibDef.new("LibC", [FunDef.new("getch", [Arg.new("x", restriction: "Int32".path)], real_name: "get.char")] of ASTNode)
+  it_parses "lib LibC\n$errno : Int32\n$errno2 : Int32\nend", LibDef.new("LibC", [ExternalVar.new("errno", "Int32".path), ExternalVar.new("errno2", "Int32".path)] of ASTNode)
+  it_parses "lib LibC\n$errno : B, C -> D\nend", LibDef.new("LibC", [ExternalVar.new("errno", Fun.new(["B".path, "C".path] of ASTNode, "D".path))] of ASTNode)
+  it_parses "lib LibC\n$errno = Foo : Int32\nend", LibDef.new("LibC", [ExternalVar.new("errno", "Int32".path, "Foo")] of ASTNode)
+  it_parses "lib LibC\nalias Foo = Bar\nend", LibDef.new("LibC", [Alias.new("Foo", "Bar".path)] of ASTNode)
 
-  it_parses "lib C\nifdef foo\ntype A = B\nend\nend", LibDef.new("C", [IfDef.new("foo".var, TypeDef.new("A", "B".path))] of ASTNode)
+  it_parses "lib LibC\nifdef foo\ntype A = B\nend\nend", LibDef.new("LibC", [IfDef.new("foo".var, TypeDef.new("A", "B".path))] of ASTNode)
 
   it_parses "fun foo(x : Int32) : Int64\nx\nend", FunDef.new("foo", [Arg.new("x", restriction: "Int32".path)], "Int64".path, body: "x".var)
 
@@ -740,7 +740,7 @@ describe "Parser" do
   # This is useful for example when interpolating __FILE__ and __DIR__
   it_parses "\"foo\#{\"bar\"}baz\"", "foobarbaz".string
 
-  it_parses "lib Foo\nend\nif true\nend", [LibDef.new("Foo"), If.new(true.bool)]
+  it_parses "lib LibFoo\nend\nif true\nend", [LibDef.new("LibFoo"), If.new(true.bool)]
 
   it_parses "foo(\n1\n)", Call.new(nil, "foo", 1.int32)
 
@@ -827,7 +827,7 @@ describe "Parser" do
 
   it_parses "foo { a = 1 }; a", [Call.new(nil, "foo", block: Block.new(body: Assign.new("a".var, 1.int32))), "a".call] of ASTNode
 
-  it_parses "lib C; ifdef foo; $foo : Int32; else; $foo : Float64; end; end", LibDef.new("C", IfDef.new("foo".var, ExternalVar.new("foo", "Int32".path), ExternalVar.new("foo", "Float64".path)))
+  it_parses "lib LibC; ifdef foo; $foo : Int32; else; $foo : Float64; end; end", LibDef.new("LibC", IfDef.new("foo".var, ExternalVar.new("foo", "Int32".path), ExternalVar.new("foo", "Float64".path)))
 
   it_parses "foo.bar(1).baz", Call.new(Call.new("foo".call, "bar", 1.int32), "baz")
 
@@ -846,7 +846,7 @@ describe "Parser" do
   it_parses "@[Foo(1, foo: 2)]", Attribute.new("Foo", [1.int32] of ASTNode, [NamedArgument.new("foo", 2.int32)])
   it_parses "@[Foo(1, foo: 2\n)]", Attribute.new("Foo", [1.int32] of ASTNode, [NamedArgument.new("foo", 2.int32)])
 
-  it_parses "lib C\n@[Bar]; end", LibDef.new("C", Attribute.new("Bar"))
+  it_parses "lib LibC\n@[Bar]; end", LibDef.new("LibC", Attribute.new("Bar"))
 
   it_parses "Foo(_)", Generic.new("Foo".path, [Underscore.new] of ASTNode)
 

--- a/spec/compiler/type_inference/block_spec.cr
+++ b/spec/compiler/type_inference/block_spec.cr
@@ -537,7 +537,7 @@ describe "Block inference" do
       end
 
       foo do
-        lib Foo
+        lib LibFoo
         end
       end
       ),
@@ -666,14 +666,14 @@ describe "Block inference" do
 
   it "types bug with yield not_nil! that is never not nil" do
     assert_type(%(
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
       def foo
         key = nil
         if 1 == 2
-          yield C.exit
+          yield LibC.exit
         end
         yield 1
       end

--- a/spec/compiler/type_inference/c_enum_spec.cr
+++ b/spec/compiler/type_inference/c_enum_spec.cr
@@ -2,25 +2,25 @@ require "../../spec_helper"
 
 describe "Type inference: c enum" do
   it "types enum value" do
-    assert_type("lib Foo; enum Bar; X, Y, Z = 10, W; end; end; Foo::Bar::X") { types["Foo"].types["Bar"] }
+    assert_type("lib LibFoo; enum Bar; X, Y, Z = 10, W; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
   end
 
   it "allows using an enum as a type in a fun" do
     assert_type("
-      lib C
+      lib LibC
         enum Foo
           A
         end
         fun my_mega_function(y : Foo) : Foo
       end
 
-      C.my_mega_function(C::Foo::A)
-    ") { types["C"].types["Foo"] }
+      LibC.my_mega_function(LibC::Foo::A)
+    ") { types["LibC"].types["Foo"] }
   end
 
   it "allows using an enum as a type in a struct" do
     assert_type("
-      lib C
+      lib LibC
         enum Foo
           A
         end
@@ -29,18 +29,18 @@ describe "Type inference: c enum" do
         end
       end
 
-      f = C::Bar.new
-      f.x = C::Foo::A
+      f = LibC::Bar.new
+      f.x = LibC::Foo::A
       f.x
-    ") { types["C"].types["Foo"] }
+    ") { types["LibC"].types["Foo"] }
   end
 
   it "types enum value with base type" do
-    assert_type("lib Foo; enum Bar : Int16; X; end; end; Foo::Bar::X") { types["Foo"].types["Bar"] }
+    assert_type("lib LibFoo; enum Bar : Int16; X; end; end; LibFoo::Bar::X") { types["LibFoo"].types["Bar"] }
   end
 
   it "errors if enum base type is not an integer" do
-    assert_error "lib Foo; enum Bar : Float32; X; end; end; Foo::Bar::X",
+    assert_error "lib LibFoo; enum Bar : Float32; X; end; end; LibFoo::Bar::X",
       "enum base type must be an integer type"
   end
 end

--- a/spec/compiler/type_inference/c_union_spec.cr
+++ b/spec/compiler/type_inference/c_union_spec.cr
@@ -2,38 +2,38 @@ require "../../spec_helper"
 
 describe "Type inference: c union" do
   it "types c union" do
-    result = assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; Foo::Bar") { types["Foo"].types["Bar"].metaclass }
+    result = assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; LibFoo::Bar") { types["LibFoo"].types["Bar"].metaclass }
     mod = result.program
-    bar = mod.types["Foo"].types["Bar"] as CUnionType
+    bar = mod.types["LibFoo"].types["Bar"] as CUnionType
     bar.vars["x"].type.should eq(mod.int32)
     bar.vars["y"].type.should eq(mod.float64)
   end
 
   it "types Union#new" do
-    assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; Foo::Bar.new") do
-      types["Foo"].types["Bar"]
+    assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; LibFoo::Bar.new") do
+      types["LibFoo"].types["Bar"]
     end
   end
 
   it "types union setter" do
-    assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; bar = Foo::Bar.new; bar.x = 1") { int32 }
+    assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x = 1") { int32 }
   end
 
   it "types union getter" do
-    assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; bar = Foo::Bar.new; bar.x") { int32 }
+    assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = LibFoo::Bar.new; bar.x") { int32 }
   end
 
   it "types union setter via pointer" do
-    assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.x = 1") { int32 }
+    assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 1") { int32 }
   end
 
   it "types union getter via pointer" do
-    assert_type("lib Foo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(Foo::Bar).malloc(1_u64); bar.value.x") { int32 }
+    assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x") { int32 }
   end
 
   it "errors if setting closure" do
     assert_error %(
-      lib Foo
+      lib LibFoo
         union Bar
           x : ->
         end
@@ -41,7 +41,7 @@ describe "Type inference: c union" do
 
       a = 1
 
-      bar = Foo::Bar.new
+      bar = LibFoo::Bar.new
       bar.x = -> { a }
       ),
       "can't set closure as C union member"

--- a/spec/compiler/type_inference/closure_spec.cr
+++ b/spec/compiler/type_inference/closure_spec.cr
@@ -226,25 +226,25 @@ describe "Type inference: closure" do
 
   it "errors if sending closured fun literal to C" do
     assert_error %(
-      lib C
+      lib LibC
         fun foo(callback : ->)
       end
 
       a = 1
-      C.foo(-> { a })
+      LibC.foo(-> { a })
       ),
       "can't send closure to C function"
   end
 
   it "errors if sending closured fun pointer to C (1)" do
     assert_error %(
-      lib C
+      lib LibC
         fun foo(callback : ->)
       end
 
       class Foo
         def foo
-          C.foo(->bar)
+          LibC.foo(->bar)
         end
 
         def bar
@@ -258,7 +258,7 @@ describe "Type inference: closure" do
 
   it "errors if sending closured fun pointer to C (2)" do
     assert_error %(
-      lib C
+      lib LibC
         fun foo(callback : ->)
       end
 
@@ -268,7 +268,7 @@ describe "Type inference: closure" do
       end
 
       foo = Foo.new
-      C.foo(->foo.bar)
+      LibC.foo(->foo.bar)
       ),
       "can't send closure to C function"
   end

--- a/spec/compiler/type_inference/const_spec.cr
+++ b/spec/compiler/type_inference/const_spec.cr
@@ -187,14 +187,14 @@ describe "Type inference: const" do
 
   it "doesn't error if using c enum" do
     assert_type(%(
-      lib C
+      lib LibC
         enum Foo
           A = 1
         end
       end
 
-      C::Foo::A
-      )) { types["C"].types["Foo"] }
+      LibC::Foo::A
+      )) { types["LibC"].types["Foo"] }
   end
 
   it "errors if constant depends on a global initialized later" do

--- a/spec/compiler/type_inference/def_spec.cr
+++ b/spec/compiler/type_inference/def_spec.cr
@@ -38,11 +38,11 @@ describe "Type inference: def" do
   end
 
   it "types putchar with Char" do
-    assert_type("lib C; fun putchar(c : Char) : Char; end; C.putchar 'a'") { char }
+    assert_type("lib LibC; fun putchar(c : Char) : Char; end; LibC.putchar 'a'") { char }
   end
 
   it "types getchar with Char" do
-    assert_type("lib C; fun getchar : Char; end; C.getchar") { char }
+    assert_type("lib LibC; fun getchar : Char; end; LibC.getchar") { char }
   end
 
   it "allows recursion" do

--- a/spec/compiler/type_inference/fun_spec.cr
+++ b/spec/compiler/type_inference/fun_spec.cr
@@ -56,13 +56,13 @@ describe "Type inference: fun" do
 
   it "allows passing fun type if it is typedefed" do
     assert_type("
-      lib C
+      lib LibC
         type Callback = Int32 -> Int32
         fun foo(x : Callback) : Float64
       end
 
       f = ->(x : Int32) { x + 1 }
-      C.foo f
+      LibC.foo f
       ") { float64 }
   end
 
@@ -74,17 +74,13 @@ describe "Type inference: fun" do
       "undefined local variable or method 'a'"
   end
 
-  # it "types int -> int fun literal as a block" do
-  #   assert_type("def foo(&block : Int32 ->); block; end; foo { |x| x + 2 }") { fun_of(int32, int32) }
-  # end
-
-  it "allows implicit cast of fun to return void in C function" do
+  it "allows implicit cast of fun to return void in LibC function" do
     assert_type("
-      lib C
+      lib LibC
         fun atexit(fun : -> ) : Int32
       end
 
-      C.atexit ->{ 1 }
+      LibC.atexit ->{ 1 }
       ") { int32 }
   end
 
@@ -174,12 +170,12 @@ describe "Type inference: fun" do
 
   it "allows passing nil as fun callback" do
     assert_type("
-      lib C
+      lib LibC
         type Cb = Int32 ->
         fun bla(Cb) : Int32
       end
 
-      C.bla(nil)
+      LibC.bla(nil)
       ") { int32 }
   end
 
@@ -284,7 +280,7 @@ describe "Type inference: fun" do
 
   it "allows passing NoReturn type for any return type (1)" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
@@ -292,32 +288,32 @@ describe "Type inference: fun" do
         f.call
       end
 
-      foo ->{ C.exit }
+      foo ->{ LibC.exit }
       ") { no_return }
   end
 
   it "allows passing NoReturn type for any return type (2)" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
         fun foo(x : -> Int32) : Int32
       end
 
-      C.foo ->{ C.exit }
+      LibC.foo ->{ LibC.exit }
       ") { int32 }
   end
 
   it "allows passing NoReturn type for any return type (3)" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
         struct S
           x : -> Int32
         end
       end
 
-      s = C::S.new
-      s.x = ->{ C.exit }
+      s = LibC::S.new
+      s.x = ->{ LibC.exit }
       s.x
       ") { fun_of(int32) }
   end
@@ -331,11 +327,11 @@ describe "Type inference: fun" do
 
   it "allows new on fun type that is a typedef" do
     assert_type("
-      lib C
+      lib LibC
         type F = Int32 -> Int32
       end
 
-      C::F.new { |x| x + 1 }
+      LibC::F.new { |x| x + 1 }
       ") { fun_of(int32, int32) }
   end
 
@@ -383,13 +379,13 @@ describe "Type inference: fun" do
       "function argument 'x' must have a type"
   end
 
-  it "allows passing function to C without specifying types" do
+  it "allows passing function to LibC without specifying types" do
     assert_type(%(
-      lib C
+      lib LibC
         fun foo(x : Int32 -> Int32) : Float64
       end
 
-      C.foo ->(x) { x + 1 }
+      LibC.foo ->(x) { x + 1 }
       )) { float64 }
   end
 
@@ -468,23 +464,23 @@ describe "Type inference: fun" do
 
   it "gives correct error message when fun return type is incorrect (#219)" do
     assert_error %(
-      lib Foo
+      lib LibFoo
         fun bar(f : Int32 -> Int32)
       end
 
-      Foo.bar ->(x) { 1.1 }
+      LibFoo.bar ->(x) { 1.1 }
       ),
-      "argument 'f' of 'Foo#bar' must be a function returning Int32, not Float64"
+      "argument 'f' of 'LibFoo#bar' must be a function returning Int32, not Float64"
   end
 
   it "doesn't capture closured var if using typeof" do
     assert_type(%(
-      lib Foo
+      lib LibFoo
         fun foo(x : ->) : Int32
       end
 
       a = 1
-      Foo.foo ->{
+      LibFoo.foo ->{
         typeof(a)
         2
       }

--- a/spec/compiler/type_inference/initialize_spec.cr
+++ b/spec/compiler/type_inference/initialize_spec.cr
@@ -289,13 +289,13 @@ describe "Type inference: initialize" do
 
   it "doesn't type instance var as nilable if out" do
     assert_type(%(
-      lib C
+      lib LibC
         fun foo(x : Int32*)
       end
 
       class Foo
         def initialize
-          C.foo(out @x)
+          LibC.foo(out @x)
           @x + 2
         end
 

--- a/spec/compiler/type_inference/is_a_spec.cr
+++ b/spec/compiler/type_inference/is_a_spec.cr
@@ -71,7 +71,7 @@ describe "Type inference: is_a?" do
 
   it "applies filter inside block" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
@@ -82,7 +82,7 @@ describe "Type inference: is_a?" do
       foo do
         a = 1
         unless a.is_a?(Int32)
-          C.exit
+          LibC.exit
         end
       end
 

--- a/spec/compiler/type_inference/no_return_spec.cr
+++ b/spec/compiler/type_inference/no_return_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 
 describe "Type inference: NoReturn" do
-  it "types call to C.exit as NoReturn" do
-    assert_type("lib C; fun exit : NoReturn; end; C.exit") { no_return }
+  it "types call to LibC.exit as NoReturn" do
+    assert_type("lib LibC; fun exit : NoReturn; end; LibC.exit") { no_return }
   end
 
   it "types raise as NoReturn" do
@@ -10,20 +10,20 @@ describe "Type inference: NoReturn" do
   end
 
   it "types union of NoReturn and something else" do
-    assert_type("lib C; fun exit : NoReturn; end; 1 == 1 ? C.exit : 1") { int32 }
+    assert_type("lib LibC; fun exit : NoReturn; end; 1 == 1 ? LibC.exit : 1") { int32 }
   end
 
   it "types union of NoReturns" do
-    assert_type("lib C; fun exit : NoReturn; end; 1 == 2 ? C.exit : C.exit") { no_return }
+    assert_type("lib LibC; fun exit : NoReturn; end; 1 == 2 ? LibC.exit : LibC.exit") { no_return }
   end
 
   it "types with no return even if code follows" do
-    assert_type("lib C; fun exit : NoReturn; end; C.exit; 1") { no_return }
+    assert_type("lib LibC; fun exit : NoReturn; end; LibC.exit; 1") { no_return }
   end
 
   it "assumes if condition's type filters when else is no return" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
@@ -34,7 +34,7 @@ describe "Type inference: NoReturn" do
       end
 
       foo = Foo.new || nil
-      C.exit unless foo
+      LibC.exit unless foo
 
       foo.foo
     ") { int32 }

--- a/spec/compiler/type_inference/pointer_spec.cr
+++ b/spec/compiler/type_inference/pointer_spec.cr
@@ -62,12 +62,12 @@ describe "Type inference: pointer" do
 
   it "types nil or pointer type with typedef" do
     result = assert_type(%(
-      lib C
+      lib LibC
         type T = Void*
         fun foo : T?
       end
-      C.foo
-      )) { |mod| union_of(mod.nil, mod.types["C"].types["T"]) }
+      LibC.foo
+      )) { |mod| union_of(mod.nil, mod.types["LibC"].types["T"]) }
     result.node.type.should be_a(NilablePointerType)
   end
 
@@ -88,12 +88,12 @@ describe "Type inference: pointer" do
 
   it "types pointer value on typedef" do
     assert_type(%(
-      lib C
+      lib LibC
         type Foo = Int32*
         fun foo : Foo
       end
 
-      C.foo.value
+      LibC.foo.value
       )) { int32 }
   end
 end

--- a/spec/compiler/type_inference/primitives_spec.cr
+++ b/spec/compiler/type_inference/primitives_spec.cr
@@ -59,11 +59,11 @@ describe "Type inference: primitives" do
 
   it "errors when comparing void (#225)" do
     assert_error %(
-      lib Foo
+      lib LibFoo
         fun foo
       end
 
-      Foo.foo == 1
+      LibFoo.foo == 1
       ), "undefined method '==' for Void"
   end
 

--- a/spec/compiler/type_inference/ssa_spec.cr
+++ b/spec/compiler/type_inference/ssa_spec.cr
@@ -177,13 +177,13 @@ describe "Type inference: ssa" do
 
   it "types a var that is declared in a while with out" do
     assert_type(%(
-      lib C
+      lib LibC
         fun foo(x : Int32*)
       end
 
       a = 'a'
       while 1 == 2
-        C.foo(out x)
+        LibC.foo(out x)
         a = x
       end
       a
@@ -255,7 +255,7 @@ describe "Type inference: ssa" do
 
   it "types a var after begin rescue with no-return in rescue" do
     assert_type(%(
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
@@ -264,7 +264,7 @@ describe "Type inference: ssa" do
         a = 'a'
         a = "hello"
       rescue ex
-        C.exit
+        LibC.exit
       end
       a
       )) { union_of [int32, char, string] of Type }
@@ -385,7 +385,7 @@ describe "Type inference: ssa" do
 
   it "types if with unreachable in then" do
     assert_type("
-      lib C
+      lib LibC
         fun exit : NoReturn
       end
 
@@ -393,7 +393,7 @@ describe "Type inference: ssa" do
         a = 1
       else
         a = 'a'
-        C.exit
+        LibC.exit
       end
 
       a


### PR DESCRIPTION
I believe it is important to keep the names consistent everywhere, even
the tests. If our direction moving forward is to use the `LibX`
convention, then that should be reflected everywhere.