### PR TITLE
Added: #addr and #peeraddr to IPSocket and UNIXSocket

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -6,8 +6,20 @@ describe "UNIXSocket" do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do |server|
+      server.addr.family.should eq("AF_UNIX")
+      server.addr.path.should eq(path)
+
       UNIXSocket.open(path) do |client|
+        client.addr.family.should eq("AF_UNIX")
+        client.addr.path.should eq(path)
+
         server.accept do |sock|
+          sock.addr.family.should eq("AF_UNIX")
+          sock.addr.path.should eq("")
+
+          sock.peeraddr.family.should eq("AF_UNIX")
+          sock.peeraddr.path.should eq("")
+
           client << "ping"
           sock.read(4).should eq("ping")
           sock << "pong"
@@ -18,7 +30,10 @@ describe "UNIXSocket" do
   end
 
   it "creates a pair of sockets" do
-    UNIXSocket.pair("/tmp/sock") do |left, right|
+    UNIXSocket.pair do |left, right|
+      left.addr.family.should eq("AF_UNIX")
+      left.addr.path.should eq("")
+
       left << "ping"
       right.read(4).should eq("ping")
       right << "pong"
@@ -30,8 +45,23 @@ end
 describe "TCPSocket" do
   it "sends and receives messages" do
     TCPServer.open("::", 12345) do |server|
+      server.addr.family.should eq("AF_INET6")
+      server.addr.port.should eq(12345)
+      server.addr.ip_address.should eq("::")
+
       TCPSocket.open("localhost", 12345) do |client|
+        client.addr.family.should eq("AF_INET")
+        client.addr.ip_address.should eq("127.0.0.1")
+
         sock = server.accept
+
+        sock.addr.family.should eq("AF_INET6")
+        sock.addr.port.should eq(12345)
+        sock.addr.ip_address.should eq("::ffff:127.0.0.1")
+
+        sock.peeraddr.family.should eq("AF_INET6")
+        sock.peeraddr.ip_address.should eq("::ffff:127.0.0.1")
+
         client << "ping"
         sock.read(4).should eq("ping")
         sock << "pong"
@@ -46,8 +76,18 @@ describe "UDPSocket" do
     server = UDPSocket.new(LibC::AF_INET6)
     server.bind("::", 12346)
 
+    server.addr.family.should eq("AF_INET6")
+    server.addr.port.should eq(12346)
+    server.addr.ip_address.should eq("::")
+
     client = UDPSocket.new(LibC::AF_INET)
     client.connect("localhost", 12346)
+
+    client.addr.family.should eq("AF_INET")
+    client.addr.ip_address.should eq("127.0.0.1")
+    client.peeraddr.family.should eq("AF_INET")
+    client.peeraddr.port.should eq(12346)
+    client.peeraddr.ip_address.should eq("127.0.0.1")
 
     client << "message"
     server.read(7).should eq("message")

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -46,7 +46,7 @@ describe "TCPSocket" do
   it "sends and receives messages" do
     TCPServer.open("::", 12345) do |server|
       server.addr.family.should eq("AF_INET6")
-      server.addr.port.should eq(12345)
+      server.addr.ip_port.should eq(12345)
       server.addr.ip_address.should eq("::")
 
       TCPSocket.open("localhost", 12345) do |client|
@@ -56,7 +56,7 @@ describe "TCPSocket" do
         sock = server.accept
 
         sock.addr.family.should eq("AF_INET6")
-        sock.addr.port.should eq(12345)
+        sock.addr.ip_port.should eq(12345)
         sock.addr.ip_address.should eq("::ffff:127.0.0.1")
 
         sock.peeraddr.family.should eq("AF_INET6")
@@ -77,7 +77,7 @@ describe "UDPSocket" do
     server.bind("::", 12346)
 
     server.addr.family.should eq("AF_INET6")
-    server.addr.port.should eq(12346)
+    server.addr.ip_port.should eq(12346)
     server.addr.ip_address.should eq("::")
 
     client = UDPSocket.new(LibC::AF_INET)
@@ -86,7 +86,7 @@ describe "UDPSocket" do
     client.addr.family.should eq("AF_INET")
     client.addr.ip_address.should eq("127.0.0.1")
     client.peeraddr.family.should eq("AF_INET")
-    client.peeraddr.port.should eq(12346)
+    client.peeraddr.ip_port.should eq(12346)
     client.peeraddr.ip_address.should eq("127.0.0.1")
 
     client << "message"

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -116,6 +116,16 @@ class SocketError < Exception
 end
 
 class Socket < FileDescriptorIO
+  class Addr
+    property :family, :port, :ip_address, :path
+
+    def initialize(@family, @port, @ip_address)
+    end
+
+    def initialize(@family, @path)
+    end
+  end
+
   def afamily(family)
     LibC::AF_UNSPEC.class.cast(family)
   end

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -116,7 +116,7 @@ class SocketError < Exception
 end
 
 class Socket < FileDescriptorIO
-  class Addr
+  struct Addr
     property :family, :port, :ip_address, :path
 
     def initialize(@family, @port, @ip_address)

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -117,9 +117,9 @@ end
 
 class Socket < FileDescriptorIO
   struct Addr
-    property :family, :port, :ip_address, :path
+    property :family, :ip_port, :ip_address, :path
 
-    def initialize(@family, @port, @ip_address)
+    def initialize(@family, @ip_port, @ip_address)
     end
 
     def initialize(@family, @path)

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -28,21 +28,29 @@ class UNIXSocket < Socket
     end
   end
 
-  def self.pair(path, socktype = LibC::SOCK_STREAM)
+  def self.pair(socktype = LibC::SOCK_STREAM, protocol = 0)
     fds = StaticArray(Int32, 2).new { 0_i32 }
-    if LibC.socketpair(LibC::AF_UNIX, socktype, 0, pointerof(fds)) != 0
+    if LibC.socketpair(LibC::AF_UNIX, socktype, protocol, pointerof(fds)) != 0
       raise Errno.new("socketpair:")
     end
     fds.map { |fd| UNIXSocket.new(fd) }
   end
 
-  def self.pair(path, socktype = LibC::SOCK_STREAM)
-    left, right = pair(path, socktype)
+  def self.pair(socktype = LibC::SOCK_STREAM, protocol = 0)
+    left, right = pair(socktype, protocol)
     begin
       yield left, right
     ensure
       left.close
       right.close
     end
+  end
+
+  def addr
+    Addr.new("AF_UNIX", path.to_s)
+  end
+
+  def peeraddr
+    Addr.new("AF_UNIX", path.to_s)
   end
 end


### PR DESCRIPTION
It could be interesting to return a Tuple, like the Array that Ruby returns: `{"AF_INET", 80, "localhost", "127.0.0.1"}` or maybe a Socket::Addr struct is more interesting (we can add methods like `ip?` `unix?`, etc).