### PR TITLE
Added Git dependency.

### DIFF
--- a/spec/std/crystal/git_dependency_spec.cr
+++ b/spec/std/crystal/git_dependency_spec.cr
@@ -5,13 +5,13 @@ module Crystal
   describe "GitDependency" do
     describe "#initialize" do
       it "uses the repository's name as the dependency name" do
-        dependency = GitDependency.new("https://example.com/owner/repo")
+        dependency = GitDependency.new("https://example.com/owner/repo.git")
 
         dependency.name.should eq("repo")
       end
 
       it "customizes Git dependency name" do
-        dependency = GitDependency.new("https://example.com/owner/repo", "name")
+        dependency = GitDependency.new("https://example.com/owner/repo.git", "name")
 
         dependency.name.should eq("name")
       end
@@ -24,20 +24,20 @@ module Crystal
 
       %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
         it "guesses name from project name like #{repo_name}" do
-          dependency = GitDependency.new("https://example.com/owner/#{repo_name}")
+          dependency = GitDependency.new("https://example.com/owner/#{repo_name}.git")
 
           dependency.name.should eq("repo")
         end
 
         it "doesn't guess name from project name when specifying name" do
-          dependency = GitDependency.new("https://example.com/owner/#{repo_name}", "name")
+          dependency = GitDependency.new("https://example.com/owner/#{repo_name}.git", "name")
 
           dependency.name.should eq("name")
         end
       end
 
       it "gets the target_dir" do
-        dependency = GitDependency.new("https://example.com/owner/repo")
+        dependency = GitDependency.new("https://example.com/owner/repo.git")
         dependency.target_dir.should eq(".deps/owner-repo")
       end
     end

--- a/spec/std/crystal/git_dependency_spec.cr
+++ b/spec/std/crystal/git_dependency_spec.cr
@@ -1,0 +1,45 @@
+require "spec"
+require "crystal/project/git_dependency"
+
+module Crystal
+  describe "GitDependency" do
+    describe "#initialize" do
+      it "uses the repository's name as the dependency name" do
+        dependency = GitDependency.new("https://example.com/owner/repo")
+
+        dependency.name.should eq("repo")
+      end
+
+      it "customizes Git dependency name" do
+        dependency = GitDependency.new("https://example.com/owner/repo", "name")
+
+        dependency.name.should eq("name")
+      end
+
+      it "raises error with invalid Git project definition" do
+        expect_raises ProjectError, /Invalid Git repository definition: invalid-repo/ do
+          GitDependency.new("invalid-repo")
+        end
+      end
+
+      %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
+        it "guesses name from project name like #{repo_name}" do
+          dependency = GitDependency.new("https://example.com/owner/#{repo_name}")
+
+          dependency.name.should eq("repo")
+        end
+
+        it "doesn't guess name from project name when specifying name" do
+          dependency = GitDependency.new("https://example.com/owner/#{repo_name}", "name")
+
+          dependency.name.should eq("name")
+        end
+      end
+
+      it "gets the target_dir" do
+        dependency = GitDependency.new("https://example.com/owner/repo")
+        dependency.target_dir.should eq(".deps/owner-repo")
+      end
+    end
+  end
+end

--- a/spec/std/crystal/project_spec.cr
+++ b/spec/std/crystal/project_spec.cr
@@ -15,6 +15,17 @@ module Crystal
         project.dependencies[0].should be_a(GitHubDependency)
       end
 
+      it "adds Git dependency" do
+        project = Project.new
+        project.eval do
+          deps do
+            git "https://example.com/owner/repo"
+          end
+        end
+        project.dependencies.length.should eq(1)
+        project.dependencies[0].should be_a(GitDependency)
+      end
+
       it "adds local dependencies" do
         project = Project.new
         project.eval do

--- a/spec/std/crystal/project_spec.cr
+++ b/spec/std/crystal/project_spec.cr
@@ -19,7 +19,7 @@ module Crystal
         project = Project.new
         project.eval do
           deps do
-            git "https://example.com/owner/repo"
+            git "https://example.com/owner/repo.git"
           end
         end
         project.dependencies.length.should eq(1)

--- a/src/crystal/project/dsl.cr
+++ b/src/crystal/project/dsl.cr
@@ -14,6 +14,10 @@ struct Crystal::Project::DSL
       @project.dependencies << GitHubDependency.new(repository, name, ssh, branch)
     end
 
+    def git(repository, name = nil : String, branch = nil : String)
+      @project.dependencies << GitDependency.new(repository, name, branch)
+    end
+
     def path(path, name = nil : String)
       @project.dependencies << PathDependency.new(path, name)
     end

--- a/src/crystal/project/git_dependency.cr
+++ b/src/crystal/project/git_dependency.cr
@@ -1,0 +1,60 @@
+require "crystal/project/dependency"
+require "crystal/project/project_error"
+
+module Crystal
+  class GitDependency < Dependency
+    getter target_dir
+
+    def initialize(@repo, name = nil : String?, branch = nil : String?)
+      unless repo =~ /(.*)(:|\/)(.*)\/(.*)(.git)/
+        raise ProjectError.new("Invalid Git repository definition: #{repo}")
+      end
+
+      @author = $3
+      @repository = $4
+      @target_dir = ".deps/#{@author}-#{@repository}"
+      @branch = if branch
+        "-b #{branch}"
+      else
+        ""
+      end
+
+      super(name || @repository)
+    end
+
+    def install
+      unless Dir.exists?(target_dir)
+        exec "git clone #{@branch} #{@repo} #{@target_dir}"
+      end
+
+      exec "ln -sf ../#{target_dir}/src libs/#{name}"
+
+      if @locked_version
+        if current_version != @locked_version
+          exec "git -C #{target_dir} checkout -q #{@locked_version}"
+        end
+      else
+        @locked_version = current_version
+      end
+    end
+
+    def update
+      exec "rm -rf #{target_dir}"
+      @locked_version = nil
+      install
+    end
+
+    def current_version
+      exec("git -C #{target_dir} rev-parse HEAD").chomp
+    end
+
+    protected def exec(cmd)
+      result = `#{cmd}`
+      unless $?.success?
+        puts "Error executing command: #{cmd}"
+        exit 1
+      end
+      result
+    end
+  end
+end

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -1,8 +1,9 @@
 require "crystal/project/dependency"
 require "crystal/project/project_error"
+require "crystal/project/git_dependency"
 
 module Crystal
-  class GitHubDependency < Dependency
+  class GitHubDependency < GitDependency
     getter target_dir
 
     def initialize(repo, name = nil : String?, ssh = false, branch = nil : String?)
@@ -10,53 +11,15 @@ module Crystal
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end
 
-      @author = $1
-      @repository = $2
-      @target_dir = ".deps/#{@author}-#{@repository}"
-      @branch = " -b #{branch}" if branch
-      @use_ssh = ssh
+      repository = $2
 
-      super(name || @repository)
-    end
-
-    def install
-      unless Dir.exists?(target_dir)
-        repo_url = if @use_ssh
-          "git@github.com:#{@author}/#{@repository}.git"
-        else
-          "git://github.com/#{@author}/#{@repository}.git"
-        end
-
-        exec "git clone#{@branch} #{repo_url} #{target_dir}"
-      end
-      exec "ln -sf ../#{target_dir}/src libs/#{name}"
-
-      if @locked_version
-        if current_version != @locked_version
-          exec "git -C #{target_dir} checkout -q #{@locked_version}"
-        end
+      repo_url = if ssh
+        "git@github.com:#{repo}.git"
       else
-        @locked_version = current_version
+        "git://github.com/#{repo}.git"
       end
-    end
 
-    def update
-      exec "rm -rf #{target_dir}"
-      @locked_version = nil
-      install
-    end
-
-    def current_version
-      exec("git -C #{target_dir} rev-parse HEAD").chomp
-    end
-
-    private def exec(cmd)
-      result = `#{cmd}`
-      unless $?.success?
-        puts "Error executing command: #{cmd}"
-        exit 1
-      end
-      result
+      super(repo_url, name || repository, branch)
     end
   end
 end


### PR DESCRIPTION
Additionally did some refactoring on GitHub dependency, which now extends GitDependency and retains all former functionality (including the recently-accepted ssh support).

Git dependencies are based on a standard git clone URL (e.g. https://example.com/user/repo.git or git@github.com:User/Repo.git) and requires the .git extension.