### PR TITLE
Fix SDL Samples

### DIFF
--- a/samples/sdl/sdl/lib_sdl.cr
+++ b/samples/sdl/sdl/lib_sdl.cr
@@ -144,10 +144,15 @@ lib LibSDL
   fun show_cursor = SDL_ShowCursor(toggle : Int32) : Int32
   fun get_ticks = SDL_GetTicks : UInt32
   fun flip = SDL_Flip(screen : Surface*) : Int32
+  fun main = SDL_main(argc : Int32, argv : UInt8*) : Int32
 end
 
-undef main
-
-redefine_main(SDL_main) do |main|
-  {{main}}
+fun main(argc : Int32, argv : UInt8*)
+  return LibSDL.main(argc, argv)
 end
+
+#undef main
+#
+#redefine_main(SDL_main) do |main|
+#  {{main}}
+#end


### PR DESCRIPTION
I was receiving this compiler error when running the SDL samples:

```
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/crt1.o: In function _start': (.text+0x20): undefined reference to 'main'
```