### PR TITLE
Fix: leaking file descriptors on socket creation errors

### DIFF
--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -10,11 +10,13 @@ class TCPServer < TCPSocket
       LibC.setsockopt(sock, LibC::SOL_SOCKET, LibC::SO_REUSEADDR, pointerof(optval) as Void*, sizeof(Int32))
 
       if LibC.bind(sock, ai.addr as LibC::SockAddr*, ai.addrlen) != 0
+        LibC.close(sock)
         next false if ai.next
         raise Errno.new("Error binding TCP server at #{host}#{port}")
       end
 
       if LibC.listen(sock, backlog) != 0
+        LibC.close(sock)
         next false if ai.next
         raise Errno.new("Error listening TCP server at #{host}#{port}")
       end

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -7,6 +7,7 @@ class TCPSocket < IPSocket
       raise Errno.new("Error opening socket") if sock <= 0
 
       if LibC.connect(sock, ai.addr, ai.addrlen) != 0
+        LibC.close(sock)
         next false if ai.next
         raise Errno.new("Error connecting to '#{host}:#{port}'")
       end

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -11,10 +11,12 @@ class UNIXServer < UNIXSocket
     addr.family = LibC::AF_UNIX
     addr.path = path.to_unsafe
     if LibC.bind(sock, pointerof(addr) as LibC::SockAddr*, sizeof(LibC::SockAddrUn)) != 0
+      LibC.close(sock)
       raise Errno.new("Error binding UNIX server at #{path}")
     end
 
     if LibC.listen(sock, backlog) != 0
+      LibC.close(sock)
       raise Errno.new("Error listening UNIX server at #{path}")
     end
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -9,6 +9,7 @@ class UNIXSocket < Socket
     addr.family = LibC::AF_UNIX
     addr.path = path.to_unsafe
     if LibC.connect(sock, pointerof(addr) as LibC::SockAddr*, sizeof(LibC::SockAddrUn)) != 0
+      LibC.close(sock)
       raise Errno.new("Error connecting to '#{path}'")
     end
 


### PR DESCRIPTION
In Prax I try to connect to an application until it's ready, but I eventually ran out of file descriptors in a test. The culprit is `TCPSocket.new` (and alikes) that never close sockets when connect, bind or listen error! Well, my bad.