### PR TITLE
[crystal] add init command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .*.swp
 /Makefile.local
 all_spec
+/tmp

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -18,8 +18,8 @@ end
 
 module Crystal
   describe Init::InitProject do
-    `rm -r tmp/example`
-    `rm -r tmp/example_app`
+    `[[ -d tmp/example ]] && rm -r tmp/example`
+    `[[ -d tmp/example_app ]] && rm -r tmp/example_app`
 
     run_init_project("lib", "example", "tmp/example", "John Smith")
     run_init_project("app", "example_app", "tmp/example_app", "John Smith")

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -1,0 +1,116 @@
+require "spec"
+require "yaml"
+require "compiler/crystal/tools/init"
+
+def describe_file(name)
+  describe name do
+    it "has proper contents" do
+      yield(File.read("tmp/#{name}"))
+    end
+  end
+end
+
+def run_init_project(skeleton_type, name, dir, author)
+  Crystal::Init::InitProject.new(
+    Crystal::Init::Config.new(skeleton_type, name, dir, author)
+  ).run
+end
+
+module Crystal
+  describe Init::InitProject do
+    `rm -r tmp/example`
+    `rm -r tmp/example_app`
+
+    run_init_project("lib", "example", "tmp/example", "John Smith")
+    run_init_project("app", "example_app", "tmp/example_app", "John Smith")
+
+    describe_file "example/.gitignore" do |gitignore|
+      gitignore.should contain("/.deps/")
+      gitignore.should contain("/.deps.lock")
+      gitignore.should contain("/libs/")
+      gitignore.should contain("/.crystal/")
+    end
+
+    describe_file "example_app/.gitignore" do |gitignore|
+      gitignore.should contain("/.deps/")
+      gitignore.should_not contain("/.deps.lock")
+      gitignore.should contain("/libs/")
+      gitignore.should contain("/.crystal/")
+    end
+
+    describe_file "example/LICENSE" do |license|
+      license.should match %r{Copyright \(c\) \d+ John Smith}
+    end
+
+    describe_file "example/README.md" do |readme|
+      readme.should contain("# example")
+
+      readme.should contain(%{```crystal
+deps do
+  github "[your-github-name]/example"
+end
+```})
+
+      readme.should contain(%{require "example"})
+      readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example/fork )})
+      readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
+    end
+
+    describe_file "example/Projectfile" do |projectfile|
+      projectfile.should eq(%{deps do\nend\n})
+    end
+
+    describe_file "example/.travis.yml" do |travis|
+      parsed = YAML.load(travis) as Hash
+
+      parsed["language"].should eq("c")
+
+      (parsed["before_install"] as String)
+        .should contain("curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash")
+
+      (parsed["before_install"] as String)
+        .should contain("sudo apt-get -q update")
+
+      (parsed["install"] as String)
+        .should contain("sudo apt-get install crystal")
+
+      parsed["script"].should eq(["crystal spec"])
+    end
+
+    describe_file "example/src/example.cr" do |example|
+      example.should eq(%{require "./example/*"
+
+module Example
+  # TODO Put your code here
+end
+})
+    end
+
+    describe_file "example/src/example/version.cr" do |version|
+      version.should eq(%{module Example
+  VERSION = "0.0.1"
+end
+})
+    end
+
+    describe_file "example/spec/spec_helper.cr" do |example|
+      example.should eq(%{require "spec"
+require "../src/example"
+})
+    end
+
+    describe_file "example/spec/example_spec.cr" do |example|
+      example.should eq(%{require "./spec_helper"
+
+describe Example do
+  # TODO: Write tests
+
+  it "works" do
+    false.should eq(true)
+  end
+end
+})
+    end
+
+  end
+end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -18,8 +18,8 @@ end
 
 module Crystal
   describe Init::InitProject do
-    `[[ -d tmp/example ]] && rm -r tmp/example`
-    `[[ -d tmp/example_app ]] && rm -r tmp/example_app`
+    `[ -d tmp/example ] && rm -r tmp/example`
+    `[ -d tmp/example_app ] && rm -r tmp/example_app`
 
     run_init_project("lib", "example", "tmp/example", "John Smith")
     run_init_project("app", "example_app", "tmp/example_app", "John Smith")
@@ -111,6 +111,8 @@ describe Example do
 end
 })
     end
+
+    describe_file "example/.git/config" {}
 
   end
 end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -12,7 +12,7 @@ end
 
 def run_init_project(skeleton_type, name, dir, author)
   Crystal::Init::InitProject.new(
-    Crystal::Init::Config.new(skeleton_type, name, dir, author)
+    Crystal::Init::Config.new(skeleton_type, name, dir, author, true)
   ).run
 end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -1,8 +1,11 @@
+require "compiler/crystal/tools/init"
+
 module Crystal::Command
   USAGE = <<-USAGE
 Usage: crystal [command] [switches] [program file] [--] [arguments]
 
 Command:
+    init                     generate new crystal project
     build                    compile program file
     browser                  open an http server to browse program file
     deps                     install project dependencies
@@ -28,6 +31,9 @@ USAGE
         run_command options
       else
         case
+        when "init".starts_with?(command)
+          options.shift
+          init options
         when "build".starts_with?(command)
           options.shift
           build options
@@ -80,6 +86,10 @@ USAGE
     end
     puts
     error "you've found a bug in the Crystal compiler. Please open an issue: https://github.com/manastech/crystal/issues"
+  end
+
+  private def self.init(options)
+    Init.run(options)
   end
 
   private def self.build(options)

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -80,37 +80,6 @@ DIR  - directory where project will be generated,
       end
     end
 
-    class InitProject
-      getter config
-
-      def initialize(@config)
-      end
-
-      def run
-        views.each do |view|
-          view.new(config).render
-        end
-      end
-
-      def views
-        [
-         GitignoreView,
-         LicenseView,
-         ReadmeView,
-         TravisView,
-         ProjectileView,
-
-         SrcExampleView,
-         SrcVersionView,
-
-         SpecHelperView,
-         SpecExampleView,
-
-         GitInitView,
-        ]
-      end
-    end
-
     abstract class View
       getter config
 
@@ -132,6 +101,33 @@ DIR  - directory where project will be generated,
       end
 
       abstract def full_path
+    end
+
+    class InitProject
+      getter config
+
+      @@views = [] of View.class
+
+      def initialize(@config)
+      end
+
+      def run
+        views.each do |view|
+          view.new(config).render
+        end
+      end
+
+      def views
+        self.class.views
+      end
+
+      def self.views
+        @@views
+      end
+
+      def self.register_view(view)
+        views << view
+      end
     end
 
     class GitInitView < View
@@ -164,6 +160,8 @@ DIR  - directory where project will be generated,
           "#{config.dir}/#{{{full_path}}}"
         end
       end
+
+      InitProject.register_view({{name.id}})
     end
 
     template GitignoreView, "gitignore.ecr", ".gitignore"
@@ -177,5 +175,7 @@ DIR  - directory where project will be generated,
 
     template SpecHelperView, "spec_helper.cr.ecr", "spec/spec_helper.cr"
     template SpecExampleView, "example_spec.cr.ecr", "spec/#{config.name}_spec.cr"
+
+    InitProject.register_view(GitInitView)
   end
 end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -43,7 +43,7 @@ DIR  - directory where project will be generated,
 
     def self.fetch_skeleton_type(opts, args)
       skeleton_type = fetch_required_parameter(opts, args, "TYPE")
-      unless ["lib", "app"].includes?(skeleton_type)
+      unless {"lib", "app"}.includes?(skeleton_type)
         puts "invalid TYPE value: #{skeleton_type}"
         puts opts
         exit 1

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -120,7 +120,11 @@ DIR  - directory where project will be generated,
       def render
         Dir.mkdir_p(File.dirname(full_path))
         File.write(full_path, to_s)
-        puts "      create  #{full_path}" unless config.silent
+        puts log_message unless config.silent
+      end
+
+      def log_message
+        "      #{"create".colorize(:light_green)}  #{full_path}" 
       end
 
       def module_name

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -83,6 +83,16 @@ DIR  - directory where project will be generated,
     abstract class View
       getter config
 
+      @@views = [] of View.class
+
+      def self.views
+        @@views
+      end
+
+      def self.register(view)
+        views << view
+      end
+
       def initialize(@config)
       end
 
@@ -106,8 +116,6 @@ DIR  - directory where project will be generated,
     class InitProject
       getter config
 
-      @@views = [] of View.class
-
       def initialize(@config)
       end
 
@@ -118,24 +126,11 @@ DIR  - directory where project will be generated,
       end
 
       def views
-        self.class.views
-      end
-
-      def self.views
-        @@views
-      end
-
-      def self.register_view(view)
-        views << view
+        View.views
       end
     end
 
     class GitInitView < View
-      getter config
-
-      def initialize(@config)
-      end
-
       def render
         return unless system(WHICH_GIT_COMMAND)
         return command if config.silent
@@ -161,7 +156,7 @@ DIR  - directory where project will be generated,
         end
       end
 
-      InitProject.register_view({{name.id}})
+      View.register({{name.id}})
     end
 
     template GitignoreView, "gitignore.ecr", ".gitignore"
@@ -176,6 +171,6 @@ DIR  - directory where project will be generated,
     template SpecHelperView, "spec_helper.cr.ecr", "spec/spec_helper.cr"
     template SpecExampleView, "example_spec.cr.ecr", "spec/#{config.name}_spec.cr"
 
-    InitProject.register_view(GitInitView)
+    View.register(GitInitView)
   end
 end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -1,0 +1,150 @@
+require "ecr/macros"
+require "option_parser"
+
+module Crystal
+  module Init
+    def self.run(args)
+      config = Config.new
+
+      OptionParser.parse(args) do |opts|
+        opts.banner = %{USAGE: crystal init TYPE NAME [DIR]
+
+TYPE is one of:
+    lib                      creates library skeleton
+    app                      creates application skeleton
+
+NAME - name of project to be generated,
+       eg: example
+DIR  - directory where project will be generated,
+       default: NAME, eg: ./custom/path/example
+}
+
+        opts.on("--help", "Shows this message") do
+          puts opts
+          exit
+        end
+
+        opts.unknown_args do |args, after_dash|
+          config.skeleton_type = fetch_skeleton_type(opts, args)
+          config.name = fetch_required_parameter(opts, args, "NAME")
+          config.dir = args.empty? ? config.name : args.shift
+        end
+      end
+
+      config.author = fetch_author
+      InitProject.new(config).run
+    end
+
+    def self.fetch_author
+      author = `which git >/dev/null && git config --get user.name`.strip
+      return "[your-name-here]" if author == ""
+      author
+    end
+
+    def self.fetch_skeleton_type(opts, args)
+      skeleton_type = fetch_required_parameter(opts, args, "TYPE")
+      unless ["lib", "app"].includes?(skeleton_type)
+        puts "invalid TYPE value: #{skeleton_type}"
+        puts opts
+        exit 1
+      end
+      skeleton_type
+    end
+
+    def self.fetch_required_parameter(opts, args, name)
+      if args.empty?
+        puts "#{name} is missing"
+        puts opts
+        exit 1
+      end
+      args.shift
+    end
+
+    class Config
+      property skeleton_type
+      property name
+      property dir
+      property author
+
+      def initialize
+        @skeleton_type = "none"
+        @name = "none"
+        @dir = "none"
+        @author = "none"
+      end
+
+      def initialize(@skeleton_type, @name, @dir, @author)
+      end
+    end
+
+    class InitProject
+      getter config
+
+      def initialize(@config)
+      end
+
+      def run
+        views.each do |view|
+          view.new(config).render
+        end
+      end
+
+      def views
+        [
+         GitignoreView,
+         LicenseView,
+         ReadmeView,
+         TravisView,
+         ProjectileView,
+
+         SrcExampleView,
+         SrcVersionView,
+
+         SpecHelperView,
+         SpecExampleView,
+        ]
+      end
+    end
+
+    abstract class View
+      getter config
+
+      def initialize(@config)
+      end
+
+      def render
+        Dir.mkdir_p(File.dirname(full_path))
+        File.write(full_path, to_s)
+      end
+
+      def module_name
+        config.name.camelcase
+      end
+
+      abstract def full_path
+    end
+
+    TEMPLATE_DIR = "#{__DIR__}/init/template"
+
+    macro template(name, template_path, full_path)
+      class {{name.id}} < View
+        ecr_file "{{TEMPLATE_DIR.id}}/{{template_path.id}}"
+        def full_path
+          "#{config.dir}/#{{{full_path}}}"
+        end
+      end
+    end
+
+    template GitignoreView, "gitignore.ecr", ".gitignore"
+    template LicenseView, "license.ecr", "LICENSE"
+    template ReadmeView, "readme.md.ecr", "README.md"
+    template TravisView, "travis.yml.ecr", ".travis.yml"
+    template ProjectileView, "projectfile.ecr", "Projectfile"
+
+    template SrcExampleView, "example.cr.ecr", "src/#{config.name}.cr"
+    template SrcVersionView, "version.cr.ecr", "src/#{config.name}/version.cr"
+
+    template SpecHelperView, "spec_helper.cr.ecr", "spec/spec_helper.cr"
+    template SpecExampleView, "example_spec.cr.ecr", "spec/#{config.name}_spec.cr"
+  end
+end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -105,6 +105,8 @@ DIR  - directory where project will be generated,
 
          SpecHelperView,
          SpecExampleView,
+
+         GitInitView,
         ]
       end
     end
@@ -126,6 +128,27 @@ DIR  - directory where project will be generated,
       end
 
       abstract def full_path
+    end
+
+    class GitInitView < View
+      getter config
+
+      def initialize(@config)
+      end
+
+      def render
+        return unless system(WHICH_GIT_COMMAND)
+        return command if config.silent
+        puts command
+      end
+
+      def full_path
+        "#{config.dir}/.git"
+      end
+
+      private def command
+        `git init #{config.dir}`
+      end
     end
 
     TEMPLATE_DIR = "#{__DIR__}/init/template"

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -3,6 +3,8 @@ require "option_parser"
 
 module Crystal
   module Init
+    WHICH_GIT_COMMAND = "which git >/dev/null"
+
     def self.run(args)
       config = Config.new
 
@@ -36,9 +38,8 @@ DIR  - directory where project will be generated,
     end
 
     def self.fetch_author
-      author = `which git >/dev/null && git config --get user.name`.strip
-      return "[your-name-here]" if author == ""
-      author
+      return "[your-name-here]" unless system(WHICH_GIT_COMMAND)
+      `git config --get user.name`.strip
     end
 
     def self.fetch_skeleton_type(opts, args)
@@ -65,15 +66,17 @@ DIR  - directory where project will be generated,
       property name
       property dir
       property author
+      property silent
 
       def initialize
         @skeleton_type = "none"
         @name = "none"
         @dir = "none"
         @author = "none"
+        @silent = false
       end
 
-      def initialize(@skeleton_type, @name, @dir, @author)
+      def initialize(@skeleton_type, @name, @dir, @author, @silent = false)
       end
     end
 
@@ -115,6 +118,7 @@ DIR  - directory where project will be generated,
       def render
         Dir.mkdir_p(File.dirname(full_path))
         File.write(full_path, to_s)
+        puts "      create  #{full_path}" unless config.silent
       end
 
       def module_name

--- a/src/compiler/crystal/tools/init/template/example.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example.cr.ecr
@@ -1,0 +1,5 @@
+require "./<%= config.name %>/*"
+
+module <%= module_name %>
+  # TODO Put your code here
+end

--- a/src/compiler/crystal/tools/init/template/example_spec.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example_spec.cr.ecr
@@ -1,0 +1,9 @@
+require "./spec_helper"
+
+describe <%= module_name %> do
+  # TODO: Write tests
+
+  it "works" do
+    false.should eq(true)
+  end
+end

--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -1,0 +1,9 @@
+/.deps/
+/libs/
+/.crystal/
+
+<% if config.skeleton_type == "lib" %>
+# Libraries don't need dependency lock
+# Dependencies will be locked in application that uses them
+/.deps.lock
+<% end %>

--- a/src/compiler/crystal/tools/init/template/license.ecr
+++ b/src/compiler/crystal/tools/init/template/license.ecr
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <%= Time.now.year %> <%= config.author %>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/compiler/crystal/tools/init/template/projectfile.ecr
+++ b/src/compiler/crystal/tools/init/template/projectfile.ecr
@@ -1,0 +1,2 @@
+deps do
+end

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -1,0 +1,37 @@
+# <%= config.name %>
+
+TODO: Write a description here for library
+
+## Installation
+
+Add it to `Projectfile`
+
+```crystal
+deps do
+  github "[your-github-name]/<%= config.name %>"
+end
+```
+
+## Usage
+
+```crystal
+require "<%= config.name %>"
+```
+
+TODO: Write usage here for library
+
+## Development
+
+TODO: Write instructions for development
+
+## Contributing
+
+1. Fork it ( https://github.com/[your-github-name]/<%= config.name %>/fork )
+2. Create your feature branch (git checkout -b my-new-feature)
+3. Commit your changes (git commit -am 'Add some feature')
+4. Push to the branch (git push origin my-new-feature)
+5. Create a new Pull Request
+
+## Contributors
+
+- [your-github-name](https://github.com/[your-github-name]) <%= config.author %> - creator, maintainer

--- a/src/compiler/crystal/tools/init/template/spec_helper.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/spec_helper.cr.ecr
@@ -1,0 +1,2 @@
+require "spec"
+require "../src/<%= @config.name %>"

--- a/src/compiler/crystal/tools/init/template/travis.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/travis.yml.ecr
@@ -1,0 +1,10 @@
+language: c
+before_install: |
+  curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash
+  sudo apt-get -q update
+
+install: |
+  sudo apt-get install crystal
+
+script:
+  - crystal spec

--- a/src/compiler/crystal/tools/init/template/version.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/version.cr.ecr
@@ -1,0 +1,3 @@
+module <%= module_name %>
+  VERSION = "0.0.1"
+end


### PR DESCRIPTION
closes #505 

```
➜  tmp  ../crystal/.build/crystal init --help
USAGE: crystal init TYPE NAME [DIR]

TYPE is one of:
    lib                      creates library skeleton
    app                      creates application skeleton

NAME - name of project to be generated,
       eg: example
DIR  - directory where project will be generated,
       default: NAME, eg: ./custom/path/example

    --help                           Shows this message
```

Generates following project structure:

```
➜  crystal  crystal init lib example
      create  example/.gitignore
      create  example/LICENSE
      create  example/README.md
      create  example/.travis.yml
      create  example/Projectfile
      create  example/src/example.cr
      create  example/src/example/version.cr
      create  example/spec/spec_helper.cr
      create  example/spec/example_spec.cr
Initialized empty Git repository in /Users/your_user_name/crystal/example/.git/
➜  crystal  cd example
➜  example  tree . -a
.
├── .git
│   ├── HEAD
# ...
├── .gitignore
├── .travis.yml
├── LICENSE
├── Projectfile
├── README.md
├── spec
│   ├── example_spec.cr
│   └── spec_helper.cr
└── src
    ├── example
    │   └── version.cr
    └── example.cr
```

- license file specifies MIT, is it OK ?
- I have added this `src/example/version.cr` which is not used currently by anything, but I expect, that it will come in handy at some point.
- anything you think needs to be added to git ignore ?
- maybe we want some output of this command (like which files and directories got generated) ? - now it is silent.

WDYT?  /cc @asterite 