### PR TITLE
Raise exception on all LibC.getaddrinfo errors

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -81,6 +81,18 @@ describe "TCPSocket" do
       end
     end
   end
+
+  it "fails when connection is refused" do
+    expect_raises(Errno, "Error connecting to 'localhost:12345': Connection refused") do
+      TCPSocket.new("localhost", 12345)
+    end
+  end
+
+  it "fails when host doesn't exist" do
+    expect_raises(SocketError, /^getaddrinfo: .+ not known$/) do
+      TCPSocket.new("localhostttttt", 12345)
+    end
+  end
 end
 
 describe "UDPSocket" do

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -36,7 +36,7 @@ class IPSocket < Socket
     hints.flags = 0
 
     ret = LibC.getaddrinfo(host, port.to_s, pointerof(hints), out addrinfo)
-    raise SocketError.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}") if ret == -1
+    raise SocketError.new("getaddrinfo: #{String.new(LibC.gai_strerror(ret))}") if ret != 0
 
     begin
       current_addrinfo = addrinfo


### PR DESCRIPTION
Opening a socket to a non existing host doesn't currently raise an error:

```
$ crystal eval 'require "socket"; p TCPSocket.new("localhosttttt", 4568)'
#<TCPSocket:fd 0>
```

Compared to Ruby (same code):

```
$ ruby -e 'require "socket"; p TCPSocket.new("localhosttttt", 4568)'
-e:1:in `initialize': getaddrinfo: nodename nor servname provided, or not known (SocketError)
	from -e:1:in `new'
	from -e:1:in `<main>'
```

Now, I have zero experience with C network programming, but according to [getaddrinfo(3)](http://man7.org/linux/man-pages/man3/getaddrinfo.3.html#RETURN_VALUE), not only -1 is an error, but everything nonzero. This PR does that, hopefully not breaking anything else :innocent:

It also adds a spec for the error raised when the connection is refused.

Thanks for the great work and keep up with it, I love Crystal!