### PR TITLE
'string["substring"]' (like in Ruby) added

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -54,6 +54,11 @@ describe "String" do
       assert { "FooBar"[/o(?<this>o)/, "this"].should eq "o" }
       assert { "FooBar"[/(?<this>x)/, "that"]?.should be_nil }
     end
+
+    it "gets with a string" do
+      "FooBar"["Bar"].should eq "Bar"
+    end
+
   end
 
   describe "byte_slice" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -160,12 +160,8 @@ class String
     end
   end
 
-  def [](regex : Regex)
-    self[regex]?.not_nil!
-  end
-
-  def [](regex : Regex, group)
-    self[regex, group]?.not_nil!
+  def []?(str : String)
+    includes?(str) ? str : nil
   end
 
   def []?(regex : Regex)
@@ -175,6 +171,18 @@ class String
   def []?(regex : Regex, group)
     match = match(regex)
     match[group]? if match
+  end
+
+  def [](str : String)
+    self[str]?.not_nil!
+  end
+
+  def [](regex : Regex)
+    self[regex]?.not_nil!
+  end
+
+  def [](regex : Regex, group)
+    self[regex, group]?.not_nil!
   end
 
   def byte_slice(start : Int, count : Int)


### PR DESCRIPTION
A nice convenient way of checking the presence of a substring in a string.