### PR TITLE
@methods variable for def macros [WIP]

### DIFF
--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -640,6 +640,8 @@ module Crystal
           if scope.is_a?(EnumType)
             return @last = TypeNode.constants(scope)
           end
+        when "@methods"
+          return @last = TypeNode.methods(@scope)
         when "@constants"
           scope = @scope.try &.instance_type
           return @last = TypeNode.constants(scope)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -591,6 +591,14 @@ module Crystal
       ArrayLiteral.map(type.all_subclasses) { |subtype| TypeNode.new(subtype) }
     end
 
+    def self.methods(type)
+      if methods = type.try(&.defs)
+        ArrayLiteral.map(methods) { |name| StringLiteral.new(name) }
+      else
+        ArrayLiteral.new
+      end
+    end
+
     def self.constants(type)
       names = type.types.map { |name, member_type| MacroId.new(name) as ASTNode }
       ArrayLiteral.new names


### PR DESCRIPTION
I was disapointed to not be able to list instance methods in a class that started with `"test_"` and run them, so I started fidlling into Crystal's internals and the availability of `@class_name` in def macros, and quickly found out how to extract the list of methods in the current class.

The `@methods` contains either the defined class methods or the instance methods, depending when creating a class def macro or an instance def macro. This won't contain parent methods.

This allows to implement #403 for instance:

```crystal
class Class
  macro def self.methods : Array(Symbol)
    [{{ @methods.map { |m| ":#{m}" }.join(", ").id }}]
  end
end

class Reference
  macro def methods : Array(Symbol)
    [{{ @methods.map { |m| ":#{m}" }.join(", ").id }}]
  end
end
```

Thought ArrayLiteral is missing some methods like `.sort` and `.shuffle`.