### PR TITLE
Use https url instead of ssh for clone

### DIFF
--- a/docs/installation/from_source_repository.html
+++ b/docs/installation/from_source_repository.html
@@ -1955,7 +1955,7 @@
 <p>If you want to contribute then you might want to install Crystal from sources. But Crystal is written in Crystal itself! So you first need to use one of the previous described methods to have a running compiler.</p>
 <p>You will also need LLVM 3.5 present in the path. If you are using Mac and the Homebrew formula, this will be automatically configured for you if you install Crystal adding <code>--with-llvm</code> flag.</p>
 <p>Then clone the repository:</p>
-<pre><code>git clone git@github.com:manastech/crystal.git
+<pre><code>git clone https://github.com/manastech/crystal.git
 </code></pre><p>and you&#39;re ready to start hacking.</p>
 <p>To build your own version of the compiler, run <code>make</code>. The new compiler will be placed at <code>.build/crystal</code>.</p>
 <p>Inside the repository you will also find a wrapper script at <code>bin/crystal</code>. This script will execute the global installed compiler or the one that you just compiled (if present).</p>


### PR DESCRIPTION
Using the ssh version only works if the machine pub key is added on github.
https version works everywhere.