### PR TITLE
Adds OptionParser#separator

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -152,6 +152,29 @@ describe "OptionParser" do
     ].join "\n")
   end
 
+  it "does to_s with separators" do
+    parser = OptionParser.parse([] of String) do |opts|
+      opts.banner = "Usage: foo"
+      opts.separator
+      opts.separator "Type F flags:"
+      opts.on("-f", "--flag", "some flag") do
+      end
+      opts.separator
+      opts.separator "Type G flags:"
+      opts.on("-g[FLAG]", "some other flag") do
+      end
+    end
+    parser.to_s.should eq([
+      "Usage: foo",
+      "",
+      "Type F flags:",
+      "    -f, --flag                       some flag"
+      "",
+      "Type G flags:",
+      "    -g[FLAG]                         some other flag"
+    ].join "\n")
+  end
+
   it "raises on invalid option" do
     expect_raises OptionParser::InvalidOption, "Invalid option: -j" do
       OptionParser.parse(["-f", "-j"]) do |opts|

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -68,6 +68,10 @@ class OptionParser
     @handlers << Handler.new(long_flag, block)
   end
 
+  def separator(message = "")
+    @flags << message.to_s
+  end
+
   def unknown_args(&@unknown_args : Array(String), Array(String) -> )
   end
 


### PR DESCRIPTION
Adds a `separator` instance method in `OptionParser` pretty much like [Ruby's](http://www.rubydoc.info/stdlib/optparse/OptionParser:separator). It helps on formatting and organizing long lists of options and flags. This code:

      opts.banner = "Usage: foo"
      opts.separator
      opts.separator "Type F flags:"
      opts.on("-f", "--flag", "some flag") {}
      opts.separator
      opts.separator "Type G flags:"
      opts.on("-g[FLAG]", "some other flag") {}

Will generate this help message:

```
Usage: foo

Type F flags:
    -f, --flag                       some flag

Type G flags:
    -g[FLAG]                         some other flag
```

An alternative to the default empty argument would be to automatically include the empty line on every separator, but I think this gives more flexibility. What do you think?