### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /.tags
 /.tags_sorted_by_file
 /.vagrant


### PR DESCRIPTION
.DS_Store is a common file created to store folder attributes in Finder (default file browser on OS X).