### PR TITLE
Add docs heading to Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -10,6 +10,8 @@ These are the most important things in need right now:
 * Documenting the standard library
 * Adding missing bits of the standard library, and/or improving its performance
 
+## Contributing to the documentation
+
 The main site and official language documentation is on the `gh-pages` branch. Just check it out
 and do `rake build && jekyll serve` to browse it. We use [GitBook](https://www.gitbook.com/) for the documentation,
 check the `_gitbook` directory.


### PR DESCRIPTION
This is a logically separate section and having a heading makes it easier to spot and reference.