### PR TITLE
Raise exception on XML parsing error

### DIFF
--- a/spec/std/xml/document_spec.cr
+++ b/spec/std/xml/document_spec.cr
@@ -68,4 +68,10 @@ describe XML::Document do
     doc = XML.parse(string)
     doc.to_s.should eq(string)
   end
+
+  it "handles errors" do
+    expect_raises(XML::Error) do
+      XML.parse(%(</people>))
+    end
+  end
 end

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -37,4 +37,6 @@ lib LibXML
   fun xmlTextReaderAttributeCount(reader : XMLTextReader) : Int32
   fun xmlTextReaderMoveToFirstAttribute(reader : XMLTextReader) : Int32
   fun xmlTextReaderMoveToNextAttribute(reader : XMLTextReader) : Int32
+
+  fun xmlTextReaderSetErrorHandler(reader : XMLTextReader, f : Void* -> Void*) : Void
 end

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -4,6 +4,8 @@ class XML::Reader
   def initialize(str : String)
     input = LibXML.xmlParserInputBufferCreateStatic(str, str.bytesize, 1)
     @reader = LibXML.xmlNewTextReader(input, "")
+    error_handler = ->(args : Void*) { raise Error.new("XML error") }
+    LibXML.xmlTextReaderSetErrorHandler(@reader, error_handler)
   end
 
   def initialize(io : IO)

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -1,1 +1,6 @@
+module XML
+  class Error < Exception
+  end
+end
+
 require "./*"


### PR DESCRIPTION
I'm far from sure that I fixed this the right way. If it's not the case, please ignore the patch and consider this just a reported issue :wink: 

## The issue

Currently, a XML parsing error doesn't raise any exception. libxml2 prints something (to stderr I guess) but processing continues.

```
$ crystal eval 'require "xml"; doc = XML::Document.parse("</bad>"); pp doc'
:1: parser error : StartTag: invalid element name
</bad>
 ^
doc = #<XML::Document:0x1069DFFC0 @parent_node=nil, @name=nil, @child_nodes=nil, @attributes=nil, @value=nil>
```

Note that after printing the error the parsing continued, and the `XML::Document` was returned.

Depending on what you're doing and the kind of problem the XML has, the problem will show in a way or another, later. For example, if I try to print the XML of that document back, an exception is raised then:

```
$ crystal eval 'require "xml"; doc = XML::Document.parse("</bad>"); puts doc.to_s'
:1: parser error : StartTag: invalid element name
</bad>
 ^
Index out of bounds
*Exception@Exception#initialize<IndexOutOfBounds, String>:Array(String) +46 [4550050382]
*IndexOutOfBounds#initialize<IndexOutOfBounds, String>:Array(String) +6 [4550050326]
*IndexOutOfBounds::new<String>:IndexOutOfBounds +111 [4550050287]
*IndexOutOfBounds::new:IndexOutOfBounds +16 [4550050160]
*Array(XML::Node+)@Array(T)#first<Array(XML::Node+)>:XML::Node+ +19 [4550054675]
*XML::Document#to_s<XML::Document, StringIO>:StringIO? +55 [4550051703]
*XML::Document@Object#to_s<XML::Document>:String +56 [4550051624]
__crystal_main +131 [4550039955]
main +32 [4550041792]
Program terminated abnormally with error code: 256
```

## The patch

With the patch, no error is directly printed and an exception is raised:

```
$ .build/crystal eval 'require "xml"; doc = XML::Document.parse("</bad>"); pp doc'
XML error (XML::Error)
*XML::Error@Exception#initialize<XML::Error, String, Nil>:Array(String) +21 [4415000213]
*XML::Error::new<String>:XML::Error +125 [4415000173]
~fun_literal_6 +20 [4414978532]
xmlTextReaderError +204 [140735602623989]
__xmlRaiseError +1602 [140735602218083]
xmlFatalErrMsg +162 [140735602309546]
xmlParseStartTag2 +4036 [140735602358640]
xmlParseTryOrFinish +4559 [140735602370794]
xmlParseChunk +866 [140735602365727]
xmlTextReaderPushData +334 [140735602609332]
xmlTextReaderRead +552 [140735602606960]
*XML::Reader#read<XML::Reader>:Bool +10 [4414999818]
*XML::Document::parse<XML::Reader>:XML::Document +39 [4414995127]
*XML::Document::parse<String>:XML::Document +14 [4414995086]
__crystal_main +1395 [4414975987]
main +32 [4414977904]
Program terminated abnormally with error code: 256
```

I did that by adding an error handler that does nothing but raising the exception. In theory and according to the libxml2 documentation, more information about the error could be fetched and a more useful exception could be raised, but that exceeds a lot my abilities as C programmer :confounded:. In fact, I'm almost sure that what I did with the type of the error handler is wrong, and I was very surprised that it worked :innocent:. Feel free to reimplement it in a better way.