### PR TITLE
Fix: SDL link declaration for Linux

### DIFF
--- a/samples/sdl/sdl/lib_sdl.cr
+++ b/samples/sdl/sdl/lib_sdl.cr
@@ -1,6 +1,10 @@
-@[Link("SDL")]
-@[Link("SDLMain")]
-@[Link(framework: "Cocoa")] ifdef darwin
+ifdef darwin
+  @[Link("SDL")]
+  @[Link("SDLMain")]
+  @[Link(framework: "Cocoa")]
+else
+  @[Link("SDL")]
+end
 lib LibSDL
   INIT_TIMER       = 0x00000001_u32
   INIT_AUDIO       = 0x00000010_u32


### PR DESCRIPTION
Crystal skips the `@[Link]` on Linux because of the `@[Link(framework: "Cocoa")] ifdef darwin` line.

Maybe it's a bug in the compiler, and it should process them? Anyway, an ifdef/else looks cleaner.