### PR TITLE
Logger

### DIFF
--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -35,9 +35,9 @@ describe "Logger" do
   it "uses custom formatter" do
     IO.pipe do |r, w|
       logger = Logger.new(w)
-      logger.formatter = ->(severity : String, datetime : Time, progname : String, message : String) {
+      logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message|
         "#{severity[0]} #{progname}: #{message}"
-      }
+      end
       logger.warn "message", "prog"
 
       r.gets.should eq("W prog: message\n")

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -1,0 +1,46 @@
+require "spec"
+require "logger"
+
+describe "Logger" do
+  it "logs messages" do
+    IO.pipe do |r, w|
+      logger = Logger.new(w)
+      logger.debug "debug:skip"
+      logger.info "info:show"
+
+      logger.level = Logger::DEBUG
+      logger.debug "debug:show"
+
+      logger.level = Logger::WARN
+      logger.debug "debug:skip:again"
+      logger.info "info:skip"
+      logger.error "error:show"
+
+      r.gets.should match(/info:show/)
+      r.gets.should match(/debug:show/)
+      r.gets.should match(/error:show/)
+    end
+  end
+
+  it "formats message" do
+    IO.pipe do |r, w|
+      logger = Logger.new(w)
+      logger.progname = "crystal"
+      logger.warn "message"
+
+      r.gets.should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
+    end
+  end
+
+  it "uses custom formatter" do
+    IO.pipe do |r, w|
+      logger = Logger.new(w)
+      logger.formatter = ->(severity : String, datetime : Time, progname : String, message : String) {
+        "#{severity[0]} #{progname}: #{message}"
+      }
+      logger.warn "message", "prog"
+
+      r.gets.should match(/W prog: message\n/)
+    end
+  end
+end

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -40,7 +40,29 @@ describe "Logger" do
       }
       logger.warn "message", "prog"
 
-      r.gets.should match(/W prog: message\n/)
+      r.gets.should eq("W prog: message\n")
+    end
+  end
+
+  it "yields message" do
+    IO.pipe do |r, w|
+      logger = Logger.new(w)
+      logger.error { "message" }
+      logger.unknown { "another message" }
+
+      r.gets.should match(/ERROR -- : message\n/)
+      r.gets.should match(/  ANY -- : another message\n/)
+    end
+  end
+
+  it "yields message with progname" do
+    IO.pipe do |r, w|
+      logger = Logger.new(w)
+      logger.error("crystal") { "message" }
+      logger.unknown("shard") { "another message" }
+
+      r.gets.should match(/ERROR -- crystal: message\n/)
+      r.gets.should match(/  ANY -- shard: another message\n/)
     end
   end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -722,4 +722,14 @@ describe "String" do
     assert { "a    bbb".squeeze(' ').should eq("a bbb") }
     assert { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
   end
+
+  describe "ljust" do
+    assert { "123".ljust(5).should eq("123  ") }
+    assert { "12".ljust(7, '-').should eq("12-----") }
+  end
+
+  describe "rjust" do
+    assert { "123".rjust(5).should eq("  123") }
+    assert { "12".rjust(7, '-').should eq("-----12") }
+  end
 end

--- a/src/io.cr
+++ b/src/io.cr
@@ -145,6 +145,16 @@ module IO
     {FileDescriptorIO.new(pipe_fds[0]), FileDescriptorIO.new(pipe_fds[1])}
   end
 
+  def self.pipe
+    r, w = IO.pipe
+    begin
+      yield r, w
+    ensure
+      r.close
+      w.close
+    end
+  end
+
   def reopen(other)
     if LibC.dup2(self.fd, other.fd) == -1
       raise Errno.new("Could not reopen file descriptor")

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -36,10 +36,18 @@ class Logger
     def {{name.id.downcase}}(message, progname = nil)
       log({{name.id}}, message, progname)
     end
+
+    def {{name.id.downcase}}(progname = nil)
+      log({{name.id}}, nil, progname) { yield }
+    end
   end
 
   def unknown(message, progname = nil)
     log(UNKNOWN, message, progname)
+  end
+
+  def unknown(progname = nil)
+    log(UNKNOWN, nil, progname) { yield }
   end
 
   log_level FATAL
@@ -50,6 +58,15 @@ class Logger
 
   def log(severity, message, progname = nil)
     return if severity < level
-    @io << formatter.call(SEV_LABEL[severity], Time.now, progname || @progname || "", message) + "\n"
+    @io << format(severity, Time.now, progname || @progname, message)
+  end
+
+  def log(severity, message = nil, progname = nil)
+    return if severity < level
+    @io << format(severity, Time.now, progname || @progname, yield)
+  end
+
+  def format(severity, datetime, progname, message)
+    @io << formatter.call(SEV_LABEL[severity], Time.now, progname.to_s, message) + "\n"
   end
 end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -67,6 +67,6 @@ class Logger
   end
 
   def format(severity, datetime, progname, message)
-    @io << formatter.call(SEV_LABEL[severity], Time.now, progname.to_s, message) + "\n"
+    formatter.call(SEV_LABEL[severity], Time.now, progname.to_s, message) + "\n"
   end
 end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -1,21 +1,23 @@
-class Logger
+class Logger(T)
   property :level, :progname, :formatter
 
-  UNKNOWN = 5
-  FATAL = 4
-  ERROR = 3
-  WARN = 2
-  INFO = 1
-  DEBUG = 0
+  enum Severity : Int32
+    UNKNOWN = 5
+    FATAL = 4
+    ERROR = 3
+    WARN = 2
+    INFO = 1
+    DEBUG = 0
+  end
 
-  SEV_LABEL = %w(DEBUG INFO WARN ERROR FATAL ANY)
+  alias Formatter = String, Time, String, String ->
 
-  DEFAULT_FORMATTER = ->(severity : String, datetime : Time, progname : String, message : String) {
+  DEFAULT_FORMATTER = Formatter.new do |severity, datetime, progname, message|
     "#{severity[0]}, [#{datetime} ##{Process.pid}] #{severity.rjust(5)} -- #{progname}: #{message}"
-  }
+  end
 
-  def initialize(@io : IO)
-    @level = INFO
+  def initialize(@io : T)
+    @level = Severity::INFO
     @formatter = DEFAULT_FORMATTER
     @progname = ""
   end
@@ -29,27 +31,22 @@ class Logger
   end
 
   macro log_level(name)
+    {{name.id}} = Severity::{{name.id}}
+
     def {{name.id.downcase}}?
-      level <= {{name.id}}
+      level <= Severity::{{name.id}}
     end
 
     def {{name.id.downcase}}(message, progname = nil)
-      log({{name.id}}, message, progname)
+      log(Severity::{{name.id}}, message, progname)
     end
 
     def {{name.id.downcase}}(progname = nil)
-      log({{name.id}}, nil, progname) { yield }
+      log(Severity::{{name.id}}, progname) { yield }
     end
   end
 
-  def unknown(message, progname = nil)
-    log(UNKNOWN, message, progname)
-  end
-
-  def unknown(progname = nil)
-    log(UNKNOWN, nil, progname) { yield }
-  end
-
+  log_level UNKNOWN
   log_level FATAL
   log_level ERROR
   log_level WARN
@@ -58,15 +55,16 @@ class Logger
 
   def log(severity, message, progname = nil)
     return if severity < level
-    @io << format(severity, Time.now, progname || @progname, message)
+    @io.puts format(severity, Time.now, progname || @progname, message)
   end
 
-  def log(severity, message = nil, progname = nil)
+  def log(severity, progname = nil)
     return if severity < level
-    @io << format(severity, Time.now, progname || @progname, yield)
+    @io.puts format(severity, Time.now, progname || @progname, yield)
   end
 
   def format(severity, datetime, progname, message)
-    formatter.call(SEV_LABEL[severity], Time.now, progname.to_s, message) + "\n"
+    label = severity == Severity::UNKNOWN ? "ANY" : severity.to_s
+    formatter.call(label, Time.now, progname.to_s, message)
   end
 end

--- a/src/logger.cr
+++ b/src/logger.cr
@@ -1,0 +1,55 @@
+class Logger
+  property :level, :progname, :formatter
+
+  UNKNOWN = 5
+  FATAL = 4
+  ERROR = 3
+  WARN = 2
+  INFO = 1
+  DEBUG = 0
+
+  SEV_LABEL = %w(DEBUG INFO WARN ERROR FATAL ANY)
+
+  DEFAULT_FORMATTER = ->(severity : String, datetime : Time, progname : String, message : String) {
+    "#{severity[0]}, [#{datetime} ##{Process.pid}] #{severity.rjust(5)} -- #{progname}: #{message}"
+  }
+
+  def initialize(@io : IO)
+    @level = INFO
+    @formatter = DEFAULT_FORMATTER
+    @progname = ""
+  end
+
+  def <<(message)
+    @io << message
+  end
+
+  def close
+    @io.close
+  end
+
+  macro log_level(name)
+    def {{name.id.downcase}}?
+      level <= {{name.id}}
+    end
+
+    def {{name.id.downcase}}(message, progname = nil)
+      log({{name.id}}, message, progname)
+    end
+  end
+
+  def unknown(message, progname = nil)
+    log(UNKNOWN, message, progname)
+  end
+
+  log_level FATAL
+  log_level ERROR
+  log_level WARN
+  log_level INFO
+  log_level DEBUG
+
+  def log(severity, message, progname = nil)
+    return if severity < level
+    @io << formatter.call(SEV_LABEL[severity], Time.now, progname || @progname || "", message) + "\n"
+  end
+end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -141,6 +141,24 @@ module Spec
       "expected #{@target} not to be #{@op} #{@expected}"
     end
   end
+
+  class MatchExpectation(T)
+    def initialize(@value : T)
+    end
+
+    def match(value)
+      @target = value
+      @target =~ @value
+    end
+
+    def failure_message
+      "expected: #{@target.inspect}\nto match: #{@value.inspect}"
+    end
+
+    def negative_failure_message
+      "expected: value #{@target.inspect}\n to not match: #{@value.inspect}"
+    end
+  end
 end
 
 def eq(value)
@@ -177,6 +195,10 @@ end
 
 def be
   Spec::Be
+end
+
+def match(value)
+ Spec::MatchExpectation.new(value)
 end
 
 macro be_a(type)

--- a/src/string.cr
+++ b/src/string.cr
@@ -906,6 +906,21 @@ class String
     end
   end
 
+  def ljust(len, chr = ' ')
+    if length >= len
+      self
+    else
+      self + chr.to_s * (len - length)
+    end
+  end
+
+  def rjust(len, chr = ' ')
+    if length >= len
+      self
+    else
+      chr.to_s * (len - length) + self
+    end
+  end
 
   def match(regex : Regex)
     regex.match self


### PR DESCRIPTION
Mostly follows the great Ruby library:

```crystal
logger = Logger.new(STDOUT)
logger.progname = "crystal"
logger.info("mogwai are safe")          # I, [2015-02-07 10:45:37 #18969]  INFO -- crystal: mogwai is safe
logger.fatal { "gremlins in the box" }  # F, [2015-02-07 10:45:37 #18969] FATAL -- crystal: gremlins in the box
```

Also allows to customize the format. Either by overriding Logger#format or by setting a lambda as Logger#formatter.
 
Also comes with a few enhancements to the core/std libraries, like `String#rjust`, `IO.pipe(&block)`, and `match` expectations.