### PR TITLE
[spec/expectations] add contain

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -46,6 +46,18 @@ describe "Spec matchers" do
       "hello world!".should contain("hello")
     end
 
+    it "works with array" do
+      [1, 2, 3, 5, 8].should contain(5)
+    end
+
+    it "works with set" do
+      [1, 2, 3, 5, 8].to_set.should contain(8)
+    end
+
+    it "works with range" do
+      (50 .. 55).should contain(53)
+    end
+
     it "does not pass when string does not includes? specified substring" do
       expect_raises Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"} do
         "hello world!".should contain("crystal")

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -41,6 +41,30 @@ describe "Spec matchers" do
     end
   end
 
+  describe "should contain" do
+    it "passes when string includes? specified substring" do
+      "hello world!".should contain("hello")
+    end
+
+    it "does not pass when string does not includes? specified substring" do
+      expect_raises Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"} do
+        "hello world!".should contain("crystal")
+      end
+    end
+  end
+
+  describe "should_not contain" do
+    it "passes when string does not includes? specified substring" do
+      "hello world!".should_not contain("crystal")
+    end
+
+    it "does not pass when string does not includes? specified substring" do
+      expect_raises Spec::AssertionFailed, %{expected: value "hello world!"\nto not include: "world"} do
+        "hello world!".should_not contain("world")
+      end
+    end
+  end
+
   context "should work as describe" do
     it "is true" do
       true.should be_truthy

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -160,22 +160,34 @@ module Spec
     end
   end
 
+  # @private
+  # Provides the implementation for `contain`. Uses `#includes?` to
+  # determine if it matches. Not intended to be instantiated directly.
   class ContainExpectation(T)
-    def initialize(@value : T)
-      @target = ""
+    # Creates ContainExpectation(T) instance
+    # @param expected - item that is expected to be contained in actual
+    def initialize(@expected : T)
+      @actual = NullActual.new
     end
 
-    def match(value)
-      @target = value
-      @target.includes?(@value)
+    # Checks if expected item is contained in provided actual value.
+    # @param actual - value where item is expected to be contained
+    def match(@actual)
+      @actual.includes?(@expected)
     end
 
     def failure_message
-      "expected:   #{@target.inspect}\nto include: #{@value.inspect}"
+      "expected:   #{@actual.inspect}\nto include: #{@expected.inspect}"
     end
 
     def negative_failure_message
-      "expected: value #{@target.inspect}\nto not include: #{@value.inspect}"
+      "expected: value #{@actual.inspect}\nto not include: #{@expected.inspect}"
+    end
+
+    class NullActual
+      def includes?(value)
+        fail "actual can't be empty"
+      end
     end
   end
 end
@@ -220,8 +232,10 @@ def match(value)
  Spec::MatchExpectation.new(value)
 end
 
-def contain(value)
-  Spec::ContainExpectation.new(value)
+# Passes if actual includes expected. Works on collections and String.
+# @param expected - item expected to be contained in actual
+def contain(expected)
+  Spec::ContainExpectation.new(expected)
 end
 
 macro be_a(type)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -159,6 +159,25 @@ module Spec
       "expected: value #{@target.inspect}\n to not match: #{@value.inspect}"
     end
   end
+
+  class ContainExpectation(T)
+    def initialize(@value : T)
+      @target = ""
+    end
+
+    def match(value)
+      @target = value
+      @target.includes?(@value)
+    end
+
+    def failure_message
+      "expected:   #{@target.inspect}\nto include: #{@value.inspect}"
+    end
+
+    def negative_failure_message
+      "expected: value #{@target.inspect}\nto not include: #{@value.inspect}"
+    end
+  end
 end
 
 def eq(value)
@@ -199,6 +218,10 @@ end
 
 def match(value)
  Spec::MatchExpectation.new(value)
+end
+
+def contain(value)
+  Spec::ContainExpectation.new(value)
 end
 
 macro be_a(type)


### PR DESCRIPTION
Adds `be_including` expectation for strings:

```crystal
"hello world!".should be_including("world")    # passes
```
