### PR TITLE
Added 'ssl' and 'branch' options to GitHub dependencies.

### DIFF
--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -10,8 +10,8 @@ struct Crystal::Project::DSL
     def initialize(@project)
     end
 
-    def github(repository, name = nil : String, ssl = nil : Bool, branch = nil : String)
-      @project.dependencies << GitHubDependency.new(repository, name, ssl, branch)
+    def github(repository, name = nil : String, ssh = nil : Bool, branch = nil : String)
+      @project.dependencies << GitHubDependency.new(repository, name, ssh, branch)
     end
 
     def path(path, name = nil : String)

--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -10,8 +10,8 @@ struct Crystal::Project::DSL
     def initialize(@project)
     end
 
-    def github(repository, name = nil : String)
-      @project.dependencies << GitHubDependency.new(repository, name)
+    def github(repository, name = nil : String, ssl = nil : Bool, branch = nil : String)
+      @project.dependencies << GitHubDependency.new(repository, name, ssl, branch)
     end
 
     def path(path, name = nil : String)

--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -10,7 +10,7 @@ struct Crystal::Project::DSL
     def initialize(@project)
     end
 
-    def github(repository, name = nil : String, ssh = nil : Bool, branch = nil : String)
+    def github(repository, name = nil : String, ssh = false, branch = nil : String)
       @project.dependencies << GitHubDependency.new(repository, name, ssh, branch)
     end
 

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -5,7 +5,7 @@ module Crystal
   class GitHubDependency < Dependency
     getter target_dir
 
-    def initialize(repo, name = nil : String?, ssl = nil : Bool?, branch = nil : String?)
+    def initialize(repo, name = nil : String?, ssh = nil : Bool?, branch = nil : String?)
       unless repo =~ /(.*)\/(.*)/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end
@@ -14,14 +14,14 @@ module Crystal
       @repository = $2
       @target_dir = ".deps/#{@author}-#{@repository}"
       @branch = " -b #{branch}" if branch
-      @use_ssl = ssl
+      @use_ssh = ssh
 
       super(name || @repository)
     end
 
     def install
       unless Dir.exists?(target_dir)
-        repo_url = if @use_ssl
+        repo_url = if @use_ssh
           "git@github.com:#{@author}/#{@repository}.git"
         else
           "git://github.com/#{@author}/#{@repository}.git"

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -5,7 +5,7 @@ module Crystal
   class GitHubDependency < Dependency
     getter target_dir
 
-    def initialize(repo, name = nil : String?, ssh = nil : Bool?, branch = nil : String?)
+    def initialize(repo, name = nil : String?, ssh = false, branch = nil : String?)
       unless repo =~ /(.*)\/(.*)/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -5,7 +5,7 @@ module Crystal
   class GitHubDependency < Dependency
     getter target_dir
 
-    def initialize(repo, name = nil : String?)
+    def initialize(repo, name = nil : String?, ssl = nil : Bool?, branch = nil : String?)
       unless repo =~ /(.*)\/(.*)/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end
@@ -13,13 +13,21 @@ module Crystal
       @author = $1
       @repository = $2
       @target_dir = ".deps/#{@author}-#{@repository}"
+      @branch = " -b #{branch}" if branch
+      @use_ssl = ssl
 
       super(name || @repository)
     end
 
     def install
       unless Dir.exists?(target_dir)
-        exec "git clone git://github.com/#{@author}/#{@repository}.git #{target_dir}"
+        repo_url = if @use_ssl
+          "git@github.com:#{@author}/#{@repository}.git"
+        else
+          "git://github.com/#{@author}/#{@repository}.git"
+        end
+
+        exec "git clone#{@branch} #{repo_url} #{target_dir}"
       end
       exec "ln -sf ../#{target_dir}/src libs/#{name}"
 


### PR DESCRIPTION
Usage:
	github "user/repo", ssl: true
	github "user/repo", branch: "branch_name"

Enabling ssl will use 'git@github.com:user/repo.git' as branch repository, allowing for the use of private repositories as dependencies.