### PR TITLE
Added Enumerable#last

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -25,6 +25,19 @@ describe "Enumerable" do
       end
     end
   end
+  
+  describe "last" do
+    it "returns the last element" do
+      (0..5).last.should eq(5)
+      (0...5).last.should eq(4)
+    end
+
+    it "raises if empty" do
+      expect_raises EmptyEnumerable do
+        (5...5).last
+      end
+    end
+  end
 
   describe "min" do
     assert { [1, 2, 3].min.should eq(1) }

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -161,6 +161,15 @@ module Enumerable(T)
       yield elem, io
     end
   end
+  
+  def last
+    last, count = first, 0
+    each do |e|
+      count += 1
+      last = e
+    end
+    count > 0 ? last : raise EmptyEnumerable.new
+  end
 
   def map(&block : T -> U)
     ary = [] of U

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -163,12 +163,11 @@ module Enumerable(T)
   end
   
   def last
-    last, count = first, 0
+    last = first
     each do |e|
-      count += 1
       last = e
     end
-    count > 0 ? last : raise EmptyEnumerable.new
+    last
   end
 
   def map(&block : T -> U)

--- a/src/range.cr
+++ b/src/range.cr
@@ -42,6 +42,10 @@ struct Range(B, E)
   def covers?(value)
     includes?(value)
   end
+  
+  def last
+    @exclusive ? super : @end
+  end
 
   def ===(value)
     includes?(value)


### PR DESCRIPTION
This method's main purpose is to spare us from things like
```ruby
last = range.end
last -= 1 if range.excludes_end?
```
which is a common sight in methods that take ranges as arguments.
It could be added to Range instead but I think it's a good idea to provide a method to get the last element for enumerable classses in general since there's already one to get the first.