### PR TITLE
Switch default relocation mode to PIC

### DIFF
--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -30,7 +30,7 @@ struct LLVM::Target
 
   def create_target_machine(triple, cpu = "", features = "",
       opt_level = LLVM::CodeGenOptLevel::Default,
-      reloc = LLVM::RelocMode::Default,
+      reloc = LLVM::RelocMode::PIC,
       code_model = LLVM::CodeModel::Default)
     target_machine = LibLLVM.create_target_machine(self, triple, cpu, features, opt_level, reloc, code_model)
     target_machine ? TargetMachine.new(target_machine) : nil


### PR DESCRIPTION
This allows linking the binary with -fPIC
and -fPIE, allowing the kernel to randomize
addresses when executing the binary. This
is a measure recommended by many hardening
guides, since it makes ROP chains more difficult.