### PR TITLE
Character sets

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -113,6 +113,50 @@ describe "Char" do
     ('b' <=> 'a').should be > 0
   end
 
+  describe "in_set?" do
+    assert { 'a'.in_set?("a").should be_true }
+    assert { 'a'.in_set?("b").should be_false }
+    assert { 'a'.in_set?("a-c").should be_true }
+    assert { 'b'.in_set?("a-c").should be_true }
+    assert { 'c'.in_set?("a-c").should be_true }
+    assert { 'c'.in_set?("a-bc").should be_true }
+    assert { 'b'.in_set?("a-bc").should be_true }
+    assert { 'd'.in_set?("a-c").should be_false }
+    assert { 'b'.in_set?("^a-c").should be_false }
+    assert { 'd'.in_set?("^a-c").should be_true }
+    assert { 'a'.in_set?("ab-c").should be_true }
+    assert { 'a'.in_set?("\\^ab-c").should be_true }
+    assert { '^'.in_set?("\\^ab-c").should be_true }
+    assert { '^'.in_set?("a^b-c").should be_true }
+    assert { '^'.in_set?("ab-c^").should be_true }
+    assert { '^'.in_set?("a0-^").should be_true }
+    assert { '^'.in_set?("^-c").should be_true }
+    assert { '^'.in_set?("a^-c").should be_true }
+    assert { '\\'.in_set?("ab-c\\").should be_true }
+    assert { '\\'.in_set?("a\\b-c").should be_false }
+    assert { '\\'.in_set?("a0-\\c").should be_true }
+    assert { '\\'.in_set?("a\\-c").should be_false }
+    assert { '-'.in_set?("a-c").should be_false }
+    assert { '-'.in_set?("a-c").should be_false }
+    assert { '-'.in_set?("a\\-c").should be_true }
+    assert { '-'.in_set?("-c").should be_true }
+    assert { '-'.in_set?("a-").should be_true }
+    assert { '-'.in_set?("^-c").should be_false }
+    assert { '-'.in_set?("^\\-c").should be_false }
+    assert { 'b'.in_set?("^\\-c").should be_true }
+    assert { '-'.in_set?("a^-c").should be_false }
+    assert { 'a'.in_set?("a", "ab").should be_true }
+    assert { 'a'.in_set?("a", "^b").should be_true }
+    assert { 'a'.in_set?("a", "b").should be_false }
+    assert { 'a'.in_set?("ab", "ac", "ad").should be_true }
+
+    it "rejects invalid ranges" do
+      expect_raises do
+        'a'.in_set?("c-a")
+      end
+    end
+  end
+
   it "raises on codepoint bigger than 0x10ffff when doing each_byte" do
     expect_raises do
       (0x10ffff + 1).chr.each_byte { |b| }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -687,4 +687,18 @@ describe "String" do
   it "has size (same as length)" do
     "テスト".size.should eq(3)
   end
+
+  describe "count" do
+    assert { "hello world".count("lo").should eq(5) }
+    assert { "hello world".count("lo", "o").should eq(2) }
+    assert { "hello world".count("hello", "^l").should eq(4) }
+    assert { "hello world".count("ej-m").should eq(4) }
+    assert { "hello^world".count("\\^aeiou").should eq(4) }
+    assert { "hello-world".count("a\\-eo").should eq(4) }
+    assert { "hello world\\r\\n".count("\\").should eq(2) }
+    assert { "hello world\\r\\n".count("\\A").should eq(0) }
+    assert { "hello world\\r\\n".count("X-\\w").should eq(3) }
+    assert { "aabbcc".count('a').should eq(2) }
+    assert { "aabbcc".count {|c| ['a', 'b'].includes?(c) }.should eq(4) }
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -714,4 +714,12 @@ describe "String" do
     assert { "aabbcc".count('a').should eq(2) }
     assert { "aabbcc".count {|c| ['a', 'b'].includes?(c) }.should eq(4) }
   end
+
+  describe "squeeze" do
+    assert { "aaabbbccc".squeeze {|c| ['a', 'b'].includes?(c) }.should eq("abccc") }
+    assert { "aaabbbccc".squeeze {|c| ['a', 'c'].includes?(c) }.should eq("abbbc") }
+    assert { "a       bbb".squeeze.should eq("a b") }
+    assert { "a    bbb".squeeze(' ').should eq("a bbb") }
+    assert { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -359,14 +359,27 @@ describe "String" do
     end
   end
 
-  it "deletes one char" do
-    deleted = "foobar".delete('o')
-    deleted.bytesize.should eq(4)
-    deleted.should eq("fbar")
+  describe "delete" do
+    assert { "foobar".delete {|char| char == 'o' }.should eq("fbar") }
+    assert { "hello world".delete("lo").should eq("he wrd") }
+    assert { "hello world".delete("lo", "o").should eq("hell wrld") }
+    assert { "hello world".delete("hello", "^l").should eq("ll wrld") }
+    assert { "hello world".delete("ej-m").should eq("ho word") }
+    assert { "hello^world".delete("\\^aeiou").should eq("hllwrld") }
+    assert { "hello-world".delete("a\\-eo").should eq("hllwrld") }
+    assert { "hello world\\r\\n".delete("\\").should eq("hello worldrn") }
+    assert { "hello world\\r\\n".delete("\\A").should eq("hello world\\r\\n") }
+    assert { "hello world\\r\\n".delete("X-\\w").should eq("hello orldrn") }
 
-    deleted = "foobar".delete('x')
-    deleted.bytesize.should eq(6)
-    deleted.should eq("foobar")
+    it "deletes one char" do
+      deleted = "foobar".delete('o')
+      deleted.bytesize.should eq(4)
+      deleted.should eq("fbar")
+
+      deleted = "foobar".delete('x')
+      deleted.bytesize.should eq(6)
+      deleted.should eq("foobar")
+    end
   end
 
   it "reverses string" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -427,17 +427,44 @@ class String
 
   # Sets should be a list of strings following the rules
   # described at Char#in_set?. Returns the number of characters
-  # in this string that matched the given set.
+  # in this string that match the given set.
   def count(*sets)
     count {|char| char.in_set?(*sets) }
   end
 
-  def delete(char : Char)
+  # Yields each char in this string to the block.
+  # Returns a new string with all characters for which the
+  # block returned a truthy value removed.
+  #
+  # ```
+  # "aabbcc".delete {|c| ['a', 'b'].includes?(c) } #=> "cc"
+  # ```
+  def delete
     String.build(bytesize) do |buffer|
-      each_char do |my_char|
-        buffer << my_char unless my_char == char
+      each_char do |char|
+        buffer << char unless yield char
       end
     end
+  end
+
+  # Returns a new string with all occurrences of char removed.
+  #
+  # ```
+  # "aabbcc".delete('b') #=> "aacc"
+  # ```
+  def delete(char : Char)
+    delete {|my_char|  my_char == char }
+  end
+
+  # Sets should be a list of strings following the rules
+  # described at Char#in_set?. Returns a new string with
+  # all characters that match the given set removed.
+  #
+  # ```
+  # "aabbccdd".delete("a-c") #=> "dd"
+  # ```
+  def delete(*sets)
+    delete {|char| char.in_set?(*sets) }
   end
 
   def empty?

--- a/src/string.cr
+++ b/src/string.cr
@@ -402,6 +402,36 @@ class String
     gsub(pattern) { replacement }
   end
 
+  # Yields each char in this string to the block,
+  # returns the number of times the block returned a truthy value.
+  #
+  # ```
+  # "aabbcc".count {|c| ['a', 'b'].includes?(c) } #=> 4
+  # ```
+  def count
+    count = 0
+    each_char do |char|
+      count += 1 if yield char
+    end
+    count
+  end
+
+  # Counts the occurrences of other in this string.
+  #
+  # ```
+  # "aabbcc".count('a') #=> 2
+  # ```
+  def count(other : Char)
+    count {|char| char == other }
+  end
+
+  # Sets should be a list of strings following the rules
+  # described at Char#in_set?. Returns the number of characters
+  # in this string that matched the given set.
+  def count(*sets)
+    count {|char| char.in_set?(*sets) }
+  end
+
   def delete(char : Char)
     String.build(bytesize) do |buffer|
       each_char do |my_char|

--- a/src/string.cr
+++ b/src/string.cr
@@ -467,6 +467,53 @@ class String
     delete {|char| char.in_set?(*sets) }
   end
 
+  # Yields each char in this string to the block.
+  # Returns a new string, that has all characters removed,
+  # that were the same as the previous one and for which the given
+  # block returned a truthy value.
+  #
+  # ```
+  # "aaabbbccc".squeeze {|c| ['a', 'b'].includes?(c) } #=> "abccc"
+  # "aaabbbccc".squeeze {|c| ['a', 'c'].includes?(c) } #=> "abbbc"
+  # ```
+  def squeeze
+    previous = nil
+    String.build(bytesize) do |buffer|
+      each_char do |char|
+        buffer << char unless yield(char) && previous == char
+        previous = char
+      end
+    end
+  end
+
+  # Returns a new string, with all runs of char replaced by one instance.
+  #
+  # ```
+  # "a    bbb".squeeze(' ') #=> "a bbb"
+  # ```
+  def squeeze(char : Char)
+    squeeze {|my_char| char == my_char }
+  end
+
+  # Sets should be a list of strings following the rules
+  # described at Char#in_set?. Returns a new string with all
+  # runs of the same character replaced by one instance, if
+  # they match the given set.
+  #
+  # If no set is given, all characters are matched.
+  #
+  # ```
+  # "aaabbbcccddd".squeeze("b-d") #=> "aaabcd"
+  # "a       bbb".squeeze #=> "a b"
+  # ```
+  def squeeze(*sets)
+    if sets.empty?
+      squeeze { true }
+    else
+      squeeze {|char| char.in_set?(*sets) }
+    end
+  end
+
   def empty?
     bytesize == 0
   end


### PR DESCRIPTION
This introduces `Char#in_set?`, which copies the semantics of Rubys [String#count](http://ruby-doc.org/core-2.2.0/String.html#method-i-count), determining whether the character it's called on is in the given set.

Based upon that I added String#count, an overload for String#delete and String#squeeze.

I also added variants for the above methods that take a single char and a block.