### PR TITLE
Pointer#new allocating memory for one object

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -312,6 +312,19 @@ struct Pointer(T)
     new 0_u64
   end
 
+  # Allocates `sizeof(T)` bytes from the system's heap initialized
+  # to zero and returns a pointer to the first byte from that memory.
+  # The memory is allocated by the `GC`, so when there are
+  # no pointers to this memory, it will be automatically freed.
+  #
+  # ```
+  # # Allocating memory for an Int32
+  # ptr = Pointer(Int32).new
+  # ```
+  def self.new
+    malloc(1_u64)
+  end
+
   # Returns a pointer that points to the given memory address. This doesn't allocate memory.
   #
   # ```


### PR DESCRIPTION
I think it would be nice to have a method to allocating memory for only one object.

I know malloc_one exists, but compare these:
```
# first
p_struct = Pointer(CustomStruct).malloc(1)
# second
p_struct = Pointer.malloc_one(CustomStruct.new)
# third
p_struct = Pointer(CustomStruct).new
```

The third one is the most talkative in my opinion, because we tell that we need a new pointer of type CustomStruct.

It's really just a readability change

