### PR TITLE
Spec : get rid of object patching

### DIFF
--- a/spec/compiler/codegen/alias_spec.cr
+++ b/spec/compiler/codegen/alias_spec.cr
@@ -2,40 +2,40 @@ require "../../spec_helper"
 
 describe "Code gen: alias" do
   it "invokes methods on empty array of recursive alias (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       alias X = Array(X)
 
       a = [] of X
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      )).to_string).to eq("")
   end
 
   it "invokes methods on empty array of recursive alias (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       alias X = Nil | Array(X)
 
       a = [] of X
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      )).to_string).to eq("")
   end
 
   it "invokes methods on empty array of recursive alias (3)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       alias X = Nil | Array(X)
 
       a = [] of X
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      )).to_string).to eq("")
   end
 
   it "casts to recursive alias" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Bar(T)
@@ -46,11 +46,11 @@ describe "Code gen: alias" do
       a = 1 as Foo
       b = a as Int32
       b
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts to recursive alias" do
-    run(%(
+    expect(run(%(
       class Bar(T)
         def self.new(&block : -> T)
         end
@@ -71,7 +71,7 @@ describe "Code gen: alias" do
       end
 
       foo(2).to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "doesn't break with alias for link attributes" do

--- a/spec/compiler/codegen/and_spec.cr
+++ b/spec/compiler/codegen/and_spec.cr
@@ -2,169 +2,169 @@ require "../../spec_helper"
 
 describe "Code gen: and" do
   it "codegens and with bool false and false" do
-    run("false && false").to_b.should be_false
+    expect(run("false && false").to_b).to be_false
   end
 
   it "codegens and with bool false and true" do
-    run("false && true").to_b.should be_false
+    expect(run("false && true").to_b).to be_false
   end
 
   it "codegens and with bool true and true" do
-    run("true && true").to_b.should be_true
+    expect(run("true && true").to_b).to be_true
   end
 
   it "codegens and with bool true and false" do
-    run("true && false").to_b.should be_false
+    expect(run("true && false").to_b).to be_false
   end
 
   it "codegens and with bool and int 1" do
-    run("struct Bool; def to_i; 0; end; end; (false && 2).to_i").to_i.should eq(0)
+    expect(run("struct Bool; def to_i; 0; end; end; (false && 2).to_i").to_i).to eq(0)
   end
 
   it "codegens and with bool and int 2" do
-    run("struct Bool; def to_i; 0; end; end; (true && 2).to_i").to_i.should eq(2)
+    expect(run("struct Bool; def to_i; 0; end; end; (true && 2).to_i").to_i).to eq(2)
   end
 
   it "codegens and with primitive type other than bool" do
-    run("1 && 2").to_i.should eq(2)
+    expect(run("1 && 2").to_i).to eq(2)
   end
 
   it "codegens and with primitive type other than bool with union" do
-    run("(1 && 1.5).to_f").to_f64.should eq(1.5)
+    expect(run("(1 && 1.5).to_f").to_f64).to eq(1.5)
   end
 
   it "codegens and with primitive type other than bool" do
-    run("require \"nil\"; (nil && 2).to_i").to_i.should eq(0)
+    expect(run("require \"nil\"; (nil && 2).to_i").to_i).to eq(0)
   end
 
   it "codegens and with nilable as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       class Object; def to_i; -1; end; end
       a = Reference.new
       a = nil
       (a && 2).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens and with nilable as left node 2" do
-    run("
+    expect(run("
       class Object; def to_i; -1; end; end
       a = nil
       a = Reference.new
       (a && 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens and with non-false union as left node" do
-    run("
+    expect(run("
       a = 1.5
       a = 1
       (a && 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens and with nil union as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       a = nil
       a = 1
       (a && 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens and with nil union as left node 2" do
-    run("
+    expect(run("
       require \"nil\"
       a = 1
       a = nil
       (a && 2).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens and with bool union as left node 1" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = false
       a = 1
       (a && 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens and with bool union as left node 2" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = 1
       a = false
       (a && 2).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens and with bool union as left node 3" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = 1
       a = true
       (a && 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens and with bool union as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = false
       a = nil
       a = 2
       (a && 3).to_i
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "codegens and with bool union as left node 2" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = nil
       a = 2
       a = false
       (a && 3).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens and with bool union as left node 3" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = nil
       a = 2
       a = true
       (a && 3).to_i
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "codegens and with bool union as left node 4" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = 2
       a = true
       a = nil
       (a && 3).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens assign in right node, after must be nilable" do
-    run("
+    expect(run("
       struct Nil; def nil?; true; end; end
       class Reference; def nil?; false; end; end
 
       a = 1 == 2 && (b = Reference.new)
       b.nil?
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "codegens assign in right node, inside if must not be nil" do
-    run("
+    expect(run("
       struct Nil; end
       class Foo; def foo; 1; end; end
 
@@ -173,17 +173,17 @@ describe "Code gen: and" do
       else
         0
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens assign in right node, after if must be nilable" do
-    run("
+    expect(run("
       struct Nil; def nil?; true; end; end
       class Reference; def nil?; false; end; end
 
       if 1 == 2 && (b = Reference.new)
       end
       b.nil?
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: array literal spec" do
   it "creates custom non-generic array" do
-    run(%(
+    expect(run(%(
       class Custom
         def initialize
           @value = 0
@@ -19,11 +19,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "creates custom generic array" do
-    run(%(
+    expect(run(%(
       class Custom(T)
         def initialize
           @value = 0
@@ -40,11 +40,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "creates custom generic array with type var" do
-    run(%(
+    expect(run(%(
       class Custom(T)
         def initialize
           @value = 0
@@ -61,11 +61,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom(Int32) {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "creates custom generic array via alias" do
-    run(%(
+    expect(run(%(
       class Custom(T)
         def initialize
           @value = 0
@@ -84,11 +84,11 @@ describe "Code gen: array literal spec" do
 
       custom = MyCustom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "creates custom generic array via alias (2)" do
-    run(%(
+    expect(run(%(
       class Custom(T)
         def initialize
           @value = 0
@@ -107,11 +107,11 @@ describe "Code gen: array literal spec" do
 
       custom = MyCustom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "creates custom non-generic array in nested module" do
-    run(%(
+    expect(run(%(
       class Foo::Custom
         def initialize
           @value = 0
@@ -128,6 +128,6 @@ describe "Code gen: array literal spec" do
 
       custom = Foo::Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 end

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: block" do
   it "generate inline" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -10,11 +10,11 @@ describe "Code gen: block" do
       foo do
         1
       end
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "passes yield arguments" do
-    run("
+    expect(run("
       def foo
         yield 1
       end
@@ -22,11 +22,11 @@ describe "Code gen: block" do
       foo do |x|
         x + 1
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "pass arguments to yielder function" do
-    run("
+    expect(run("
       def foo(a)
         yield a
       end
@@ -34,11 +34,11 @@ describe "Code gen: block" do
       foo(3) do |x|
         x + 1
       end
-    ").to_i.should eq(4)
+    ").to_i).to eq(4)
   end
 
   it "pass self to yielder function" do
-    run("
+    expect(run("
       struct Int
         def foo
           yield self
@@ -48,11 +48,11 @@ describe "Code gen: block" do
       3.foo do |x|
         x + 1
       end
-    ").to_i.should eq(4)
+    ").to_i).to eq(4)
   end
 
   it "pass self and arguments to yielder function" do
-    run("
+    expect(run("
       struct Int
         def foo(i)
           yield self, i
@@ -62,11 +62,11 @@ describe "Code gen: block" do
       3.foo(2) do |x, i|
         x + i
       end
-    ").to_i.should eq(5)
+    ").to_i).to eq(5)
   end
 
   it "allows access to local variables" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -75,11 +75,11 @@ describe "Code gen: block" do
       foo do
         x + 1
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "can access instance vars from yielder function" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @x = 1
@@ -92,11 +92,11 @@ describe "Code gen: block" do
       Foo.new.foo do |x|
         x + 1
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "can set instance vars from yielder function" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @x = 1
@@ -113,11 +113,11 @@ describe "Code gen: block" do
       a = Foo.new
       a.foo { 2 }
       a.value
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "can use instance methods from yielder function" do
-    run("
+    expect(run("
       class Foo
         def foo
           yield value
@@ -128,11 +128,11 @@ describe "Code gen: block" do
       end
 
       Foo.new.foo { |x| x + 1 }
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "can call methods from block when yielder is an instance method" do
-    run("
+    expect(run("
       class Foo
         def foo
           yield
@@ -144,11 +144,11 @@ describe "Code gen: block" do
       end
 
       Foo.new.foo { bar }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "nested yields" do
-    run("
+    expect(run("
       def bar
         yield
       end
@@ -158,33 +158,33 @@ describe "Code gen: block" do
       end
 
       a = foo { 1 }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "assigns yield to argument" do
-    run("
+    expect(run("
       def foo(x)
         yield
         x = 1
       end
 
       foo(1) { 1 }
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "can use global constant" do
-    run("
+    expect(run("
       FOO = 1
       def foo
         yield
         FOO
       end
       foo { }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "return from yielder function" do
-    run("
+    expect(run("
       def foo
         yield
         return 1
@@ -192,11 +192,11 @@ describe "Code gen: block" do
 
       foo { }
       2
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "return from block" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -207,11 +207,11 @@ describe "Code gen: block" do
       end
 
       bar
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "return from yielder function (2)" do
-    run("
+    expect(run("
       def foo
         yield
         return 1 if true
@@ -223,11 +223,11 @@ describe "Code gen: block" do
       end
 
       bar
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "union value of yielder function" do
-    run("
+    expect(run("
       def foo
         yield
         a = 1.1
@@ -236,11 +236,11 @@ describe "Code gen: block" do
       end
 
       foo {}.to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "allow return from function called from yielder function" do
-    run("
+    expect(run("
       def foo
         return 2
       end
@@ -252,22 +252,22 @@ describe "Code gen: block" do
       end
 
       bar {}
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "" do
-    run("
+    expect(run("
       def foo
         yield
         true ? return 1 : return 1.1
       end
 
       foo {}.to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "return from block that always returns from function that always yields inside if block" do
-    run("
+    expect(run("
       def bar
         yield
         2
@@ -282,11 +282,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "return from block that always returns from function that conditionally yields" do
-    run("
+    expect(run("
       def bar
         if true
           yield
@@ -299,11 +299,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "call block from dispatch" do
-    run("
+    expect(run("
       def bar(y)
         yield y
       end
@@ -315,11 +315,11 @@ describe "Code gen: block" do
       end
 
       foo.to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "call block from dispatch and use local vars" do
-    run("
+    expect(run("
       def bar(y)
         yield y
       end
@@ -336,11 +336,11 @@ describe "Code gen: block" do
       end
 
       foo.to_i
-    ").to_i.should eq(4)
+    ").to_i).to eq(4)
   end
 
   it "break without value returns nil" do
-    run("
+    expect(run("
       require \"nil\"
       require \"value\"
 
@@ -354,11 +354,11 @@ describe "Code gen: block" do
       end
 
       x.nil?
-    ").to_b.should be_true
+    ").to_b).to be_true
   end
 
   it "break block with yielder inside while" do
-    run("
+    expect(run("
       require \"prelude\"
       a = 0
       10.times do
@@ -366,11 +366,11 @@ describe "Code gen: block" do
         break if a > 5
       end
       a
-    ").to_i.should eq(6)
+    ").to_i).to eq(6)
   end
 
   it "break from block returns from yielder" do
-    run("
+    expect(run("
       def foo
         yield
         yield
@@ -379,11 +379,11 @@ describe "Code gen: block" do
       a = 0
       foo { a += 1; break }
       a
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "break from block with value" do
-    run("
+    expect(run("
       def foo
         while true
           yield
@@ -394,11 +394,11 @@ describe "Code gen: block" do
       foo do
         break 1
       end
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "returns from block with value" do
-    run("
+    expect(run("
       require \"prelude\"
 
       def foo
@@ -415,11 +415,11 @@ describe "Code gen: block" do
       end
 
       bar.to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "doesn't codegen after while that always yields and breaks" do
-    run("
+    expect(run("
       def foo
         while true
           yield
@@ -430,18 +430,18 @@ describe "Code gen: block" do
       foo do
         break 2
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "break from block with value" do
-    run("
+    expect(run("
       require \"prelude\"
       10.times { break 20 }
-    ").to_i.should eq(20)
+    ").to_i).to eq(20)
   end
 
   it "doesn't codegen call if arg yields and always breaks" do
-    run("
+    expect(run("
       require \"nil\"
 
       def foo
@@ -449,11 +449,11 @@ describe "Code gen: block" do
       end
 
       foo { break 2 }.to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens nested return" do
-    run("
+    expect(run("
       def bar
         yield
         a = 1
@@ -468,11 +468,11 @@ describe "Code gen: block" do
       end
 
       z
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens nested break" do
-    run("
+    expect(run("
       def bar
         yield
         a = 1
@@ -483,11 +483,11 @@ describe "Code gen: block" do
       end
 
       foo { break 2 }
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens call with block with call with arg that yields" do
-    run("
+    expect(run("
       def bar
         yield
         a = 2
@@ -498,11 +498,11 @@ describe "Code gen: block" do
       end
 
       foo { break 3 }
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "can break without value from yielder that returns nilable (1)" do
-    run("
+    expect(run("
       require \"nil\"
       require \"reference\"
 
@@ -516,11 +516,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    ").to_b.should be_true
+    ").to_b).to be_true
   end
 
   it "can break without value from yielder that returns nilable (2)" do
-    run("
+    expect(run("
       require \"nil\"
       require \"reference\"
 
@@ -534,11 +534,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    ").to_b.should be_true
+    ").to_b).to be_true
   end
 
   it "break with value from yielder that returns a nilable" do
-    run("
+    expect(run("
       require \"nil\"
       require \"reference\"
 
@@ -553,11 +553,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    ").to_b.should be_false
+    ").to_b).to be_false
   end
 
   it "can use self inside a block called from dispatch" do
-    run("
+    expect(run("
       require \"nil\"
 
       class Foo
@@ -577,11 +577,11 @@ describe "Code gen: block" do
 
       123.foo
       $x.to_i
-    ").to_i.should eq(123)
+    ").to_i).to eq(123)
   end
 
   it "return from block called from dispatch" do
-    run("
+    expect(run("
       class Foo
         def do; yield; end
       end
@@ -596,11 +596,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "breaks from while in function called from block" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -615,21 +615,21 @@ describe "Code gen: block" do
       foo do
         bar
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "allows modifying yielded value (with literal)" do
-    run("
+    expect(run("
       def foo
         yield 1
       end
 
       foo { |x| x = 2; x }
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "allows modifying yielded value (with variable)" do
-    run("
+    expect(run("
       def foo
         a = 1
         yield a
@@ -637,7 +637,7 @@ describe "Code gen: block" do
       end
 
       foo { |x| x = 2; x }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "it yields nil from another call" do
@@ -660,7 +660,7 @@ describe "Code gen: block" do
   end
 
   it "allows yield from dispatch call" do
-    run("
+    expect(run("
       def foo(x : Value)
         yield 1
       end
@@ -679,7 +679,7 @@ describe "Code gen: block" do
       x = 0
       bar { |i| x = i }
       x
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "block with nilable type" do
@@ -724,7 +724,7 @@ describe "Code gen: block" do
   end
 
   it "allows yields with less arguments than in block" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -740,11 +740,11 @@ describe "Code gen: block" do
         a += x + y.to_i
       end
       a
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens block with nilable type with return (1)" do
-    run("
+    expect(run("
       struct Nil; def nil?; true; end; end
       class Reference; def nil?; false; end; end
 
@@ -756,11 +756,11 @@ describe "Code gen: block" do
       end
 
       foo { false }.nil?
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "codegens block with nilable type with return (2)" do
-    run("
+    expect(run("
       struct Nil; def nil?; true; end; end
       class Reference; def nil?; false; end; end
 
@@ -772,7 +772,7 @@ describe "Code gen: block" do
       end
 
       foo { false }.nil?
-      ").to_b.should be_false
+      ").to_b).to be_false
   end
 
   it "codegens block with union with return" do
@@ -791,7 +791,7 @@ describe "Code gen: block" do
   end
 
   it "codegens if with call with block (ssa issue)" do
-    run("
+    expect(run("
       def bar
         yield
       end
@@ -807,11 +807,11 @@ describe "Code gen: block" do
       end
 
       foo
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens block with return and yield and no return" do
-    run("
+    expect(run("
       lib LibC
         fun exit : NoReturn
       end
@@ -828,11 +828,11 @@ describe "Code gen: block" do
       end
 
       foo 1
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens while/break inside block" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -843,21 +843,21 @@ describe "Code gen: block" do
         end
         1
       end
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens block with union arg (1)" do
-    run("
+    expect(run("
       def foo
         yield 1 || 1.5
       end
 
       foo { |x| x }.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens block with union arg (2)" do
-    run("
+    expect(run("
       struct Number
         def abs
           self
@@ -878,11 +878,11 @@ describe "Code gen: block" do
       a.each do |x|
         x.abs
       end.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens block with virtual type arg" do
-    run("
+    expect(run("
       class Var(T)
         def initialize(x : T)
           @x = x
@@ -909,22 +909,22 @@ describe "Code gen: block" do
       a.each do |x|
         x.bar
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens call with blocks of different type without args" do
-    run("
+    expect(run("
       def foo
         yield
       end
 
       foo { 1.1 }
       foo { 1 }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens dispatch with block and break (1)" do
-    run("
+    expect(run("
       class Foo(T)
         def initialize(@x : T)
         end
@@ -941,11 +941,11 @@ describe "Code gen: block" do
         n += x
       end
       n.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens dispatch with block and break (2)" do
-    run("
+    expect(run("
       require \"prelude\"
 
       a = [1, 2, 3] || [1.5]
@@ -955,7 +955,7 @@ describe "Code gen: block" do
         n += x
       end
       n.to_i
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
    end
 
   it "codegens block call when argument type changes" do
@@ -987,7 +987,7 @@ describe "Code gen: block" do
   end
 
   it "executes yield expression if no arg is given for block" do
-    run("
+    expect(run("
       def foo
         a = 1
         yield (a = 2)
@@ -995,11 +995,11 @@ describe "Code gen: block" do
       end
 
       foo { }
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens bug with block and arg and var" do
-    run("
+    expect(run("
       def foo
         yield 1
       end
@@ -1010,11 +1010,11 @@ describe "Code gen: block" do
         a = 'A'
         a.ord
       end
-      ").to_i.should eq(65)
+      ").to_i).to eq(65)
   end
 
   it "allows using var as block arg with outer var" do
-    run("
+    expect(run("
       def foo
         yield 'a'
       end
@@ -1022,11 +1022,11 @@ describe "Code gen: block" do
       a = foo do |a|
         1
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows initialize with yield (#224)" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           @x = yield 1
@@ -1041,11 +1041,11 @@ describe "Code gen: block" do
         a + 1
       end
       foo.x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "uses block inside array literal (bug)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo
@@ -1054,7 +1054,7 @@ describe "Code gen: block" do
 
       ary = [foo { |x| x.abs }]
       ary[0]
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens method invocation on a object of a captured block with a type that was never instantiated" do
@@ -1118,7 +1118,7 @@ describe "Code gen: block" do
   end
 
   it "codegens bug with yield not_nil! that is never not nil" do
-    run(%(
+    expect(run(%(
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -1157,11 +1157,11 @@ describe "Code gen: block" do
       end
 
       extra.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "uses block var with same name as local var" do
-    run(%(
+    expect(run(%(
       def foo
         yield "hello"
       end
@@ -1171,11 +1171,11 @@ describe "Code gen: block" do
         a
       end
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "doesn't crash on untyped array to_s" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Bar(T)
@@ -1188,11 +1188,11 @@ describe "Code gen: block" do
       end
 
       Foo(Int32).new.foo { |k| k + 1 }.to_s
-      )).to_string.should eq("[]")
+      )).to_string).to eq("[]")
   end
 
   it "codegens block which always breaks but never enters (#494)" do
-    run(%(
+    expect(run(%(
       def foo
         while 1 == 2
           yield
@@ -1203,6 +1203,6 @@ describe "Code gen: block" do
       foo do
         break 10
       end
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 end

--- a/spec/compiler/codegen/c_abi_spec.cr
+++ b/spec/compiler/codegen/c_abi_spec.cr
@@ -18,8 +18,8 @@ describe "Code gen: C ABI" do
       LibC.foo(s)
       )).first_value
     str = mod.to_s
-    str.should contain("call void @foo({ i64 }")
-    str.should contain("declare void @foo({ i64 })")
+    expect(str).to contain("call void @foo({ i64 }")
+    expect(str).to contain("declare void @foo({ i64 })")
   end
 
   it "passes struct less than 64 bits as { i64 } in varargs" do
@@ -37,7 +37,7 @@ describe "Code gen: C ABI" do
       LibC.foo(s)
       )).first_value
     str = mod.to_s
-    str.should contain("call void (...)* @foo({ i64 }")
+    expect(str).to contain("call void (...)* @foo({ i64 }")
   end
 
   it "passes struct between 64 and 128 bits as { i64, i64 }" do
@@ -55,8 +55,8 @@ describe "Code gen: C ABI" do
       LibC.foo(s)
       )).first_value
     str = mod.to_s
-    str.should contain("call void @foo({ i64, i64 }")
-    str.should contain("declare void @foo({ i64, i64 })")
+    expect(str).to contain("call void @foo({ i64, i64 }")
+    expect(str).to contain("declare void @foo({ i64, i64 })")
   end
 
   it "passes struct bigger than128 bits with byval" do
@@ -75,7 +75,7 @@ describe "Code gen: C ABI" do
       LibC.foo(s)
       )).first_value
     str = mod.to_s
-    str.scan(/byval/).length.should eq(2)
+    expect(str.scan(/byval/).length).to eq(2)
   end
 
   it "returns struct less than 64 bits as { i64 }" do
@@ -92,8 +92,8 @@ describe "Code gen: C ABI" do
       str = LibC.foo
       )).first_value
     str = mod.to_s
-    str.should contain("call { i64 } @foo()")
-    str.should contain("declare { i64 } @foo()")
+    expect(str).to contain("call { i64 } @foo()")
+    expect(str).to contain("declare { i64 } @foo()")
   end
 
   it "returns struct between 64 and 128 bits as { i64, i64 }" do
@@ -110,8 +110,8 @@ describe "Code gen: C ABI" do
       str = LibC.foo
       )).first_value
     str = mod.to_s
-    str.should contain("call { i64, i64 } @foo()")
-    str.should contain("declare { i64, i64 } @foo()")
+    expect(str).to contain("call { i64, i64 } @foo()")
+    expect(str).to contain("declare { i64, i64 } @foo()")
   end
 
   it "returns struct bigger than 128 bits with sret" do
@@ -129,7 +129,7 @@ describe "Code gen: C ABI" do
       str = LibC.foo(1)
       )).first_value
     str = mod.to_s
-    str.scan(/sret/).length.should eq(2)
-    str.should contain("sret, i32") # sret goes as first argument
+    expect(str.scan(/sret/).length).to eq(2)
+    expect(str).to contain("sret, i32") # sret goes as first argument
   end
 end

--- a/spec/compiler/codegen/c_enum_spec.cr
+++ b/spec/compiler/codegen/c_enum_spec.cr
@@ -4,19 +4,19 @@ CodeGenCEnumString = "lib LibFoo; enum Bar; X, Y, Z = 10, W; end end"
 
 describe "Code gen: c enum" do
   it "codegens enum value" do
-    run("#{CodeGenCEnumString}; LibFoo::Bar::X").to_i.should eq(0)
+    expect(run("#{CodeGenCEnumString}; LibFoo::Bar::X").to_i).to eq(0)
   end
 
   it "codegens enum value 2" do
-    run("#{CodeGenCEnumString}; LibFoo::Bar::Y").to_i.should eq(1)
+    expect(run("#{CodeGenCEnumString}; LibFoo::Bar::Y").to_i).to eq(1)
   end
 
   it "codegens enum value 3" do
-    run("#{CodeGenCEnumString}; LibFoo::Bar::Z").to_i.should eq(10)
+    expect(run("#{CodeGenCEnumString}; LibFoo::Bar::Z").to_i).to eq(10)
   end
 
   it "codegens enum value 4" do
-    run("#{CodeGenCEnumString}; LibFoo::Bar::W").to_i.should eq(11)
+    expect(run("#{CodeGenCEnumString}; LibFoo::Bar::W").to_i).to eq(11)
   end
 
   [
@@ -32,7 +32,7 @@ describe "Code gen: c enum" do
     {"10 % 3", 1},
   ].each do |test_case|
     it "codegens enum with #{test_case[0]} " do
-      run("
+      expect(run("
         lib LibFoo
           enum Bar
             X = #{test_case[0]}
@@ -40,12 +40,12 @@ describe "Code gen: c enum" do
         end
 
         LibFoo::Bar::X
-        ").to_i.should eq(test_case[1])
+        ").to_i).to eq(test_case[1])
     end
   end
 
   it "codegens enum that refers to another enum constant" do
-    run("
+    expect(run("
       lib LibFoo
         enum Bar
           A = 1
@@ -55,11 +55,11 @@ describe "Code gen: c enum" do
       end
 
       LibFoo::Bar::C
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens enum that refers to another constant" do
-    run("
+    expect(run("
       lib LibFoo
         X = 10
         enum Bar
@@ -70,6 +70,6 @@ describe "Code gen: c enum" do
       end
 
       LibFoo::Bar::C
-      ").to_i.should eq(12)
+      ").to_i).to eq(12)
   end
 end

--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -4,27 +4,27 @@ CodeGenStructString = "lib LibFoo; struct Bar; x : Int32; y : Float32; end; end"
 
 describe "Code gen: struct" do
   it "codegens struct property default value" do
-    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
+    expect(run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i).to eq(0)
   end
 
   it "codegens struct property setter" do
-    run("#{CodeGenStructString}; bar = LibFoo::Bar.new; bar.y = 2.5_f32; bar.y").to_f32.should eq(2.5)
+    expect(run("#{CodeGenStructString}; bar = LibFoo::Bar.new; bar.y = 2.5_f32; bar.y").to_f32).to eq(2.5)
   end
 
   it "codegens struct property setter via pointer" do
-    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
+    expect(run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32).to eq(2.5)
   end
 
   it "codegens struct property setter via pointer" do
-    run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32.should eq(2.5)
+    expect(run("#{CodeGenStructString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.y = 2.5_f32; bar.value.y").to_f32).to eq(2.5)
   end
 
   it "codegens set struct value with constant" do
-    run("#{CodeGenStructString}; CONST = 1; bar = LibFoo::Bar.new; bar.x = CONST; bar.x").to_i.should eq(1)
+    expect(run("#{CodeGenStructString}; CONST = 1; bar = LibFoo::Bar.new; bar.x = CONST; bar.x").to_i).to eq(1)
   end
 
   it "codegens union inside struct" do
-    run("
+    expect(run("
       lib LibFoo
         union Bar
           x : Int32
@@ -39,11 +39,11 @@ describe "Code gen: struct" do
       a = Pointer(LibFoo::Baz).malloc(1_u64)
       a.value.lala.x = 10
       a.value.lala.x
-      ").to_i.should eq(10)
+      ").to_i).to eq(10)
   end
 
   it "codegens struct get inside struct" do
-    run("
+    expect(run("
       lib LibC
         struct Bar
           y : Int32
@@ -59,11 +59,11 @@ describe "Code gen: struct" do
       ((foo as Int32*) + 1_i64).value = 2
 
       foo.value.bar.y
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens struct set inside struct" do
-    run("
+    expect(run("
       lib LibC
         struct Bar
           y : Int32
@@ -81,11 +81,11 @@ describe "Code gen: struct" do
       foo.value.bar = bar
 
       foo.value.bar.y
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens pointer malloc of struct" do
-    run("
+    expect(run("
       lib LibC
         struct Foo
           x : Int32
@@ -95,11 +95,11 @@ describe "Code gen: struct" do
       p = Pointer(LibC::Foo).malloc(1_u64)
       p.value.x = 1
       p.value.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "passes struct to method (1)" do
-    run("
+    expect(run("
       lib LibC
         struct Foo
           x : Int32
@@ -117,11 +117,11 @@ describe "Code gen: struct" do
       f2 = foo(f1)
 
       f1.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "passes struct to method (2)" do
-    run("
+    expect(run("
       lib LibC
         struct Foo
           x : Int32
@@ -138,11 +138,11 @@ describe "Code gen: struct" do
 
       f2 = foo(f1)
       f2.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens struct access with -> and then ." do
-    run("
+    expect(run("
       lib LibC
         struct ScalarEvent
           x : Int32
@@ -159,11 +159,11 @@ describe "Code gen: struct" do
 
       e = Pointer(LibC::Event).malloc(1_u64)
       e.value.data.scalar.x
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "yields struct via ->" do
-    run("
+    expect(run("
       lib LibC
         struct ScalarEvent
           x : Int32
@@ -186,11 +186,11 @@ describe "Code gen: struct" do
       foo do |data|
         data.scalar.x
       end
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens assign struct to union" do
-    run("
+    expect(run("
       lib LibFoo
         struct Coco
           x : Int32
@@ -200,11 +200,11 @@ describe "Code gen: struct" do
       x = LibFoo::Coco.new
       c = x || 0
       c.is_a?(LibFoo::Coco)
-    ").to_b.should be_true
+    ").to_b).to be_true
   end
 
   it "codegens passing pointerof(struct) to fun" do
-    run("
+    expect(run("
       lib LibC
         struct Foo
           a : Int32
@@ -219,7 +219,7 @@ describe "Code gen: struct" do
       f.a = 1
 
       foo pointerof(f)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "builds struct setter with fun type (1)" do
@@ -253,7 +253,7 @@ describe "Code gen: struct" do
   end
 
   it "allows forward declarations" do
-    run(%(
+    expect(run(%(
       lib LibC
         struct A; end
         struct B; end
@@ -277,11 +277,11 @@ describe "Code gen: struct" do
       a.x = b
 
       a.y + a.x.value.y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "allows using named arguments for new" do
-    run(%(
+    expect(run(%(
       lib LibC
         struct Point
           x, y : Int32
@@ -290,11 +290,11 @@ describe "Code gen: struct" do
 
       point = LibC::Point.new x: 1, y: 2
       point.x + point.y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "does to_s" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       lib LibFoo
@@ -305,6 +305,6 @@ describe "Code gen: struct" do
 
       point = LibFoo::Point.new x: 1, y: 2
       point.to_s
-      )).to_string.should eq("LibFoo::Point(@x=1, @y=2)")
+      )).to_string).to eq("LibFoo::Point(@x=1, @y=2)")
   end
 end

--- a/spec/compiler/codegen/c_union_spec.cr
+++ b/spec/compiler/codegen/c_union_spec.cr
@@ -4,31 +4,31 @@ CodeGenUnionString = "lib LibFoo; union Bar; x : Int32; y : Int64; z : Float32; 
 
 describe "Code gen: c union" do
   it "codegens union property default value" do
-    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i.should eq(0)
+    expect(run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x").to_i).to eq(0)
   end
 
   it "codegens union property default value 2" do
-    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z").to_f32.should eq(0)
+    expect(run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z").to_f32).to eq(0)
   end
 
   it "codegens union property setter 1" do
-    run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.x = 42; bar.x").to_i.should eq(42)
+    expect(run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.x = 42; bar.x").to_i).to eq(42)
   end
 
   it "codegens union property setter 2" do
-    run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.z = 42.0_f32; bar.z").to_f32.should eq(42.0)
+    expect(run("#{CodeGenUnionString}; bar = LibFoo::Bar.new; bar.z = 42.0_f32; bar.z").to_f32).to eq(42.0)
   end
 
   it "codegens union property setter 1 via pointer" do
-    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 42; bar.value.x").to_i.should eq(42)
+    expect(run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.x = 42; bar.value.x").to_i).to eq(42)
   end
 
   it "codegens union property setter 2 via pointer" do
-    run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z = 42.0_f32; bar.value.z").to_f32.should eq(42.0)
+    expect(run("#{CodeGenUnionString}; bar = Pointer(LibFoo::Bar).malloc(1_u64); bar.value.z = 42.0_f32; bar.value.z").to_f32).to eq(42.0)
   end
 
   it "codegens struct inside union" do
-    run("
+    expect(run("
       lib LibFoo
         struct Baz
           lele : Int64
@@ -46,11 +46,11 @@ describe "Code gen: c union" do
       a.value.z = LibFoo::Baz.new
       a.value.z.lala = 10
       a.value.z.lala
-      ").to_i.should eq(10)
+      ").to_i).to eq(10)
   end
 
   it "codegens assign c union to union" do
-    run("
+    expect(run("
       lib LibFoo
         union Bar
           x : Int32
@@ -65,7 +65,7 @@ describe "Code gen: c union" do
       else
         1
       end
-      ").to_i.should eq(10)
+      ").to_i).to eq(10)
   end
 
   it "builds union setter with fun type" do
@@ -84,7 +84,7 @@ describe "Code gen: c union" do
   end
 
   it "does to_s" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       lib LibNVG
@@ -95,6 +95,6 @@ describe "Code gen: c union" do
 
       color = LibNVG::Color.new
       color.to_s
-      )).to_string.should eq("LibNVG::Color()")
+      )).to_string).to eq("LibNVG::Color()")
   end
 end

--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -2,19 +2,19 @@ require "../../spec_helper"
 
 describe "Code gen: case" do
   it "codegens case with one condition" do
-    run("require \"object\"; case 1; when 1; 2; else; 3; end").to_i.should eq(2)
+    expect(run("require \"object\"; case 1; when 1; 2; else; 3; end").to_i).to eq(2)
   end
 
   it "codegens case with two conditions" do
-    run("require \"object\"; case 1; when 0, 1; 2; else; 3; end").to_i.should eq(2)
+    expect(run("require \"object\"; case 1; when 0, 1; 2; else; 3; end").to_i).to eq(2)
   end
 
   it "codegens case with else" do
-    run("require \"object\"; case 1; when 0; 2; else; 3; end").to_i.should eq(3)
+    expect(run("require \"object\"; case 1; when 0; 2; else; 3; end").to_i).to eq(3)
   end
 
   it "codegens case that always returns" do
-    run("
+    expect(run("
       require \"object\"
       def foo
         if true
@@ -27,11 +27,11 @@ describe "Code gen: case" do
       end
 
       foo
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "codegens case when cond is a call" do
-    run("
+    expect(run("
       require \"object\"
 
       $a = 0
@@ -48,11 +48,11 @@ describe "Code gen: case" do
       else
         3
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens case with class" do
-    run("
+    expect(run("
       require \"nil\"
       struct Int32
         def foo
@@ -67,11 +67,11 @@ describe "Code gen: case" do
       when Char
         a.ord
       end.to_i
-      ").to_i.should eq(-1)
+      ").to_i).to eq(-1)
   end
 
   it "codegens value-less case" do
-    run("
+    expect(run("
       case
       when 1 == 2
         1
@@ -80,6 +80,6 @@ describe "Code gen: case" do
       else
         3
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: cast" do
   it "allows casting object to pointer and back" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -16,31 +16,31 @@ describe "Code gen: cast" do
       p = f as Void*
       f = p as Foo
       f.x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts from int to int" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1
       b = a as Int32
       b.abs
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts from union to single type" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 || 'a'
       b = a as Int32
       b.abs
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts from union to single type raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 || 'a'
@@ -50,21 +50,21 @@ describe "Code gen: cast" do
       rescue ex
         ex.message == "cast to Char failed"
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts from union to another union" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 || 1.5 || 'a'
       b = a as Int32 | Float64
       b.abs.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts from union to another union raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 || 1.5 || 'a'
@@ -74,11 +74,11 @@ describe "Code gen: cast" do
       rescue ex
         ex.message == "cast to (Float64 | Char) failed"
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts from virtual to single type" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class CastSpecFoo
@@ -96,11 +96,11 @@ describe "Code gen: cast" do
       a = CastSpecBar.new || CastSpecFoo.new || CastSpecBaz.new
       b = a as CastSpecBar
       b.bar
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts from virtual to single type raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class CastSpecFoo
@@ -122,20 +122,20 @@ describe "Code gen: cast" do
       rescue ex
         ex.message == "cast to CastSpecBaz failed"
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts from pointer to pointer" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1_i64
       (pointerof(a) as Int32*).value
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts to module" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       module CastSpecMoo
@@ -165,21 +165,21 @@ describe "Code gen: cast" do
       a = CastSpecBar.new || CastSpecFoo.new || CastSpecBaz.new || CastSpecBan.new
       m = a as CastSpecMoo
       m.moo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "casts from nilable to nil" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 == 2 ? Reference.new : nil
       c = a as Nil
       c == nil
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts from nilable to nil raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 == 1 ? Reference.new : nil
@@ -189,21 +189,21 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.includes? "cast to Nil failed"
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts from nilable to reference" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 == 1 ? Reference.new : nil
       c = a as Reference
       c == nil
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "casts from nilable to reference raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 1 == 2 ? Reference.new : nil
@@ -213,11 +213,11 @@ describe "Code gen: cast" do
       rescue ex
         ex.message == "cast to Reference failed"
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "casts to base class making it virtual" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo
           1
@@ -233,47 +233,47 @@ describe "Code gen: cast" do
       bar = Bar.new
       x = (bar as Foo).foo
       x.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "casts to bigger union" do
-    run(%(
+    expect(run(%(
       x = 1.5 as Int32 | Float64
       x.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "allows casting nil to Void*" do
-    run(%(
+    expect(run(%(
       (nil as Void*).address
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "allows casting nilable type to Void* (1)" do
-    run(%(
+    expect(run(%(
       a = 1 == 1 ? Reference.new : nil
       (a as Void*).address
-      )).to_i.should_not eq(0)
+      )).to_i).to_not eq(0)
   end
 
   it "allows casting nilable type to Void* (2)" do
-    run(%(
+    expect(run(%(
       a = 1 == 2 ? Reference.new : nil
       (a as Void*).address
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "allows casting nilable type to Void* (3)" do
-    run(%(
+    expect(run(%(
       class Foo
       end
       a = 1 == 1 ? Reference.new : (1 == 2 ? Foo.new : nil)
       (a as Void*).address
-      )).to_i.should_not eq(0)
+      )).to_i).to_not eq(0)
   end
 
   it "errors if casting to a non-allocated type" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -292,6 +292,6 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.includes?("can't cast to Baz because it was never instantiated")
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -163,10 +163,11 @@ describe "Code gen: class" do
       ").to_i).to eq(2)
   end
 
-  # it "gets object_id of class" do
-  #   program = Program.new
-  expect()#   program.run("Reference.object_id").to_i).to eq(program.reference.metaclass.type_id)
-  # end
+  # FIXME: figure out why it is commented but not pending
+  #it "gets object_id of class" do
+  #  program = Program.new
+  #  expect(program.run("Reference.object_id").to_i).to eq(program.reference.metaclass.type_id)
+  #end
 
   it "calls method on Class class" do
     expect(run("

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -2,23 +2,23 @@ require "../../spec_helper"
 
 describe "Code gen: class" do
   it "codegens instace method with allocate" do
-    run("class Foo; def coco; 1; end; end; Foo.allocate.coco").to_i.should eq(1)
+    expect(run("class Foo; def coco; 1; end; end; Foo.allocate.coco").to_i).to eq(1)
   end
 
   it "codegens instace method with new and instance var" do
-    run("class Foo; def initialize; @coco = 2; end; def coco; @coco = 1; @coco; end; end; f = Foo.new; f.coco").to_i.should eq(1)
+    expect(run("class Foo; def initialize; @coco = 2; end; def coco; @coco = 1; @coco; end; end; f = Foo.new; f.coco").to_i).to eq(1)
   end
 
   it "codegens instace method with new" do
-    run("class Foo; def coco; 1; end; end; Foo.new.coco").to_i.should eq(1)
+    expect(run("class Foo; def coco; 1; end; end; Foo.new.coco").to_i).to eq(1)
   end
 
   it "codegens call to same instance" do
-    run("class Foo; def foo; 1; end; def bar; foo; end; end; Foo.new.bar").to_i.should eq(1)
+    expect(run("class Foo; def foo; 1; end; def bar; foo; end; end; Foo.new.bar").to_i).to eq(1)
   end
 
   it "codegens instance var" do
-    run("
+    expect(run("
       class Foo
         def initialize(@coco)
         end
@@ -30,7 +30,7 @@ describe "Code gen: class" do
       f = Foo.new(2)
       g = Foo.new(40)
       f.coco + g.coco
-      ").to_i.should eq(42)
+      ").to_i).to eq(42)
   end
 
   it "codegens recursive type" do
@@ -46,7 +46,7 @@ describe "Code gen: class" do
   end
 
   it "codegens method call of instance var" do
-    run("
+    expect(run("
       class List
         def initialize
           @last = 0
@@ -60,11 +60,11 @@ describe "Code gen: class" do
 
       l = List.new
       l.foo
-      ").to_f64.should eq(1.0)
+      ").to_f64).to eq(1.0)
   end
 
   it "codegens new which calls initialize" do
-    run("
+    expect(run("
       class Foo
         def initialize(value)
           @value = value
@@ -77,11 +77,11 @@ describe "Code gen: class" do
 
       f = Foo.new 1
       f.value
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens method from another method without obj and accesses instance vars" do
-    run("
+    expect(run("
       class Foo
         def foo
           bar
@@ -94,11 +94,11 @@ describe "Code gen: class" do
 
       f = Foo.new
       f.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens virtual call that calls another method" do
-    run("
+    expect(run("
       class Foo
         def foo
           foo2
@@ -113,11 +113,11 @@ describe "Code gen: class" do
       end
 
       Bar.new.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codgens virtual method of generic class" do
-    run("
+    expect(run("
       require \"char\"
 
       class Object
@@ -137,11 +137,11 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.foo.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "changes instance variable in method (ssa bug)" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @var = 0
@@ -160,16 +160,16 @@ describe "Code gen: class" do
 
       foo = Foo.new
       foo.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   # it "gets object_id of class" do
   #   program = Program.new
-  #   program.run("Reference.object_id").to_i.should eq(program.reference.metaclass.type_id)
+  expect()#   program.run("Reference.object_id").to_i).to eq(program.reference.metaclass.type_id)
   # end
 
   it "calls method on Class class" do
-    run("
+    expect(run("
       class Class
         def foo
           1
@@ -180,11 +180,11 @@ describe "Code gen: class" do
       end
 
       Foo.foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "uses number type var" do
-    run("
+    expect(run("
       class Foo(T)
         def self.foo
           T
@@ -192,11 +192,11 @@ describe "Code gen: class" do
       end
 
       Foo(1).foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "calls class method without self" do
-    run("
+    expect(run("
       class Foo
         def self.coco
           1
@@ -205,11 +205,11 @@ describe "Code gen: class" do
         a = coco
       end
       a
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "calls class method without self (2)" do
-    run("
+    expect(run("
       class Foo
         def self.coco
           lala
@@ -228,11 +228,11 @@ describe "Code gen: class" do
         a = coco
       end
       a
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "assigns type to reference union type" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -245,19 +245,19 @@ describe "Code gen: class" do
       f = Foo.new(Bar.new)
       f.x = Baz.new
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does to_s for class" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       Reference.to_s
-      )).to_string.should eq("Reference")
+      )).to_string).to eq("Reference")
   end
 
   it "allows fixing an instance variable's type" do
-    run(%(
+    expect(run(%(
       class Foo
         @x :: Bool
 
@@ -270,11 +270,11 @@ describe "Code gen: class" do
       end
 
       Foo.new(true).x
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "codegens initialize with instance var" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           @x
@@ -283,11 +283,11 @@ describe "Code gen: class" do
 
       Foo.new
       1
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "reads other instance var" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -295,11 +295,11 @@ describe "Code gen: class" do
 
       foo = Foo.new(1)
       foo.@x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "reads a virtual type instance var" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -310,11 +310,11 @@ describe "Code gen: class" do
 
       foo = Foo.new(1) || Bar.new(2)
       foo.@x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "runs with nil instance var" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -335,11 +335,11 @@ describe "Code gen: class" do
 
       bar = Bar.new
       bar.x.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "runs with nil instance var when inheriting" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -362,11 +362,11 @@ describe "Code gen: class" do
 
       bar = Bar.new
       bar.x.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens bug #168" do
-    run("
+    expect(run("
       class A
         def foo
           x = @x
@@ -384,11 +384,11 @@ describe "Code gen: class" do
       end
 
       B.new(A.new).foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows initializing var with constant" do
-    run(%(
+    expect(run(%(
       class Foo
         A = 1
         @x = A
@@ -399,7 +399,7 @@ describe "Code gen: class" do
       end
 
       Foo.new.x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens class method" do
@@ -421,7 +421,7 @@ describe "Code gen: class" do
   end
 
   it "allows using self in class scope" do
-    run(%(
+    expect(run(%(
       class Foo
         def self.foo
           1
@@ -431,11 +431,11 @@ describe "Code gen: class" do
       end
 
       $x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "allows using self in class scope" do
-    run(%(
+    expect(run(%(
       class Foo
         def self.foo
           1
@@ -445,7 +445,7 @@ describe "Code gen: class" do
       end
 
       $x.foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "makes .class always be a virtual type even if no subclasses" do
@@ -462,7 +462,7 @@ describe "Code gen: class" do
   end
 
   it "does to_s for virtual metaclass type (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo; end
@@ -471,11 +471,11 @@ describe "Code gen: class" do
 
       a = Foo || A || B
       a.to_s
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "does to_s for virtual metaclass type (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo; end
@@ -484,11 +484,11 @@ describe "Code gen: class" do
 
       a = A || Foo || B
       a.to_s
-      )).to_string.should eq("A")
+      )).to_string).to eq("A")
   end
 
   it "does to_s for virtual metaclass type (3)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo; end
@@ -497,11 +497,11 @@ describe "Code gen: class" do
 
       a = B || A || Foo
       a.to_s
-      )).to_string.should eq("B")
+      )).to_string).to eq("B")
   end
 
   it "does to_s for virtual metaclass type (4)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo; end
@@ -516,7 +516,7 @@ describe "Code gen: class" do
 
       t = Obj(Foo+).t
       t.to_s
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "builds generic class bug" do
@@ -562,7 +562,7 @@ describe "Code gen: class" do
   end
 
   it "gets class of virtual type" do
-    run(%(
+    expect(run(%(
       class Foo
         def self.foo
           1
@@ -577,6 +577,6 @@ describe "Code gen: class" do
 
       f = Bar.new || Foo.new
       f.class.foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Codegen: class var" do
   it "codegens class var" do
-    run("
+    expect(run("
       class Foo
         @@foo = 1
 
@@ -12,11 +12,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens class var as nil" do
-    run("
+    expect(run("
       require \"nil\"
 
       class Foo
@@ -26,11 +26,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens class var inside instance method" do
-    run("
+    expect(run("
       class Foo
         @@foo = 1
 
@@ -40,11 +40,11 @@ describe "Codegen: class var" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens class var as nil if assigned for the first time inside method" do
-    run("
+    expect(run("
       require \"nil\"
 
       class Foo
@@ -55,25 +55,25 @@ describe "Codegen: class var" do
       end
 
       Foo.foo.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens class var of program" do
-    run("
+    expect(run("
       @@foo = 1
       @@foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens class var of program as nil" do
-    run("
+    expect(run("
       require \"nil\"
       @@foo.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens class var inside module" do
-    run("
+    expect(run("
       module Foo
         @@foo = 1
 
@@ -83,11 +83,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "accesses class var from fun literal" do
-    run("
+    expect(run("
       class Foo
         @@a = 1
 
@@ -97,6 +97,6 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -2,36 +2,36 @@ require "../../spec_helper"
 
 describe "Code gen: closure" do
   it "codegens simple closure at global scope" do
-    run("
+    expect(run("
       a = 1
       foo = ->{ a }
       foo.call
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens simple closure in function" do
-    run("
+    expect(run("
       def foo
         a = 1
         ->{ a }
       end
 
       foo.call
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens simple closure in function with argument" do
-    run("
+    expect(run("
       def foo(a)
         ->{ a }
       end
 
       foo(1).call
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens simple closure in block" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -42,11 +42,11 @@ describe "Code gen: closure" do
       end
 
       f.call
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens closured nested in block" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -57,11 +57,11 @@ describe "Code gen: closure" do
         -> { a + b }
       end
       f.call
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "codegens closured nested in block with a call with a closure with same names" do
-    run("
+    expect(run("
       def foo
         a = 3
         f = -> { a }
@@ -73,11 +73,11 @@ describe "Code gen: closure" do
         -> { a + x }
       end
       f.call
-    ").to_i.should eq(4)
+    ").to_i).to eq(4)
   end
 
   it "codegens closure with block that declares same var" do
-    run("
+    expect(run("
       def foo
         a = 1
         yield a
@@ -88,11 +88,11 @@ describe "Code gen: closure" do
         -> { a + x }
       end
       f.call
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens closure with def that has an if" do
-    run("
+    expect(run("
       def foo
         yield 1 if 1
         yield 2
@@ -102,11 +102,11 @@ describe "Code gen: closure" do
         -> { x }
       end
       f.call
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens multiple nested blocks" do
-    run("
+    expect(run("
       def foo
         yield 1
         yield 2
@@ -122,11 +122,11 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(9)
+      ").to_i).to eq(9)
   end
 
   it "codegens closure with nested context without new closured vars" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -136,11 +136,11 @@ describe "Code gen: closure" do
         -> { a }
       end
       f.call
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens closure with nested context without new closured vars" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -157,11 +157,11 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens closure with nested context without new closured vars but with block arg" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -179,31 +179,31 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "unifies types of closured var" do
-    run("
+    expect(run("
       a = 1
       f = -> { a }
       a = 2.5
       f.call.to_i
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens closure with block" do
-    run("
+    expect(run("
       def foo
         yield
       end
 
       a = 1
       ->{ foo { a } }.call
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens closure with self and var" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -219,11 +219,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens closure with implicit self and var" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -239,11 +239,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens closure with instance var and var" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -255,11 +255,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens closure with instance var" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -270,11 +270,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens closure with instance var and block" do
-    run("
+    expect(run("
       def bar
         yield
       end
@@ -292,11 +292,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegen closure in instance method without self closured" do
-    run("
+    expect(run("
       class Foo
         def foo
           ->(a : Int32) { a }
@@ -304,7 +304,7 @@ describe "Code gen: closure" do
       end
 
       Foo.new.foo.call(1)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens closure inside initialize inside block with self" do
@@ -326,7 +326,7 @@ describe "Code gen: closure" do
   end
 
   it "doesn't free closure memory (bug)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo
@@ -348,57 +348,57 @@ describe "Code gen: closure" do
         a += func.call
       end
       a
-      )).to_i.should eq(1249975000_i64)
+      )).to_i).to eq(1249975000_i64)
   end
 
   it "codegens nested closure" do
-    run(%(
+    expect(run(%(
       a = 1
       ->{ ->{ a } }.call.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens super nested closure" do
-    run(%(
+    expect(run(%(
       a = 1
       ->{ ->{ -> { -> { a } } } }.call.call.call.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens nested closure with block (1)" do
-    run(%(
+    expect(run(%(
       def foo
         yield
       end
 
       a = 1
       ->{ foo { ->{ a } } }.call.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens nested closure with block (2)" do
-    run(%(
+    expect(run(%(
       def foo
         yield
       end
 
       a = 1
       ->{ ->{ foo { a } } }.call.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens nested closure with nested closured variable" do
-    run(%(
+    expect(run(%(
       a = 1
       ->{
         b = 2
         ->{ a + b }
       }.call.call
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "codegens super nested closure with nested closured variable" do
-    run(%(
+    expect(run(%(
       def foo
         yield 4
       end
@@ -419,11 +419,11 @@ describe "Code gen: closure" do
           }
         }
       }.call.call.call.call.call
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "codegens fun literal with struct" do
-    run(%(
+    expect(run(%(
       struct Foo
         def initialize(@x)
         end
@@ -437,11 +437,11 @@ describe "Code gen: closure" do
 
       obj = Foo.new(2)
       f.call(obj)
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "codegens closure with struct" do
-    run(%(
+    expect(run(%(
       struct Foo
         def initialize(@x)
         end
@@ -458,11 +458,11 @@ describe "Code gen: closure" do
 
       obj = Foo.new(2)
       f.call(obj)
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "codegens closure with self and arguments" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -478,22 +478,22 @@ describe "Code gen: closure" do
 
       f = Foo.new(1).bar
       f.call(2)
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "codegens nested closure that mentions var in both contexts" do
-    run(%(
+    expect(run(%(
       a = 1
       f = ->{
         a
         -> { a }
       }
       f.call.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "transforms block to fun literal" do
-    run("
+    expect(run("
       def foo(&block : Int32 -> Int32)
         block.call(1)
       end
@@ -502,11 +502,11 @@ describe "Code gen: closure" do
       foo do |x|
         x + a
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "transforms block to fun literal with free var" do
-    run("
+    expect(run("
       def foo(&block : Int32 -> U)
         block
       end
@@ -515,11 +515,11 @@ describe "Code gen: closure" do
       g = foo { |x| x + a }
       h = foo { |x| x.to_f + a }
       (g.call(3) + h.call(5)).to_i
-      ").to_i.should eq(10)
+      ").to_i).to eq(10)
   end
 
   it "allows passing block as fun literal to new and to initialize" do
-    run("
+    expect(run("
       class Foo
         def initialize(&block : Int32 -> Float64)
           @block = block
@@ -533,11 +533,11 @@ describe "Code gen: closure" do
       a = 1
       foo = Foo.new { |x| x.to_f + a }
       foo.block.call(1).to_i
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "allows giving less block args when transforming block to fun literal" do
-    run("
+    expect(run("
       def foo(&block : Int32 -> U)
         block.call(1)
       end
@@ -547,11 +547,11 @@ describe "Code gen: closure" do
         1.5 + a
       end
       v.to_i
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "allows passing fun literal to def that captures block with &" do
-    run("
+    expect(run("
       def foo(&block : Int32 -> Int32)
         block.call(1)
       end
@@ -559,11 +559,11 @@ describe "Code gen: closure" do
       a = 1
       f = ->(x : Int32) { x + a }
       foo &f
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "allows mixing yield and block.call" do
-    run(%(
+    expect(run(%(
       def foo(&block : Int32 ->)
         yield 1
         block.call 2
@@ -572,11 +572,11 @@ describe "Code gen: closure" do
       a = 0
       foo { |x| a += x }
       a
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "closures struct self" do
-    run(%(
+    expect(run(%(
       struct Foo
         def initialize(@x)
         end
@@ -587,6 +587,6 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -2,15 +2,15 @@ require "../../spec_helper"
 
 describe "Codegen: const" do
   it "define a constant" do
-    run("A = 1; A").to_i.should eq(1)
+    expect(run("A = 1; A").to_i).to eq(1)
   end
 
   it "support nested constant" do
-    run("class B; A = 1; end; B::A").to_i.should eq(1)
+    expect(run("class B; A = 1; end; B::A").to_i).to eq(1)
   end
 
   it "support constant inside a def" do
-    run("
+    expect(run("
       class Foo
         A = 1
 
@@ -20,11 +20,11 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "finds nearest constant first" do
-    run("
+    expect(run("
       A = 1
 
       class Foo
@@ -36,11 +36,11 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_f32.should eq(2.5)
+    ").to_f32).to eq(2.5)
   end
 
   it "allows constants with same name" do
-    run("
+    expect(run("
       A = 1
 
       class Foo
@@ -53,18 +53,18 @@ describe "Codegen: const" do
 
       A
       Foo.new.foo
-    ").to_f32.should eq(2.5)
+    ").to_f32).to eq(2.5)
   end
 
   it "constants with expression" do
-    run("
+    expect(run("
       A = 1 + 1
       A
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "finds global constant" do
-    run("
+    expect(run("
       A = 1
 
       class Foo
@@ -74,27 +74,27 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "define a constant in lib" do
-    run("lib LibFoo; A = 1; end; LibFoo::A").to_i.should eq(1)
+    expect(run("lib LibFoo; A = 1; end; LibFoo::A").to_i).to eq(1)
   end
 
   it "invokes block in const" do
-    run("require \"prelude\"; A = [\"1\"].map { |x| x.to_i }; A[0]").to_i.should eq(1)
+    expect(run("require \"prelude\"; A = [\"1\"].map { |x| x.to_i }; A[0]").to_i).to eq(1)
   end
 
   it "declare constants in right order" do
-    run(%(
+    expect(run(%(
       A = 1 + 1
       B = true ? A : 0
       B
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "uses correct types lookup" do
-    run("
+    expect(run("
       module A
         class B
           def foo
@@ -110,11 +110,11 @@ describe "Codegen: const" do
       end
 
       foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens variable assignment in const" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -134,11 +134,11 @@ describe "Codegen: const" do
       end
 
       foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "declaring var" do
-    run("
+    expect(run("
       BAR = begin
         a = 1
         while 1 == 2
@@ -153,11 +153,11 @@ describe "Codegen: const" do
       end
 
       Foo.new.compile
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "initialize const that might raise an exception" do
-    run("
+    expect(run("
       require \"prelude\"
       CONST = (raise \"OH NO\" if 1 == 2)
 
@@ -167,11 +167,11 @@ describe "Codegen: const" do
       end
 
       doit.nil?
-    ").to_b.should be_true
+    ").to_b).to be_true
   end
 
   it "allows implicit self in constant, called from another class (bug)" do
-    run("
+    expect(run("
       module Foo
         def self.foo
           1
@@ -187,11 +187,11 @@ describe "Codegen: const" do
       end
 
       Bar.new.bar
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens two consts with same variable name" do
-    run("
+    expect(run("
       A = begin
             a = 1
           end
@@ -201,19 +201,19 @@ describe "Codegen: const" do
           end
 
       (A + B).to_i
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "works with const initialized after global variable" do
-    run(%(
+    expect(run(%(
       $a = 1
       COCO = $a
       COCO
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "works with variable declared inside if" do
-    run(%(
+    expect(run(%(
       FOO = begin
         if 1 == 2
           x = 3
@@ -223,11 +223,11 @@ describe "Codegen: const" do
         x
       end
       FOO
-      )).to_i.should eq(4)
+      )).to_i).to eq(4)
   end
 
   it "codegens constant that refers to another constant that is a struct" do
-    run(%(
+    expect(run(%(
       struct Foo
         X = Foo.new(1)
         Y = X
@@ -241,11 +241,11 @@ describe "Codegen: const" do
       end
 
       Foo::Y.value
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens constant that is declared later because of virtual dispatch" do
-    run(%(
+    expect(run(%(
       class Base
         def base
         end
@@ -268,6 +268,6 @@ describe "Codegen: const" do
       end
 
       MyBase.new.base
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/declare_var_spec.cr
+++ b/spec/compiler/codegen/declare_var_spec.cr
@@ -7,11 +7,11 @@ describe "Code gen: declare var" do
   end
 
   it "codegens declare var and changes it" do
-    run("a :: Int32; while a != 10; a = 10; end; a").to_i.should eq(10)
+    expect(run("a :: Int32; while a != 10; a = 10; end; a").to_i).to eq(10)
   end
 
   it "codegens declare instance var" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @x :: Int32
@@ -23,7 +23,7 @@ describe "Code gen: declare var" do
       end
 
       Foo.new.x
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens declare instance var with static array type" do
@@ -44,7 +44,7 @@ describe "Code gen: declare var" do
   end
 
   it "codegens initialize instance var" do
-    run("
+    expect(run("
       class Foo
         @x = 1
 
@@ -54,11 +54,11 @@ describe "Code gen: declare var" do
       end
 
       Foo.new.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens initialize instance var of superclass" do
-    run("
+    expect(run("
       class Foo
         @x = 1
 
@@ -71,11 +71,11 @@ describe "Code gen: declare var" do
       end
 
       Bar.new.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens initialize instance var with var declaration" do
-    run("
+    expect(run("
       class Foo
         @x = begin
           a = 1
@@ -88,11 +88,11 @@ describe "Code gen: declare var" do
       end
 
       Foo.new.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "doesn't break on inherited declared var (#390)" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           # @x :: Int32
@@ -118,6 +118,6 @@ describe "Code gen: declare var" do
 
       bar = Bar.new
       bar.x + bar.y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 end

--- a/spec/compiler/codegen/def_default_value_spec.cr
+++ b/spec/compiler/codegen/def_default_value_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: def with default value" do
   it "codegens def with one default value" do
-    run(%(
+    expect(run(%(
       def foo(x = 1)
         x
       end
 
       foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens def new with one default value" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x = 1)
         end
@@ -23,11 +23,11 @@ describe "Code gen: def with default value" do
       end
 
       Foo.new.x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "considers first the one with more arguments" do
-    run(%(
+    expect(run(%(
       def foo(x, y = 1)
         1
       end
@@ -37,11 +37,11 @@ describe "Code gen: def with default value" do
       end
 
       foo 1, "hello"
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "considers first the one with a restriction" do
-    run(%(
+    expect(run(%(
       def foo(x : String, y = "")
         1
       end
@@ -51,7 +51,7 @@ describe "Code gen: def with default value" do
       end
 
       foo "hello"
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "doesn't mix types of instance vars with initialize and new" do

--- a/spec/compiler/codegen/def_spec.cr
+++ b/spec/compiler/codegen/def_spec.cr
@@ -6,32 +6,32 @@ describe "Code gen: def" do
   end
 
   it "codegens call without args" do
-    run("def foo; 1; end; 2; foo").to_i.should eq(1)
+    expect(run("def foo; 1; end; 2; foo").to_i).to eq(1)
   end
 
   it "call functions defined in any order" do
-    run("def foo; bar; end; def bar; 1; end; foo").to_i.should eq(1)
+    expect(run("def foo; bar; end; def bar; 1; end; foo").to_i).to eq(1)
   end
 
   it "codegens call with args" do
-    run("def foo(x); x; end; foo 1").to_i.should eq(1)
+    expect(run("def foo(x); x; end; foo 1").to_i).to eq(1)
   end
 
   it "call external function 'putchar'" do
-    run("
+    expect(run("
       lib LibC
         fun putchar(c : Char) : Char
       end
       LibC.putchar '\\0'
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "uses self" do
-    run("struct Int; def foo; self + 1; end; end; 3.foo").to_i.should eq(4)
+    expect(run("struct Int; def foo; self + 1; end; end; 3.foo").to_i).to eq(4)
   end
 
   it "uses var after external" do
-    run("
+    expect(run("
       lib LibC
         fun putchar(c : Char) : Char
       end
@@ -39,11 +39,11 @@ describe "Code gen: def" do
       a = 1
       LibC.putchar '\\0'
       a
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows to change argument values" do
-    run("def foo(x); x = 1; x; end; foo(2)").to_i.should eq(1)
+    expect(run("def foo(x); x = 1; x; end; foo(2)").to_i).to eq(1)
   end
 
   it "runs empty def" do
@@ -55,7 +55,7 @@ describe "Code gen: def" do
   end
 
   it "unifies all calls to same def" do
-    run("
+    expect(run("
       require \"prelude\"
 
       def raise(msg)
@@ -83,7 +83,7 @@ describe "Code gen: def" do
       hash = Hash2.new
       hash[1] = 2
       hash[1]
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens recursive type with union" do
@@ -159,27 +159,27 @@ describe "Code gen: def" do
   end
 
   it "codegens with and witout default arguments" do
-    run("
+    expect(run("
       def foo(x = 1)
         x + 1
       end
 
       foo(2) + foo
-      ").to_i.should eq(5)
+      ").to_i).to eq(5)
   end
 
   it "codegens with and witout many default arguments" do
-    run("
+    expect(run("
       def foo(x = 1, y = 2, z = 3)
         x + y + z
       end
 
       foo + foo(9) + foo(3, 4) + foo(6, 3, 1)
-      ").to_i.should eq(40)
+      ").to_i).to eq(40)
   end
 
   it "codegens with interesting default argument" do
-    run("
+    expect(run("
       class Foo
         def foo(x = self.bar)
           x + 1
@@ -193,11 +193,11 @@ describe "Code gen: def" do
       f = Foo.new
 
       f.foo(2) + f.foo
-      ").to_i.should eq(5)
+      ").to_i).to eq(5)
   end
 
   it "codegens dispatch on static method" do
-    run("
+    expect(run("
       def Object.foo(x)
         1
       end
@@ -205,11 +205,11 @@ describe "Code gen: def" do
       a = 1
       a = 1.5
       Object.foo(a)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "use target def type as return type" do
-    run("
+    expect(run("
       require \"nil\"
       require \"value\"
       require \"object\"
@@ -221,7 +221,7 @@ describe "Code gen: def" do
       end
 
       foo.nil? ? 1 : 0
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens recursive nasty code" do
@@ -259,7 +259,7 @@ describe "Code gen: def" do
   end
 
   it "looks up matches in super classes and merges them with subclasses" do
-    run("
+    expect(run("
       class Foo
         def foo(other)
           1
@@ -274,11 +274,11 @@ describe "Code gen: def" do
 
       bar1 = Bar.new
       bar1.foo(1 || 1.5)
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens def which changes type of arg" do
-    run("
+    expect(run("
       def foo(x)
         while x >= 0
           x = -0.5
@@ -287,11 +287,11 @@ describe "Code gen: def" do
       end
 
       foo(2).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens return nil when nilable type (1)" do
-    run("
+    expect(run("
       struct Nil
         def nil?
           true
@@ -310,11 +310,11 @@ describe "Code gen: def" do
       end
 
       foo.nil?
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "codegens return nil when nilable type (2)" do
-    run("
+    expect(run("
       struct Nil
         def nil?
           true
@@ -333,22 +333,22 @@ describe "Code gen: def" do
       end
 
       foo.nil?
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "codegens dispatch with nilable reference union type" do
-    run("
+    expect(run("
       struct Nil; def object_id; 0_u64; end; end
       class Foo; end
       class Bar; end
 
       f = 1 == 1 ? nil : (Foo.new || Bar.new)
       f.object_id
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens dispatch without obj, bug 1" do
-    run("
+    expect(run("
       def coco(x : Int32)
         2
       end
@@ -364,11 +364,11 @@ describe "Code gen: def" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens dispatch without obj, bug 1" do
-    run("
+    expect(run("
       def coco(x : Int32)
         2
       end
@@ -387,11 +387,11 @@ describe "Code gen: def" do
       end
 
       (Foo.new || Bar.new).foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens dispatch with single def when discarding unallocated ones (1)" do
-    run("
+    expect(run("
       class Foo
         def bar
           1
@@ -406,11 +406,11 @@ describe "Code gen: def" do
 
       foo = 1 == 1 ? Foo.new : (Pointer(Int32).new(0_u64) as Bar)
       foo.bar
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens dispatch with single def when discarding unallocated ones (2)" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -427,20 +427,20 @@ describe "Code gen: def" do
 
       foo = 1 == 1 ? Foo.new : (Pointer(Int32).new(0_u64) as Bar)
       something(foo)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens bug #119" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       x = {} of String => Hash(String, String)
       x.has_key?("a")
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "puts union before single type in matches preferences" do
-    run("
+    expect(run("
       abstract class Foo
       end
 
@@ -460,11 +460,11 @@ describe "Code gen: def" do
 
       node = Baz.new || Bar.new
       foo(node)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "dispatches on virtual type implementing generic module (related to bug #165)" do
-    run("
+    expect(run("
       module Moo(T)
         def moo
           1
@@ -491,11 +491,11 @@ describe "Code gen: def" do
 
       foo = Bar.new || Baz.new
       method(foo)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "fixes #230: include original owner in mangled def" do
-    run(%(
+    expect(run(%(
       class Base
         def some(other : self)
           false
@@ -518,6 +518,6 @@ describe "Code gen: def" do
 
       c = Foo(Int32).new
       c.some(c)
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/enum_spec.cr
+++ b/spec/compiler/codegen/enum_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: enum" do
   it "codegens enum" do
-    run(%(
+    expect(run(%(
       enum Foo
         A = 1
       end
 
       Foo::A
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens enum without explicit value" do
-    run(%(
+    expect(run(%(
       enum Foo
         A
         B
@@ -20,43 +20,43 @@ describe "Code gen: enum" do
       end
 
       Foo::C
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "codegens enum value" do
-    run(%(
+    expect(run(%(
       enum Foo
         A = 1
       end
 
       Foo::A.value
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "creates enum from value" do
-    run(%(
+    expect(run(%(
       enum Foo
         A
         B
       end
 
       Foo.new(1).value
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens enum bitflags (1)" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
       end
 
       Foo::A
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens enum bitflags (2)" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
@@ -64,11 +64,11 @@ describe "Code gen: enum" do
       end
 
       Foo::B
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "codegens enum bitflags (4)" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
@@ -77,22 +77,22 @@ describe "Code gen: enum" do
       end
 
       Foo::C
-      )).to_i.should eq(4)
+      )).to_i).to eq(4)
   end
 
   it "codegens enum bitflags None" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
       end
 
       Foo::None
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "codegens enum bitflags All" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
@@ -101,11 +101,11 @@ describe "Code gen: enum" do
       end
 
       Foo::All
-      )).to_i.should eq(1 + 2 + 4)
+      )).to_i).to eq(1 + 2 + 4)
   end
 
   it "codegens enum None redefined" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
@@ -113,11 +113,11 @@ describe "Code gen: enum" do
       end
 
       Foo::None
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "codegens enum All redefined" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Foo
         A
@@ -125,11 +125,11 @@ describe "Code gen: enum" do
       end
 
       Foo::All
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "allows class vars in enum" do
-    run(%(
+    expect(run(%(
       enum Foo
         A
 
@@ -141,6 +141,6 @@ describe "Code gen: enum" do
       end
 
       Foo.class_var
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: exception" do
   it "codegens rescue specific leaf exception" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo < Exception
@@ -22,11 +22,11 @@ describe "Code gen: exception" do
       rescue ex : Foo
         bar(ex)
       end
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens exception handler with return" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo
@@ -38,11 +38,11 @@ describe "Code gen: exception" do
       end
 
       foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "does ensure after rescue which returns (#171)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       $x = 0
@@ -59,11 +59,11 @@ describe "Code gen: exception" do
       foo
 
       $x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "executes body if nothing raised (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       y = 1
@@ -73,11 +73,11 @@ describe "Code gen: exception" do
             y = 10
           end
       x + y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "executes rescue if something is raised conditionally" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       y = 1
@@ -89,11 +89,11 @@ describe "Code gen: exception" do
             y = 4
           end
       x + y
-      )).to_i.should eq(8)
+      )).to_i).to eq(8)
   end
 
   it "executes rescue if something is raised unconditionally" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       y = 1
@@ -105,11 +105,11 @@ describe "Code gen: exception" do
             y = 3
           end
       x + y
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "can result into union (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       x = begin
@@ -118,11 +118,11 @@ describe "Code gen: exception" do
             2.1
           end
       x.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "can result into union (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       y = begin
@@ -131,11 +131,11 @@ describe "Code gen: exception" do
             2.1
           end
       y.to_i
-    )).to_i.should eq(2)
+    )).to_i).to eq(2)
   end
 
   it "handles nested exceptions" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -151,11 +151,11 @@ describe "Code gen: exception" do
           end
 
       a + b
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "executes ensure when no exception is raised (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -167,11 +167,11 @@ describe "Code gen: exception" do
             a = 10
           end
       a
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "executes ensure when no exception is raised (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -183,11 +183,11 @@ describe "Code gen: exception" do
             a = 10
           end
       b
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "executes ensure when exception is raised (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -200,11 +200,11 @@ describe "Code gen: exception" do
             a = 2
           end
       a
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "executes ensure when exception is raised (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -217,11 +217,11 @@ describe "Code gen: exception" do
             a = 2
           end
       b
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "executes ensure when exception is unhandled (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -240,11 +240,11 @@ describe "Code gen: exception" do
             4
           end
       a
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "executes ensure when exception is unhandled (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -263,11 +263,11 @@ describe "Code gen: exception" do
             4
           end
       b
-      )).to_i.should eq(4)
+      )).to_i).to eq(4)
   end
 
   it "ensure without rescue" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       a = 0
@@ -281,11 +281,11 @@ describe "Code gen: exception" do
       end
 
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "executes ensure when the main block returns" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo(x)
@@ -298,11 +298,11 @@ describe "Code gen: exception" do
 
       x = 0
       foo(pointerof(x)).to_i
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "executes ensure when the main block returns" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo(x)
@@ -316,11 +316,11 @@ describe "Code gen: exception" do
       x = 0
       foo(pointerof(x))
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "executes ensure when the main block yields and returns" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo2(x)
@@ -340,11 +340,11 @@ describe "Code gen: exception" do
       x = 0
       bar2(pointerof(x))
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "rescues with type" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -359,11 +359,11 @@ describe "Code gen: exception" do
           end
 
       a
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "rescues with types defaults to generic rescue" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -380,11 +380,11 @@ describe "Code gen: exception" do
           end
 
       a
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "handles exception in outer block (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -403,11 +403,11 @@ describe "Code gen: exception" do
           end
 
       x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "handles exception in outer block (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -426,11 +426,11 @@ describe "Code gen: exception" do
           end
 
       p
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "handles subclass" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -444,11 +444,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "handle multiple exception types (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -461,11 +461,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "handle multiple exception types (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -478,11 +478,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "receives exception object" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception
@@ -499,11 +499,11 @@ describe "Code gen: exception" do
       end
 
       x
-      )).to_string.should eq("Ex1")
+      )).to_string).to eq("Ex1")
   end
 
   it "executes else if no exception is raised (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       x = 1
@@ -514,11 +514,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "executes else if no exception is raised (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       x = 1
@@ -529,11 +529,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "doesn't execute else if exception is raised (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -547,11 +547,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "doesn't execute else if exception is raised (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -565,11 +565,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "doesn't execute else if exception is raised conditionally (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -583,11 +583,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "doesn't execute else if exception is raised conditionally (2)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Ex1 < Exception; end
@@ -601,11 +601,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "handle exception raised by fun literal" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       x = 0
@@ -616,7 +616,7 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens issue #118 (1)" do
@@ -647,7 +647,7 @@ describe "Code gen: exception" do
   end
 
   it "captures exception thrown from proc" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo
@@ -661,11 +661,11 @@ describe "Code gen: exception" do
         a = 2
       end
       a
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "uses exception after rescue" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       begin
@@ -673,6 +673,6 @@ describe "Code gen: exception" do
       rescue ex
       end
       ex.not_nil!.message
-      )).to_string.should eq("OH NO")
+      )).to_string).to eq("OH NO")
   end
 end

--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -2,30 +2,30 @@ require "../../spec_helper"
 
 describe "Code gen: fun" do
   it "call simple fun literal" do
-    run("x = -> { 1 }; x.call").to_i.should eq(1)
+    expect(run("x = -> { 1 }; x.call").to_i).to eq(1)
   end
 
   it "call fun literal with arguments" do
-    run("f = ->(x : Int32) { x + 1 }; f.call(41)").to_i.should eq(42)
+    expect(run("f = ->(x : Int32) { x + 1 }; f.call(41)").to_i).to eq(42)
   end
 
   it "call fun pointer" do
-    run("def foo; 1; end; x = ->foo; x.call").to_i.should eq(1)
+    expect(run("def foo; 1; end; x = ->foo; x.call").to_i).to eq(1)
   end
 
   it "call fun pointer with args" do
-    run("
+    expect(run("
       def foo(x, y)
         x + y
       end
 
       f = ->foo(Int32, Int32)
       f.call(1, 2)
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "call fun pointer of instance method" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           @x = 1
@@ -39,11 +39,11 @@ describe "Code gen: fun" do
       foo = Foo.new
       f = ->foo.coco
       f.call
-    )).to_i.should eq(1)
+    )).to_i).to eq(1)
   end
 
   it "call fun pointer of instance method that raises" do
-    run(%(
+    expect(run(%(
       require "prelude"
       class Foo
         def coco
@@ -54,7 +54,7 @@ describe "Code gen: fun" do
       foo = Foo.new
       f = ->foo.coco
       f.call rescue 1
-    )).to_i.should eq(1)
+    )).to_i).to eq(1)
   end
 
   it "codegens fun with another var" do
@@ -71,7 +71,7 @@ describe "Code gen: fun" do
   end
 
   it "codegens fun that returns a virtual type" do
-    run("
+    expect(run("
       class Foo
         def coco; 1; end
       end
@@ -82,18 +82,18 @@ describe "Code gen: fun" do
 
       x = -> { Foo.new || Bar.new }
       x.call.coco
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens fun that accepts a union and is called with a single type" do
-    run("
+    expect(run("
       f = ->(x : Int32 | Float64) { x + 1 }
       f.call(1).to_i
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "makes sure that fun pointer is transformed after type inference" do
-    run("
+    expect(run("
       require \"prelude\"
 
       class B
@@ -117,11 +117,11 @@ describe "Code gen: fun" do
       c = ->_on_(A*)
       a = A.new
       c.call(pointerof(a))
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "binds function pointer to associated call" do
-    run("
+    expect(run("
       class A
         def initialize(@e : Int32)
         end
@@ -140,26 +140,26 @@ describe "Code gen: fun" do
       a.on_something
 
       c.call(pointerof(a))
-      ").to_i.should eq(12)
+      ").to_i).to eq(12)
   end
 
   it "call simple fun literal with return" do
-    run("x = -> { return 1 }; x.call").to_i.should eq(1)
+    expect(run("x = -> { return 1 }; x.call").to_i).to eq(1)
   end
 
   it "calls fun pointer with union (passed by value) arg" do
-    run("
+    expect(run("
       struct Number
         def abs; self; end
       end
 
       f = ->(x : Int32 | Float64) { x.abs }
       f.call(1 || 1.5).to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows passing fun type to C automatically" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       lib LibC
@@ -173,11 +173,11 @@ describe "Code gen: fun" do
         a.value <=> b.value
       })
       ary[0]
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "allows fun pointer where self is a class" do
-    run("
+    expect(run("
       class A
         def self.bla
           1
@@ -186,11 +186,11 @@ describe "Code gen: fun" do
 
       f = ->A.bla
       f.call
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens fun literal hard type inference (1)" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -213,11 +213,11 @@ describe "Code gen: fun" do
       bar
 
       1
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "automatically casts fun that returns something to fun that returns void" do
-    run("
+    expect(run("
       $a = 0
 
       def foo(x : ->)
@@ -227,11 +227,11 @@ describe "Code gen: fun" do
       foo ->{ $a = 1 }
 
       $a
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows fun type of enum type" do
-    run("
+    expect(run("
       lib LibFoo
         enum MyEnum
           X = 1
@@ -241,11 +241,11 @@ describe "Code gen: fun" do
       ->(x : LibFoo::MyEnum) {
         x
       }.call(LibFoo::MyEnum::X)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows fun type of enum type with base type" do
-    run("
+    expect(run("
       lib LibFoo
         enum MyEnum : UInt16
           X = 1
@@ -255,33 +255,33 @@ describe "Code gen: fun" do
       ->(x : LibFoo::MyEnum) {
         x
       }.call(LibFoo::MyEnum::X)
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens nilable fun type (1)" do
-    run("
+    expect(run("
       a = 1 == 2 ? nil : ->{ 3 }
       if a
         a.call
       else
         4
       end
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens nilable fun type (2)" do
-    run("
+    expect(run("
       a = 1 == 1 ? nil : ->{ 3 }
       if a
         a.call
       else
         4
       end
-      ").to_i.should eq(4)
+      ").to_i).to eq(4)
   end
 
   it "codegens nilable fun type dispatch (1)" do
-    run("
+    expect(run("
       def foo(x : -> U)
         x.call
       end
@@ -292,11 +292,11 @@ describe "Code gen: fun" do
 
       a = 1 == 1 ? (->{ 3 }) : nil
       foo(a)
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens nilable fun type dispatch (2)" do
-    run("
+    expect(run("
       def foo(x : -> U)
         x.call
       end
@@ -307,7 +307,7 @@ describe "Code gen: fun" do
 
       a = 1 == 1 ? nil : ->{ 3 }
       foo(a)
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "builds fun type from fun" do
@@ -335,7 +335,7 @@ describe "Code gen: fun" do
   end
 
   it "assigns nil and fun to nilable fun type" do
-    run("
+    expect(run("
       class Foo
         def initialize
         end
@@ -357,11 +357,11 @@ describe "Code gen: fun" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows invoking fun literal with smaller type" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -372,21 +372,21 @@ describe "Code gen: fun" do
         x
       }
       f.call(1).to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does new on fun type" do
-    run("
+    expect(run("
       alias F = Int32 -> Int32
 
       a = 2
       f = F.new { |x| x + a }
       f.call(1)
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "allows invoking a function with a subtype" do
-    run(%(
+    expect(run(%(
       class Foo
         def x
           1
@@ -401,11 +401,11 @@ describe "Code gen: fun" do
 
       f = ->(foo : Foo) { foo.x }
       f.call Bar.new
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "allows invoking a function with a subtype when defined as block spec" do
-    run(%(
+    expect(run(%(
       class Foo
         def x
           1
@@ -424,11 +424,11 @@ describe "Code gen: fun" do
 
       f = func { |foo| foo.x }
       f.call Bar.new
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "allows redefining fun" do
-    run(%(
+    expect(run(%(
       fun foo : Int32
         1
       end
@@ -438,11 +438,11 @@ describe "Code gen: fun" do
       end
 
       foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "passes block to another function (bug: mangling of both methods was the same)" do
-    run(%(
+    expect(run(%(
       def foo(&block : ->)
         foo(block)
       end
@@ -452,21 +452,21 @@ describe "Code gen: fun" do
       end
 
       foo { }
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens fun with union type that returns itself" do
-    run(%(
+    expect(run(%(
       a = 1 || 1.5
 
       foo = ->(x : Int32 | Float64) { x }
       foo.call(a)
       foo.call(a).to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens issue with missing byval in fun literal inside struct" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       struct Params
@@ -480,11 +480,11 @@ describe "Code gen: fun" do
       end
 
       Params.new.foo
-      )).to_string.should eq("bar")
+      )).to_string).to eq("bar")
   end
 
   it "codegens fun that references struct (bug)" do
-    run(%(
+    expect(run(%(
       class Context
         def initialize
           @x = Reference.new
@@ -513,7 +513,7 @@ describe "Code gen: fun" do
         Foo.new
       end
       context.run
-      )).to_i.should_not eq(42)
+      )).to_i).to_not eq(42)
   end
 
   it "codegens captured block that returns tuple" do
@@ -530,15 +530,15 @@ describe "Code gen: fun" do
   end
 
   it "allows using fun arg name shadowing local variable" do
-    run(%(
+    expect(run(%(
       a = 1
       f = ->(a : String) { }
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens fun that accepts array of type" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -561,7 +561,7 @@ describe "Code gen: fun" do
       elems = [Bar.new, Foo.new]
       bar = block.call elems
       bar.foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "gets proc to lib fun (#504)" do

--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: generic class type" do
   it "codegens inherited generic class instance var" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def initialize(@x : T)
         end
@@ -16,11 +16,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar.new(1).x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "creates pointer of unspecified generic type" do
-    run(%(
+    expect(run(%(
       struct Int32
         def to_i
           self
@@ -46,11 +46,11 @@ describe "Code gen: generic class type" do
       p.value = Foo.new(1)
       p.value = Foo.new('a')
       p.value.x.to_i
-      )).to_i.should eq('a'.ord)
+      )).to_i).to eq('a'.ord)
   end
 
   it "creates pointer of unspecified generic type with inherited class" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def initialize(@x : T)
         end
@@ -66,11 +66,11 @@ describe "Code gen: generic class type" do
       p = Pointer(Foo).malloc(1_u64)
       p.value = Bar.new(1)
       p.value.x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "creates pointer of unspecified generic type with inherited class (2)" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def initialize(@x : T)
         end
@@ -86,11 +86,11 @@ describe "Code gen: generic class type" do
       p = Pointer(Foo).malloc(1_u64)
       p.value = Bar.new(1)
       p.value.x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "instantiates generic class with default argument in initialize (#394)" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def initialize(@x = 1)
         end
@@ -101,6 +101,6 @@ describe "Code gen: generic class type" do
       end
 
       Foo(Int32).new.x + 1
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/global_spec.cr
+++ b/spec/compiler/codegen/global_spec.cr
@@ -2,18 +2,18 @@ require "../../spec_helper"
 
 describe "Code gen: global" do
   it "codegens global" do
-    run("$foo = 1; def foo; $foo = 2; end; foo; $foo").to_i.should eq(2)
+    expect(run("$foo = 1; def foo; $foo = 2; end; foo; $foo").to_i).to eq(2)
   end
 
   it "codegens global with union" do
-    run("$foo = 1; def foo; $foo = 2.5_f32; end; foo; $foo.to_f").to_f64.should eq(2.5)
+    expect(run("$foo = 1; def foo; $foo = 2.5_f32; end; foo; $foo.to_f").to_f64).to eq(2.5)
   end
 
   it "codegens global when not initialized" do
-    run("require \"nil\"; $foo.to_i").to_i.should eq(0)
+    expect(run("require \"nil\"; $foo.to_i").to_i).to eq(0)
   end
 
   it "codegens global when not initialized" do
-    run("require \"nil\"; def foo; $foo = 2 if 1 == 2; end; foo; $foo.to_i").to_i.should eq(0)
+    expect(run("require \"nil\"; def foo; $foo = 2 if 1 == 2; end; foo; $foo.to_i").to_i).to eq(0)
   end
 end

--- a/spec/compiler/codegen/hash_literal_spec.cr
+++ b/spec/compiler/codegen/hash_literal_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: hash literal spec" do
   it "creates custom non-generic hash" do
-    run(%(
+    expect(run(%(
       class Custom
         def initialize
           @keys = 0
@@ -25,11 +25,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom {1 => 10, 2 => 20}
       custom.keys * custom.values
-      )).to_i.should eq(90)
+      )).to_i).to eq(90)
   end
 
   it "creates custom generic hash" do
-    run(%(
+    expect(run(%(
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -52,11 +52,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom {1 => 10, 2 => 20}
       custom.keys * custom.values
-      )).to_i.should eq(90)
+      )).to_i).to eq(90)
   end
 
   it "creates custom generic hash with type vars" do
-    run(%(
+    expect(run(%(
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -79,11 +79,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom(Int32, Int32) {1 => 10, 2 => 20}
       custom.keys * custom.values
-      )).to_i.should eq(90)
+      )).to_i).to eq(90)
   end
 
   it "creates custom generic hash via alias (1)" do
-    run(%(
+    expect(run(%(
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -108,11 +108,11 @@ describe "Code gen: hash literal spec" do
 
       custom = MyCustom {1 => 10, 2 => 20}
       custom.keys * custom.values
-      )).to_i.should eq(90)
+      )).to_i).to eq(90)
   end
 
   it "creates custom generic hash via alias (2)" do
-    run(%(
+    expect(run(%(
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -137,6 +137,6 @@ describe "Code gen: hash literal spec" do
 
       custom = MyCustom {1 => 10, 2 => 20}
       custom.keys * custom.values
-      )).to_i.should eq(90)
+      )).to_i).to eq(90)
   end
 end

--- a/spec/compiler/codegen/hooks_spec.cr
+++ b/spec/compiler/codegen/hooks_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: hooks" do
   it "does inherited macro" do
-    run("
+    expect(run("
       class Foo
         macro inherited
           $x = 1
@@ -13,11 +13,11 @@ describe "Code gen: hooks" do
       end
 
       $x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does included macro" do
-    run("
+    expect(run("
       module Foo
         macro included
           $x = 1
@@ -29,11 +29,11 @@ describe "Code gen: hooks" do
       end
 
       $x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does extended macro" do
-    run("
+    expect(run("
       module Foo
         macro extended
           $x = 1
@@ -45,11 +45,11 @@ describe "Code gen: hooks" do
       end
 
       $x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does inherited macro recursively" do
-    run("
+    expect(run("
       $x = 0
       class Foo
         macro inherited
@@ -64,6 +64,6 @@ describe "Code gen: hooks" do
       end
 
       $x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -2,35 +2,35 @@ require "../../spec_helper"
 
 describe "Code gen: if" do
   it "codegens if without an else with true" do
-    run("a = 1; if true; a = 2; end; a").to_i.should eq(2)
+    expect(run("a = 1; if true; a = 2; end; a").to_i).to eq(2)
   end
 
   it "codegens if without an else with false" do
-    run("a = 1; if false; a = 2; end; a").to_i.should eq(1)
+    expect(run("a = 1; if false; a = 2; end; a").to_i).to eq(1)
   end
 
   it "codegens if with an else with false" do
-    run("a = 1; if false; a = 2; else; a = 3; end; a").to_i.should eq(3)
+    expect(run("a = 1; if false; a = 2; else; a = 3; end; a").to_i).to eq(3)
   end
 
   it "codegens if with an else with true" do
-    run("a = 1; if true; a = 2; else; a = 3; end; a").to_i.should eq(2)
+    expect(run("a = 1; if true; a = 2; else; a = 3; end; a").to_i).to eq(2)
   end
 
   it "codegens if inside def without an else with true" do
-    run("def foo; a = 1; if true; a = 2; end; a; end; foo").to_i.should eq(2)
+    expect(run("def foo; a = 1; if true; a = 2; end; a; end; foo").to_i).to eq(2)
   end
 
   it "codegen if inside if" do
-    run("a = 1; if false; a = 1; elsif false; a = 2; else; a = 3; end; a").to_i.should eq(3)
+    expect(run("a = 1; if false; a = 1; elsif false; a = 2; else; a = 3; end; a").to_i).to eq(3)
   end
 
   it "codegens if value from then" do
-    run("if true; 1; else 2; end").to_i.should eq(1)
+    expect(run("if true; 1; else 2; end").to_i).to eq(1)
   end
 
   it "codegens if with union" do
-    run("a = if true; 2.5_f32; else; 1; end; a.to_f").to_f64.should eq(2.5)
+    expect(run("a = if true; 2.5_f32; else; 1; end; a.to_f").to_f64).to eq(2.5)
   end
 
   it "codes if with two whiles" do
@@ -38,39 +38,39 @@ describe "Code gen: if" do
   end
 
   it "codegens if with int" do
-    run("require \"object\"; if 1; 2; else 3; end").to_i.should eq(2)
+    expect(run("require \"object\"; if 1; 2; else 3; end").to_i).to eq(2)
   end
 
   it "codegens if with nil" do
-    run("require \"nil\"; if nil; 2; else 3; end").to_i.should eq(3)
+    expect(run("require \"nil\"; if nil; 2; else 3; end").to_i).to eq(3)
   end
 
   it "codegens if of nilable type in then" do
-    run("if false; nil; else; \"foo\"; end").to_string.should eq("foo")
+    expect(run("if false; nil; else; \"foo\"; end").to_string).to eq("foo")
   end
 
   it "codegens if of nilable type in then 2" do
-    run("if 1 == 2; nil; else; \"foo\"; end").to_string.should eq("foo")
+    expect(run("if 1 == 2; nil; else; \"foo\"; end").to_string).to eq("foo")
   end
 
   it "codegens if of nilable type in else" do
-    run("if true; \"foo\"; else; nil; end").to_string.should eq("foo")
+    expect(run("if true; \"foo\"; else; nil; end").to_string).to eq("foo")
   end
 
   it "codegens if of nilable type in else 3" do
-    run("if 1 == 1; \"foo\"; else; nil; end").to_string.should eq("foo")
+    expect(run("if 1 == 1; \"foo\"; else; nil; end").to_string).to eq("foo")
   end
 
   it "codegens if with return and no else" do
-    run("def foo; if true; return 1; end; 2; end; foo").to_i.should eq(1)
+    expect(run("def foo; if true; return 1; end; 2; end; foo").to_i).to eq(1)
   end
 
   it "codegens if with return in both branches" do
-    run("def foo; if true; return 1; else; return 2; end; end; foo").to_i.should eq(1)
+    expect(run("def foo; if true; return 1; else; return 2; end; end; foo").to_i).to eq(1)
   end
 
   it "codegen if with nested if that returns" do
-    run("
+    expect(run("
       def foo
         if true
           if true
@@ -83,11 +83,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegen if with union type and then without type" do
-    run("
+    expect(run("
       def foo
         if true
           return 1
@@ -98,11 +98,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegen if with union type and else without type" do
-    run("
+    expect(run("
       def foo
         if false
           1 || 1.1
@@ -113,11 +113,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens if with virtual" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -130,11 +130,11 @@ describe "Code gen: if" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens nested if with var (ssa bug)" do
-    run("
+    expect(run("
       foo = 1
       if 1 == 2
         if 1 == 2
@@ -144,11 +144,11 @@ describe "Code gen: if" do
         end
       end
       foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens if with nested if that raises" do
-    run("
+    expect(run("
       require \"prelude\"
       block = 1 || nil
       if 1 == 2
@@ -158,11 +158,11 @@ describe "Code gen: if" do
       else
         block
       end.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens if with return in else preserves type filter" do
-    run("
+    expect(run("
       require \"prelude\"
 
       def foo
@@ -176,6 +176,6 @@ describe "Code gen: if" do
       end
 
       foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -2,55 +2,55 @@ require "../../spec_helper"
 
 describe "Codegen: is_a?" do
   it "codegens is_a? true for simple type" do
-    run("1.is_a?(Int)").to_b.should be_true
+    expect(run("1.is_a?(Int)").to_b).to be_true
   end
 
   it "codegens is_a? false for simple type" do
-    run("1.is_a?(Bool)").to_b.should be_false
+    expect(run("1.is_a?(Bool)").to_b).to be_false
   end
 
   it "codegens is_a? with union gives true" do
-    run("(1 == 1 ? 1 : 'a').is_a?(Int)").to_b.should be_true
+    expect(run("(1 == 1 ? 1 : 'a').is_a?(Int)").to_b).to be_true
   end
 
   it "codegens is_a? with union gives false" do
-    run("(1 == 1 ? 1 : 'a').is_a?(Char)").to_b.should be_false
+    expect(run("(1 == 1 ? 1 : 'a').is_a?(Char)").to_b).to be_false
   end
 
   it "codegens is_a? with union gives false" do
-    run("(1 == 1 ? 1 : 'a').is_a?(Float)").to_b.should be_false
+    expect(run("(1 == 1 ? 1 : 'a').is_a?(Float)").to_b).to be_false
   end
 
   it "codegens is_a? with union gives true" do
-    run("(1 == 1 ? 1 : 'a').is_a?(Object)").to_b.should be_true
+    expect(run("(1 == 1 ? 1 : 'a').is_a?(Object)").to_b).to be_true
   end
 
   it "codegens is_a? with nilable gives true" do
-    run("(1 == 1 ? nil : Reference.new).is_a?(Nil)").to_b.should be_true
+    expect(run("(1 == 1 ? nil : Reference.new).is_a?(Nil)").to_b).to be_true
   end
 
   it "codegens is_a? with nilable gives false becuase other type 1" do
-    run("(1 == 1 ? nil : Reference.new).is_a?(Reference)").to_b.should be_false
+    expect(run("(1 == 1 ? nil : Reference.new).is_a?(Reference)").to_b).to be_false
   end
 
   it "codegens is_a? with nilable gives false becuase other type 2" do
-    run("(1 == 2 ? nil : Reference.new).is_a?(Reference)").to_b.should be_true
+    expect(run("(1 == 2 ? nil : Reference.new).is_a?(Reference)").to_b).to be_true
   end
 
   it "codegens is_a? with nilable gives false becuase no type" do
-    run("(1 == 2 ? nil : Reference.new).is_a?(String)").to_b.should be_false
+    expect(run("(1 == 2 ? nil : Reference.new).is_a?(String)").to_b).to be_false
   end
 
   it "codegens is_a? with nilable gives false becuase no type" do
-    run("1.is_a?(Object)").to_b.should be_true
+    expect(run("1.is_a?(Object)").to_b).to be_true
   end
 
   it "evaluate method on filtered type" do
-    run("a = 1; a = 'a'; if a.is_a?(Char); a.ord; else; 0; end").to_i.chr.should eq('a')
+    expect(run("a = 1; a = 'a'; if a.is_a?(Char); a.ord; else; 0; end").to_i.chr).to eq('a')
   end
 
   it "evaluate method on filtered type nilable type not-nil" do
-    run("
+    expect(run("
       class Foo
         def foo
           1
@@ -64,11 +64,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "evaluate method on filtered type nilable type nil" do
-    run("
+    expect(run("
       struct Nil
         def foo
           1
@@ -85,11 +85,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "evaluates method on filtered union type" do
-    run("
+    expect(run("
       class Foo
         def initialize(x)
           @x = x
@@ -108,11 +108,11 @@ describe "Codegen: is_a?" do
       else
         0
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "evaluates method on filtered union type 2" do
-    run("
+    expect(run("
       class Foo
         def initialize(x)
           @x = x
@@ -142,11 +142,11 @@ describe "Codegen: is_a?" do
       else
         0
       end
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "evaluates method on filtered union type 3" do
-    run("
+    expect(run("
       require \"prelude\"
       a = 1
       a = [1.1]
@@ -157,11 +157,11 @@ describe "Codegen: is_a?" do
       else
         0
       end.to_i
-    ").to_i.should eq(5)
+    ").to_i).to eq(5)
   end
 
   it "codegens when is_a? is always false but properties are used" do
-    run("
+    expect(run("
       require \"prelude\"
 
       class Foo
@@ -170,11 +170,11 @@ describe "Codegen: is_a?" do
 
       foo = 1
       foo.is_a?(Foo) && foo.obj && foo.obj
-    ").to_b.should be_false
+    ").to_b).to be_false
   end
 
   it "codegens is_a? on right side of and" do
-    run("
+    expect(run("
       class Foo
         def bar
           true
@@ -187,11 +187,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens is_a? with virtual" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -200,11 +200,11 @@ describe "Codegen: is_a?" do
 
       foo = Bar.new || Foo.new
       foo.is_a?(Bar) ? 1 : 2
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens is_a? with virtual and nil" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -213,11 +213,11 @@ describe "Codegen: is_a?" do
 
       f = Foo.new || Bar.new || nil
       f.is_a?(Foo) ? 1 : 2
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens is_a? with virtual and module" do
-    run("
+    expect(run("
       module Bar
       end
 
@@ -236,22 +236,22 @@ describe "Codegen: is_a?" do
 
       f = Foo.new || Foo2.new
       f.is_a?(Bar)
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "restricts simple type with union" do
-    run("
+    expect(run("
       a = 1
       if a.is_a?(Int32 | Char)
         a + 1
       else
         0
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "restricts union with union" do
-    run("
+    expect(run("
       struct Char
         def +(other : Int32)
           other
@@ -270,37 +270,37 @@ describe "Codegen: is_a?" do
       else
         a.foo
       end
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens is_a? with a Const does comparison and gives true" do
-    run("
+    expect(run("
       require \"prelude\"
       A = 1
       1.is_a?(A)
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "codegens is_a? with a Const does comparison and gives false" do
-    run("
+    expect(run("
       require \"prelude\"
       A = 1
       2.is_a?(A)
-      ").to_b.should be_false
+      ").to_b).to be_false
   end
 
   it "gives false if generic type doesn't match exactly" do
-    run("
+    expect(run("
       class Foo(T)
       end
 
       foo = Foo(Int32 | Float64).new
       foo.is_a?(Foo(Int32)) ? 1 : 2
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "does is_a? with more strict virtual type" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -316,11 +316,11 @@ describe "Codegen: is_a?" do
       else
         1
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens is_a? casts union to nilable" do
-    run("
+    expect(run("
       class Foo; end
 
       var = \"hello\" || Foo.new || nil
@@ -330,11 +330,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens is_a? casts union to nilable in method" do
-    run("
+    expect(run("
       class Foo; end
 
       def foo(var)
@@ -348,11 +348,11 @@ describe "Codegen: is_a?" do
 
       var = \"hello\" || Foo.new || nil
       foo(var)
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens is_a? from virtual type to module" do
-    run("
+    expect(run("
       module Moo
       end
 
@@ -374,11 +374,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens is_a? from nilable reference union type to nil" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -392,11 +392,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens is_a? from nilable reference union type to type" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -410,17 +410,17 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "says false for value.is_a?(Class)" do
-    run("
+    expect(run("
       1.is_a?(Class)
-      ").to_b.should be_false
+      ").to_b).to be_false
   end
 
   it "restricts type in else but lazily" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -439,11 +439,11 @@ describe "Codegen: is_a?" do
       end
 
       z
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "works with inherited generic class against an instantiation" do
-    run(%(
+    expect(run(%(
       class Foo(T)
       end
 
@@ -452,11 +452,11 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Int32))
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "works with inherited generic class against an instantiation (2)" do
-    run(%(
+    expect(run(%(
       class A
       end
 
@@ -471,11 +471,11 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(A))
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "works with inherited generic class against an instantiation (3)" do
-    run(%(
+    expect(run(%(
       class Foo(T)
       end
 
@@ -484,28 +484,28 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Float32))
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "doesn't type merge (1) (#548)" do
-    run(%(
+    expect(run(%(
       class Base; end
       class A < Base; end
       class B < Base; end
       class C < Base; end
 
       C.new.is_a?(A | B)
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "doesn't type merge (2) (#548)" do
-    run(%(
+    expect(run(%(
       class Base; end
       class A < Base; end
       class B < Base; end
       class C < Base; end
 
       A.new.is_a?(A | B) && B.new.is_a?(A | B)
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/lib_spec.cr
+++ b/spec/compiler/codegen/lib_spec.cr
@@ -2,14 +2,14 @@ require "../../spec_helper"
 
 describe "Code gen: lib" do
   pending "codegens lib var set and get" do
-    run("
+    expect(run("
       lib LibC
         $errno : Int32
       end
 
       LibC.errno = 1
       LibC.errno
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "call to void function" do

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -2,21 +2,21 @@ require "../../spec_helper"
 
 describe "Code gen: macro" do
   it "expands macro" do
-    run("macro foo; 1 + 2; end; foo").to_i.should eq(3)
+    expect(run("macro foo; 1 + 2; end; foo").to_i).to eq(3)
   end
 
   it "expands macro with arguments" do
-    run(%(
+    expect(run(%(
       macro foo(n)
         {{n}} + 2
       end
 
       foo(1)
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "expands macro that invokes another macro" do
-    run(%(
+    expect(run(%(
       macro foo
         def x
           1 + 2
@@ -29,11 +29,11 @@ describe "Code gen: macro" do
 
       bar
       x
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "expands macro defined in class" do
-    run(%(
+    expect(run(%(
       class Foo
         macro foo
           def bar
@@ -46,11 +46,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new
       foo.bar
-    )).to_i.should eq(1)
+    )).to_i).to eq(1)
   end
 
   it "expands macro defined in base class" do
-    run(%(
+    expect(run(%(
       class Object
         macro foo
           def bar
@@ -65,48 +65,48 @@ describe "Code gen: macro" do
 
       foo = Foo.new
       foo.bar
-    )).to_i.should eq(1)
+    )).to_i).to eq(1)
   end
 
   it "expands inline macro" do
-    run(%(
+    expect(run(%(
       a = {{ 1 }}
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands inline macro for" do
-    run(%(
+    expect(run(%(
       a = 0
       {% for i in [1, 2, 3] %}
         a += {{i}}
       {% end %}
       a
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "expands inline macro if (true)" do
-    run(%(
+    expect(run(%(
       a = 0
       {% if 1 == 1 %}
         a += 1
       {% end %}
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands inline macro if (false)" do
-    run(%(
+    expect(run(%(
       a = 0
       {% if 1 == 2 %}
         a += 1
       {% end %}
       a
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "finds macro in class" do
-    run(%(
+    expect(run(%(
       class Foo
         macro foo
           1 + 2
@@ -118,11 +118,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "expands def macro" do
-    run(%(
+    expect(run(%(
       def bar_baz
         1
       end
@@ -132,21 +132,21 @@ describe "Code gen: macro" do
       end
 
       foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands def macro with var" do
-    run(%(
+    expect(run(%(
       macro def foo : Int32
         a = {{ 1 }}
       end
 
       foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands def macro with @instance_vars" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -158,11 +158,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new(1)
       foo.to_s
-      )).to_string.should eq("x")
+      )).to_string).to eq("x")
   end
 
   it "expands def macro with @instance_vars with subclass" do
-    run(%(
+    expect(run(%(
       class Reference
         macro def to_s : String
           {{ @instance_vars.last.stringify }}
@@ -180,11 +180,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new(1, 2).to_s
-      )).to_string.should eq("y")
+      )).to_string).to eq("y")
   end
 
   it "expands def macro with @instance_vars with virtual" do
-    run(%(
+    expect(run(%(
       class Reference
         macro def to_s : String
           {{ @instance_vars.last.stringify }}
@@ -202,11 +202,11 @@ describe "Code gen: macro" do
       end
 
       (Bar.new(1, 2) || Foo.new(1)).to_s
-      )).to_string.should eq("y")
+      )).to_string).to eq("y")
   end
 
   it "expands def macro with @class_name" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -218,11 +218,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new(1)
       foo.to_s
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "expands macro and resolves type correctly" do
-    run(%(
+    expect(run(%(
       class Foo
         macro def foo : Int32
           1
@@ -234,11 +234,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new.foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands def macro with @class_name with virtual" do
-    run(%(
+    expect(run(%(
       class Reference
         macro def to_s : String
           {{ @class_name }}
@@ -252,11 +252,11 @@ describe "Code gen: macro" do
       end
 
       (Bar.new || Foo.new).to_s
-      )).to_string.should eq("Bar")
+      )).to_string).to eq("Bar")
   end
 
   it "expands def macro with @class_name with virtual (2)" do
-    run(%(
+    expect(run(%(
       class Reference
         macro def to_s : String
           {{ @class_name }}
@@ -270,11 +270,11 @@ describe "Code gen: macro" do
       end
 
       (Foo.new || Bar.new).to_s
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "allows overriding macro definition when redefining base class" do
-    run(%(
+    expect(run(%(
       class Foo
         macro def inspect : String
           {{@class_name}}
@@ -291,11 +291,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new.inspect
-      )).to_string.should eq("OH NO")
+      )).to_string).to eq("OH NO")
   end
 
   it "uses invocation context" do
-    run(%(
+    expect(run(%(
       macro foo
         def bar
           {{@class_name}}
@@ -307,11 +307,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "allows macro with default arguments" do
-    run(%(
+    expect(run(%(
       def bar
         2
       end
@@ -321,11 +321,11 @@ describe "Code gen: macro" do
       end
 
       foo(1)
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "expands def macro with instance var and method call (bug)" do
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -340,11 +340,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.foo.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "expands @class_name in virtual metaclass (1)" do
-    run(%(
+    expect(run(%(
       class Class
         macro def to_s : String
           {{ @class_name }}
@@ -361,11 +361,11 @@ describe "Code gen: macro" do
       p.value = Bar
       p.value = Foo
       p.value.to_s
-      )).to_string.should eq("Foo:Class")
+      )).to_string).to eq("Foo:Class")
   end
 
   it "expands @class_name in virtual metaclass (2)" do
-    run(%(
+    expect(run(%(
       class Class
         macro def to_s : String
           {{ @class_name }}
@@ -382,11 +382,11 @@ describe "Code gen: macro" do
       p.value = Foo
       p.value = Bar
       p.value.to_s
-      )).to_string.should eq("Bar:Class")
+      )).to_string).to eq("Bar:Class")
   end
 
   it "doesn't skip abstract classes when defining macro methods" do
-    run(%(
+    expect(run(%(
       class Object
         macro def foo : Int32
           1
@@ -410,11 +410,11 @@ describe "Code gen: macro" do
 
       t = Type1.new || Type2.new
       t.foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "doesn't reuse macro nodes (bug)" do
-    run(%(
+    expect(run(%(
       def foo(x)
         {% for y in [1, 2] %}
           x + 1
@@ -423,18 +423,18 @@ describe "Code gen: macro" do
 
       foo 1
       foo(1.5).to_i
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "can use constants" do
-    run(%(
+    expect(run(%(
       A = 1
       {{ A }}
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "can refer to types" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x, @y)
         end
@@ -443,81 +443,81 @@ describe "Code gen: macro" do
       Foo.new(1, 2)
 
       {{ Foo.instance_vars.last.name }}
-      )).to_string.should eq("y")
+      )).to_string).to eq("y")
   end
 
   it "runs macro with splat" do
-    run(%(
+    expect(run(%(
       macro foo(*args)
         {{args.length}}
       end
 
       foo 1, 1, 1
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "runs macro with arg and splat" do
-    run(%(
+    expect(run(%(
       macro foo(name, *args)
         {{args.length}}
       end
 
       foo bar, 1, 1, 1
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "runs macro with arg and splat in first position (1)" do
-    run(%(
+    expect(run(%(
       macro foo(*args, name)
         {{args.length}}
       end
 
       foo 1, 1, 1, bar
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "runs macro with arg and splat in first position (2)" do
-    run(%(
+    expect(run(%(
       macro foo(*args, name)
         {{name}}
       end
 
       foo 1, 1, 1, "hello"
-      )).to_string.should eq("hello")
+      )).to_string).to eq("hello")
   end
 
   it "runs macro with arg and splat in the middle (1)" do
-    run(%(
+    expect(run(%(
       macro foo(foo, *args, name)
         {{args.length}}
       end
 
       foo x, 1, 1, 1, bar
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "runs macro with arg and splat in the middle (2)" do
-    run(%(
+    expect(run(%(
       macro foo(foo, *args, name)
         {{foo}}
       end
 
       foo "yellow", 1, 1, 1, bar
-      )).to_string.should eq("yellow")
+      )).to_string).to eq("yellow")
   end
 
   it "runs macro with arg and splat in the middle (3)" do
-    run(%(
+    expect(run(%(
       macro foo(foo, *args, name)
         {{name}}
       end
 
       foo "yellow", 1, 1, 1, "cool"
-      )).to_string.should eq("cool")
+      )).to_string).to eq("cool")
   end
 
   it "expands macro that yields" do
-    run(%(
+    expect(run(%(
       def foo
         {% for i in 0 .. 2 %}
           yield {{i}}
@@ -529,29 +529,29 @@ describe "Code gen: macro" do
         a += x
       end
       a
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "can refer to abstract (1)" do
-    run(%(
+    expect(run(%(
       class Foo
       end
 
       {{ Foo.abstract? }}
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "can refer to abstract (2)" do
-    run(%(
+    expect(run(%(
       abstract class Foo
       end
 
       {{ Foo.abstract? }}
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "can refer to @type" do
-    run(%(
+    expect(run(%(
       class Foo
         macro def foo : String
           {{@type.name}}
@@ -559,11 +559,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.foo
-      )).to_string.should eq("Foo")
+      )).to_string).to eq("Foo")
   end
 
   it "receives &block" do
-    run(%(
+    expect(run(%(
       macro foo(&block)
         bar {{block}}
       end
@@ -575,21 +575,21 @@ describe "Code gen: macro" do
       foo do |x|
         x + 1
       end
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "executes with named arguments" do
-    run(%(
+    expect(run(%(
       macro foo(x = 1)
         {{x}} + 1
       end
 
       foo x: 2
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "gets correct class name when there are classes in the middle" do
-    run(%(
+    expect(run(%(
       class Foo
         macro def class_desc : String
           {{@class_name}}
@@ -608,7 +608,7 @@ describe "Code gen: macro" do
       a = Pointer(Foo).malloc(1_u64)
       a.value = Qux.new
       a.value.class_desc
-      )).to_string.should eq("Qux")
+      )).to_string).to eq("Qux")
   end
 
   it "transforms hooks (bug)" do
@@ -633,7 +633,7 @@ describe "Code gen: macro" do
   end
 
   it "executs subclasses" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -650,11 +650,11 @@ describe "Code gen: macro" do
 
       names = {{ Foo.subclasses.map &.name }}
       names.join("-")
-      )).to_string.should eq("Bar-Baz")
+      )).to_string).to eq("Bar-Baz")
   end
 
   it "executs all_subclasses" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -668,11 +668,11 @@ describe "Code gen: macro" do
 
       names = {{ Foo.all_subclasses.map &.name }}
       names.join("-")
-      )).to_string.should eq("Bar-Baz")
+      )).to_string).to eq("Bar-Baz")
   end
 
   it "gets enum members with @enum_members (will be deprecated)" do
-    run(%(
+    expect(run(%(
       enum Color
         Red
         Green
@@ -692,11 +692,11 @@ describe "Code gen: macro" do
       end
 
       Color.red.value + Color.green.value + Color.blue.value
-      )).to_i.should eq(0 + 1 + 2)
+      )).to_i).to eq(0 + 1 + 2)
   end
 
   it "gets enum members with @constants" do
-    run(%(
+    expect(run(%(
       enum Color
         Red
         Green
@@ -716,11 +716,11 @@ describe "Code gen: macro" do
       end
 
       Color.red.value + Color.green.value + Color.blue.value
-      )).to_i.should eq(0 + 1 + 2)
+      )).to_i).to eq(0 + 1 + 2)
   end
 
   it "gets enum members as constants" do
-    run(%(
+    expect(run(%(
       enum Color
         Red
         Green
@@ -728,11 +728,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.constants[1].stringify}}
-      )).to_string.should eq("Green")
+      )).to_string).to eq("Green")
   end
 
   it "says that enum has Flags attribute" do
-    run(%(
+    expect(run(%(
       @[Flags]
       enum Color
         Red
@@ -741,11 +741,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.has_attribute?("Flags")}}
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "says that enum doesn't have Flags attribute" do
-    run(%(
+    expect(run(%(
       enum Color
         Red
         Green
@@ -753,11 +753,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.has_attribute?("Flags")}}
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 
   it "gets methods" do
-    run(%(
+    expect(run(%(
       class Foo
         def bar
           1
@@ -769,11 +769,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.first_method_name
-      )).to_string.should eq("bar")
+      )).to_string).to eq("bar")
   end
 
   it "copies base macro def to sub-subtype even after it was copied to a subtype (#448)" do
-    run(%(
+    expect(run(%(
       class Object
         macro def class_name : String
           {{@class_name}}
@@ -799,11 +799,11 @@ describe "Code gen: macro" do
       class C < B; end
       A.children.value = C.new
       A.children.value.class_name
-      )).to_string.should eq("C")
+      )).to_string).to eq("C")
   end
 
   it "recalculates method when virtual metaclass type is added" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       $x = [] of String
@@ -839,11 +839,11 @@ describe "Code gen: macro" do
 
       run
       $x.join(", ")
-      )).to_string.should eq("Test:Class, RunnableTest:Class")
+      )).to_string).to eq("Test:Class, RunnableTest:Class")
   end
 
   it "correctly recomputes call (bug)" do
-    run(%(
+    expect(run(%(
       class Object
         def in_object
           in_class(1)
@@ -874,11 +874,11 @@ describe "Code gen: macro" do
 
       f2 = Baz.new || Foo.new
       f2.class.in_object
-      )).to_string.should eq("Baz:Class")
+      )).to_string).to eq("Baz:Class")
   end
 
   it "doesn't override local variable when using macro variable" do
-    run(%(
+    expect(run(%(
       macro foo(x)
         %a = {{x}}
         %a
@@ -888,11 +888,11 @@ describe "Code gen: macro" do
       foo(2)
       foo(3)
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "doesn't override local variable when using macro variable (2)" do
-    run(%(
+    expect(run(%(
       macro foo(x)
         %a = {{x}} + 10
         %a
@@ -902,11 +902,11 @@ describe "Code gen: macro" do
       z = foo(2)
       w = foo(3)
       a + z + w
-      )).to_i.should eq(26)
+      )).to_i).to eq(26)
   end
 
   it "uses indexed macro variable" do
-    run(%(
+    expect(run(%(
       macro foo(*elems)
         {% for elem, i in elems %}
           %var{i} = {{elem}}
@@ -923,11 +923,11 @@ describe "Code gen: macro" do
       z += foo 4, 5, 6
       z += foo 40, 50, 60
       z
-      )).to_i.should eq(4 + 5 + 6 + 40 + 50 + 60)
+      )).to_i).to eq(4 + 5 + 6 + 40 + 50 + 60)
   end
 
   it "uses indexed macro variable with many keys" do
-    run(%(
+    expect(run(%(
       macro foo(*elems)
         {% for elem, i in elems %}
           %var{elem, i} = {{elem}}
@@ -942,11 +942,11 @@ describe "Code gen: macro" do
 
       z = foo 4, 5, 6
       z
-      )).to_i.should eq(4 + 5 + 6)
+      )).to_i).to eq(4 + 5 + 6)
   end
 
   it "codegens macro def with splat (#496)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro def bar(*args) : Int32
           args[0] + args[1] + args[2]
@@ -954,11 +954,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar(1, 2, 3)
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "codegens macro def with default arg (similar to #496)"  do
-    run(%(
+    expect(run(%(
       class Foo
         macro def bar(foo = 1) : Int32
           foo + 2
@@ -966,6 +966,6 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 end

--- a/spec/compiler/codegen/magic_constants_spec.cr
+++ b/spec/compiler/codegen/magic_constants_spec.cr
@@ -2,37 +2,37 @@ require "../../spec_helper"
 
 describe "Code gen: magic constants" do
   it "does __LINE__" do
-    run(%(
+    expect(run(%(
       def foo(x = __LINE__)
         x
       end
 
       foo
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "does __FILE__" do
-    run(%(
+    expect(run(%(
       def foo(x = __FILE__)
         x
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
+      ), filename: "/foo/bar/baz.cr").to_string).to eq("/foo/bar/baz.cr")
   end
 
   it "does __DIR__" do
-    run(%(
+    expect(run(%(
       def foo(x = __DIR__)
         x
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
+      ), filename: "/foo/bar/baz.cr").to_string).to eq("/foo/bar")
   end
 
   it "does __LINE__ with dispatch" do
-    run(%(
+    expect(run(%(
       def foo(z : Int32, x = __LINE__)
         x
       end
@@ -43,66 +43,66 @@ describe "Code gen: magic constants" do
 
       a = 1 || "hello"
       foo(a)
-      )).to_i.should eq(11)
+      )).to_i).to eq(11)
   end
 
   it "does __LINE__ when specifying one default arg with __FILE__" do
-    run(%(
+    expect(run(%(
       def foo(x, file = __FILE__, line = __LINE__)
         line
       end
 
       foo 1, "hello"
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "does __LINE__ when specifying one normal default arg" do
-    run(%(
+    expect(run(%(
       def foo(x, z = 10, line = __LINE__)
         z + line
       end
 
       foo 1, 20
-      )).to_i.should eq(26)
+      )).to_i).to eq(26)
   end
 
   it "does __LINE__ when specifying one middle argument" do
-    run(%(
+    expect(run(%(
       def foo(x, line = __LINE__, z = 1)
         z + line
       end
 
       foo 1, z: 20
-      )).to_i.should eq(26)
+      )).to_i).to eq(26)
   end
 
   it "does __LINE__ in macro" do
-    run(%(
+    expect(run(%(
       macro foo(line = __LINE__)
         {{line}}
       end
 
       foo
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "does __FILE__ in macro" do
-    run(%(
+    expect(run(%(
       macro foo(file = __FILE__)
         {{file}}
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
+      ), filename: "/foo/bar/baz.cr").to_string).to eq("/foo/bar/baz.cr")
   end
 
   it "does __DIR__ in macro" do
-    run(%(
+    expect(run(%(
       macro foo(dir = __DIR__)
         {{dir}}
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
+      ), filename: "/foo/bar/baz.cr").to_string).to eq("/foo/bar")
   end
 end

--- a/spec/compiler/codegen/method_missing_spec.cr
+++ b/spec/compiler/codegen/method_missing_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: method_missing" do
   it "does method_missing macro without args" do
-    run("
+    expect(run("
       class Foo
         def foo_something
           1
@@ -14,11 +14,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does method_missing macro with args" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           {{args.join(" + ").id}}
@@ -26,11 +26,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo(1, 2, 3)
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "does method_missing macro with block" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo_something
           yield 1
@@ -48,11 +48,11 @@ describe "Code gen: method_missing" do
         a += x
       end
       a
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "does method_missing macro with block but not using it" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo_something
           1 + 2
@@ -64,11 +64,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "does method_missing macro with virtual type (1)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           "{{@class_name.id}}{{name.id}}"
@@ -80,11 +80,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new || Bar.new
       foo.coco
-      )).to_string.should eq("Foococo")
+      )).to_string).to eq("Foococo")
   end
 
   it "does method_missing macro with virtual type (2)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           "{{@class_name.id}}{{name.id}}"
@@ -96,11 +96,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.coco
-      )).to_string.should eq("Barcoco")
+      )).to_string).to eq("Barcoco")
   end
 
   it "does method_missing macro with virtual type (3)" do
-    run(%(
+    expect(run(%(
       class Foo
         def lala
           1
@@ -116,11 +116,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "does method_missing macro with virtual type (4)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           1
@@ -135,11 +135,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "does method_missing macro with virtual type (5)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           1
@@ -160,11 +160,11 @@ describe "Code gen: method_missing" do
 
       foo = Baz.new || Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "does method_missing macro with virtual type (6)" do
-    run(%(
+    expect(run(%(
       abstract class Foo
       end
 
@@ -182,11 +182,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Baz.new
       foo.lala
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "does method_missing macro with virtual type (7)" do
-    run(%(
+    expect(run(%(
       abstract class Foo
       end
 
@@ -204,11 +204,11 @@ describe "Code gen: method_missing" do
 
       foo = Baz.new || Bar.new
       foo.lala
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "does method_missing macro with virtual type (8)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           {{@class_name}}
@@ -223,11 +223,11 @@ describe "Code gen: method_missing" do
 
       bar = Bar.new
       bar.coco
-      )).to_string.should eq("Bar")
+      )).to_string).to eq("Bar")
   end
 
   it "does method_missing macro with module involved" do
-    run("
+    expect(run("
       module Moo
         def lala
           1
@@ -243,11 +243,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.lala
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does method_missing macro with top level method involved" do
-    run("
+    expect(run("
       def lala
         1
       end
@@ -264,11 +264,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "does method_missing macro with included module" do
-    run("
+    expect(run("
       module Moo
         macro method_missing(name, args, block)
           {{@class_name}}
@@ -280,11 +280,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.coco
-      ").to_string.should eq("Foo")
+      ").to_string).to eq("Foo")
   end
 
   it "does method_missing with assignment (bug)" do
-    run(%(
+    expect(run(%(
       class Foo
         macro method_missing(name, args, block)
           x = {{args[0]}}
@@ -294,11 +294,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar(1)
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "does method_missing with assignment (2) (bug)" do
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -314,6 +314,6 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar(1).to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: module" do
   it "codegens pointer of module with method" do
-    run("
+    expect(run("
       module Moo
       end
 
@@ -17,11 +17,11 @@ describe "Code gen: module" do
       p = Pointer(Moo).malloc(1_u64)
       p.value = Foo.new
       p.value.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens pointer of module with method with two including types" do
-    run("
+    expect(run("
       module Moo
       end
 
@@ -45,11 +45,11 @@ describe "Code gen: module" do
       p.value = Foo.new
       p.value = Bar.new
       p.value.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens pointer of module with method with two including types with one struct" do
-    run("
+    expect(run("
       module Foo
       end
 
@@ -73,11 +73,11 @@ describe "Code gen: module" do
       p.value = Bar.new
       p.value = Coco.new
       p.value.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens pointer of module with method with two including types with one struct (2)" do
-    run("
+    expect(run("
       module Foo
       end
 
@@ -102,11 +102,11 @@ describe "Code gen: module" do
       p.value = Coco.new
       x = p.value
       x.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens pointer of module and pass value to method" do
-    run(%(
+    expect(run(%(
       module Foo
       end
 
@@ -125,11 +125,11 @@ describe "Code gen: module" do
       p = Pointer(Foo).malloc(1_u64)
       p.value = Bar.new
       foo p.value
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens pointer of module with block" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       module Moo
@@ -156,11 +156,11 @@ describe "Code gen: module" do
         x = io
       end
       x.not_nil!.foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens module with virtual type" do
-    run(%(
+    expect(run(%(
       module Moo
       end
 
@@ -181,11 +181,11 @@ describe "Code gen: module" do
       p = Pointer(Moo).malloc(1_u64)
       p.value = Bar.new
       p.value.foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "declares proc with module type" do
-    run(%(
+    expect(run(%(
       module Moo
         def moo
           1
@@ -202,7 +202,7 @@ describe "Code gen: module" do
 
       foo = ->(x : Moo) { x.moo }
       foo.call(Bar.new)
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "declares proc with module type and invoke it with two different types that return themselves" do

--- a/spec/compiler/codegen/named_args_spec.cr
+++ b/spec/compiler/codegen/named_args_spec.cr
@@ -2,27 +2,27 @@ require "../../spec_helper"
 
 describe "Code gen: named args" do
   it "calls with named arg" do
-    run(%(
+    expect(run(%(
       def foo(y = 2)
         y
       end
 
       foo y: 10
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "calls with named arg and other args" do
-    run(%(
+    expect(run(%(
       def foo(x, y = 2, z = 3)
         x + y + z
       end
 
       foo 1, z: 10
-      )).to_i.should eq(13)
+      )).to_i).to eq(13)
   end
 
   it "calls with named arg as object method" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo(x, y = 2, z = 3)
           x + y + z
@@ -30,11 +30,11 @@ describe "Code gen: named args" do
       end
 
       Foo.new.foo 1, z: 10
-      )).to_i.should eq(13)
+      )).to_i).to eq(13)
   end
 
   it "calls twice with different types" do
-    run(%(
+    expect(run(%(
       def add(x, y = 1)
         x + y
       end
@@ -43,11 +43,11 @@ describe "Code gen: named args" do
       value += add(1, y: 2)
       value += add(1, y: 1.3)
       value.to_i
-      )).to_i.should eq(5)
+      )).to_i).to eq(5)
   end
 
   it "calls new with named arg" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(x, y = 2, z = 3)
           @value = x + y + z
@@ -59,11 +59,11 @@ describe "Code gen: named args" do
       end
 
       Foo.new(1, z: 10).value
-      )).to_i.should eq(13)
+      )).to_i).to eq(13)
   end
 
   it "uses named args in dispatch" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo(x, z = 2)
           x + z + 1
@@ -78,6 +78,6 @@ describe "Code gen: named args" do
 
       a = Foo.new || Bar.new
       a.foo 1, z: 20
-      )).to_i.should eq(22)
+      )).to_i).to eq(22)
   end
 end

--- a/spec/compiler/codegen/next_spec.cr
+++ b/spec/compiler/codegen/next_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: next" do
   it "codegens next" do
-    run("
+    expect(run("
       def foo
         yield
       end
@@ -10,11 +10,11 @@ describe "Code gen: next" do
       foo do
         next 1
       end
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens next conditionally" do
-    run("
+    expect(run("
       def foo
         yield 1
         yield 2
@@ -28,11 +28,11 @@ describe "Code gen: next" do
         a += i
       end
       a
-      ").to_i.should eq(4)
+      ").to_i).to eq(4)
   end
 
   it "codegens next conditionally with int type (2)" do
-    run("
+    expect(run("
       def foo
         x = 0
         x += yield 1
@@ -52,11 +52,11 @@ describe "Code gen: next" do
         end
         40
       end
-      ").to_i.should eq(100)
+      ").to_i).to eq(100)
   end
 
   it "codegens next with break (1)" do
-    run("
+    expect(run("
       def foo
         yield 1
       end
@@ -68,11 +68,11 @@ describe "Code gen: next" do
           next 10
         end
       end
-      ").to_i.should eq(20)
+      ").to_i).to eq(20)
   end
 
   it "codegens next with break (2)" do
-    run("
+    expect(run("
       def foo
         a = 0
         a += yield 1
@@ -88,11 +88,11 @@ describe "Code gen: next" do
         end
         30
       end
-      ").to_i.should eq(40)
+      ").to_i).to eq(40)
   end
 
   it "codegens next with break (3)" do
-    run("
+    expect(run("
       def foo
         a = 0
         a += yield 1
@@ -108,11 +108,11 @@ describe "Code gen: next" do
         end
         30
       end
-      ").to_i.should eq(20)
+      ").to_i).to eq(20)
   end
 
   it "codegens next with while inside block" do
-    run("
+    expect(run("
       def foo
         a = 0
         a += yield 4
@@ -133,11 +133,11 @@ describe "Code gen: next" do
         end
         20
       end
-      ").to_i.should eq(30)
+      ").to_i).to eq(30)
   end
 
   it "codegens next without expressions" do
-    run("
+    expect(run("
       struct Nil; def to_i; 0; end; end
 
       def foo
@@ -151,6 +151,6 @@ describe "Code gen: next" do
           next
         end
       end.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -2,11 +2,11 @@ require "../../spec_helper"
 
 describe "Code gen: no return" do
   it "codegens if with NoReturn on then and union on else" do
-    run("lib LibC; fun exit(c : Int32) : NoReturn; end; (if 1 == 2; LibC.exit(1); else; 1 || 2.5; end).to_i").to_i.should eq(1)
+    expect(run("lib LibC; fun exit(c : Int32) : NoReturn; end; (if 1 == 2; LibC.exit(1); else; 1 || 2.5; end).to_i").to_i).to eq(1)
   end
 
   it "codegens Pointer(NoReturn).malloc" do
-    run("Pointer(NoReturn).malloc(1_u64); 1").to_i.should eq(1)
+    expect(run("Pointer(NoReturn).malloc(1_u64); 1").to_i).to eq(1)
   end
 
   it "codegens if with no reutrn and variable used afterwards" do

--- a/spec/compiler/codegen/or_spec.cr
+++ b/spec/compiler/codegen/or_spec.cr
@@ -2,154 +2,154 @@ require "../../spec_helper"
 
 describe "Code gen: or" do
   it "codegens or with bool false and false" do
-    run("false || false").to_b.should be_false
+    expect(run("false || false").to_b).to be_false
   end
 
   it "codegens or with bool false and true" do
-    run("false || true").to_b.should be_true
+    expect(run("false || true").to_b).to be_true
   end
 
   it "codegens or with bool true and true" do
-    run("true || true").to_b.should be_true
+    expect(run("true || true").to_b).to be_true
   end
 
   it "codegens or with bool true and false" do
-    run("true || false").to_b.should be_true
+    expect(run("true || false").to_b).to be_true
   end
 
   it "codegens or with bool and int 1" do
-    run("struct Bool; def to_i; 0; end; end; (false || 2).to_i").to_i.should eq(2)
+    expect(run("struct Bool; def to_i; 0; end; end; (false || 2).to_i").to_i).to eq(2)
   end
 
   it "codegens or with bool and int 2" do
-    run("struct Bool; def to_i; 0; end; end; (true || 2).to_i").to_i.should eq(0)
+    expect(run("struct Bool; def to_i; 0; end; end; (true || 2).to_i").to_i).to eq(0)
   end
 
   it "codegens or with primitive type other than bool" do
-    run("1 || 2").to_i.should eq(1)
+    expect(run("1 || 2").to_i).to eq(1)
   end
 
   it "codegens or with primitive type other than bool with union" do
-    run("(1 || 1.5).to_f").to_f64.should eq(1)
+    expect(run("(1 || 1.5).to_f").to_f64).to eq(1)
   end
 
   it "codegens or with primitive type other than bool" do
-    run("require \"nil\"; (nil || 2).to_i").to_i.should eq(2)
+    expect(run("require \"nil\"; (nil || 2).to_i").to_i).to eq(2)
   end
 
   it "codegens or with nilable as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       class Object; def to_i; -1; end; end
       a = Reference.new
       a = nil
       (a || 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens or with nilable as left node 2" do
-    run("
+    expect(run("
       class Object; def to_i; -1; end; end
       a = nil
       a = Reference.new
       (a || 2).to_i
-    ").to_i.should eq(-1)
+    ").to_i).to eq(-1)
   end
 
   it "codegens or with non-false union as left node" do
-    run("
+    expect(run("
       a = 1.5
       a = 1
       (a || 2).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens or with nil union as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       a = nil
       a = 1
       (a || 2).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens or with nil union as left node 2" do
-    run("
+    expect(run("
       require \"nil\"
       a = 1
       a = nil
       (a || 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens or with bool union as left node 1" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = false
       a = 1
       (a || 2).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens or with bool union as left node 2" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = 1
       a = false
       (a || 2).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens or with bool union as left node 3" do
-    run("
+    expect(run("
       struct Bool; def to_i; 0; end; end
       a = 1
       a = true
       (a || 2).to_i
-    ").to_i.should eq(0)
+    ").to_i).to eq(0)
   end
 
   it "codegens or with bool union as left node 1" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = false
       a = nil
       a = 2
       (a || 3).to_i
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens or with bool union as left node 2" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = nil
       a = 2
       a = false
       (a || 3).to_i
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "codegens or with bool union as left node 3" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = nil
       a = 2
       a = true
       (a || 3).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens or with bool union as left node 4" do
-    run("
+    expect(run("
       require \"nil\"
       struct Bool; def to_i; 1; end; end
       a = 2
       a = true
       a = nil
       (a || 3).to_i
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 end

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -2,11 +2,11 @@ require "../../spec_helper"
 
 describe "Code gen: pointer" do
   it "get pointer and value of it" do
-    run("a = 1; b = pointerof(a); b.value").to_i.should eq(1)
+    expect(run("a = 1; b = pointerof(a); b.value").to_i).to eq(1)
   end
 
   it "get pointer of instance var" do
-    run("
+    expect(run("
       class Foo
         def initialize(value)
           @value = value
@@ -20,23 +20,23 @@ describe "Code gen: pointer" do
       foo = Foo.new(10)
       value_ptr = foo.value_ptr
       value_ptr.value
-      ").to_i.should eq(10)
+      ").to_i).to eq(10)
   end
 
   it "set pointer value" do
-    run("a = 1; b = pointerof(a); b.value = 2; a").to_i.should eq(2)
+    expect(run("a = 1; b = pointerof(a); b.value = 2; a").to_i).to eq(2)
   end
 
   it "get value of pointer to union" do
-    run("a = 1.1; a = 1; b = pointerof(a); b.value.to_i").to_i.should eq(1)
+    expect(run("a = 1.1; a = 1; b = pointerof(a); b.value.to_i").to_i).to eq(1)
   end
 
   it "sets value of pointer to union" do
-    run("p = Pointer(Int32|Float64).malloc(1_u64); a = 1; a = 2.5; p.value = a; p.value.to_i").to_i.should eq(2)
+    expect(run("p = Pointer(Int32|Float64).malloc(1_u64); a = 1; a = 2.5; p.value = a; p.value.to_i").to_i).to eq(2)
   end
 
   it "increments pointer" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @a = 1
@@ -49,31 +49,31 @@ describe "Code gen: pointer" do
         end
       end
       Foo.new.value
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "codegens malloc" do
-    run("p = Pointer(Int32).malloc(10_u64); p.value = 1; p.value + 1_i64").to_i.should eq(2)
+    expect(run("p = Pointer(Int32).malloc(10_u64); p.value = 1; p.value + 1_i64").to_i).to eq(2)
   end
 
   it "codegens realloc" do
-    run("p = Pointer(Int32).malloc(10_u64); p.value = 1; x = p.realloc(20_u64); x.value + 1_i64").to_i.should eq(2)
+    expect(run("p = Pointer(Int32).malloc(10_u64); p.value = 1; x = p.realloc(20_u64); x.value + 1_i64").to_i).to eq(2)
   end
 
   it "codegens pointer cast" do
-    run("a = 1_i64; (pointerof(a) as Int32*).value").to_i.should eq(1)
+    expect(run("a = 1_i64; (pointerof(a) as Int32*).value").to_i).to eq(1)
   end
 
   it "codegens pointer as if condition" do
-    run("a = 0; pointerof(a) ? 1 : 2").to_i.should eq(1)
+    expect(run("a = 0; pointerof(a) ? 1 : 2").to_i).to eq(1)
   end
 
   it "codegens null pointer as if condition" do
-    run("Pointer(Int32).new(0_u64) ? 1 : 2").to_i.should eq(2)
+    expect(run("Pointer(Int32).new(0_u64) ? 1 : 2").to_i).to eq(2)
   end
 
   it "gets pointer of instance variable in virtual type" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @a = 1
@@ -90,11 +90,11 @@ describe "Code gen: pointer" do
       foo = Foo.new || Bar.new
       x = foo.foo
       x.value
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "sets value of pointer to struct" do
-    run("
+    expect(run("
       lib LibC
         struct Color
           r, g, b, a : UInt8
@@ -110,54 +110,54 @@ describe "Code gen: pointer" do
       color.value = color2.value
 
       color.value.r
-      ").to_i.should eq(20)
+      ").to_i).to eq(20)
   end
 
   it "changes through var and reads from pointer" do
-    run("
+    expect(run("
       x = 1
       px = pointerof(x)
       x = 2
       px.value
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "creates pointer by address" do
-    run("
+    expect(run("
       x = Pointer(Int32).new(123_u64)
       x.address
-    ").to_i.should eq(123)
+    ").to_i).to eq(123)
   end
 
   it "calculates pointer diff" do
-    run("
+    expect(run("
       x = 1
       (pointerof(x) + 1_i64) - pointerof(x)
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "can dereference pointer to func" do
-    run("
+    expect(run("
       def foo; 1; end
       x = ->foo
       y = pointerof(x)
       y.value.call
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "gets pointer of argument that is never assigned to" do
-    run("
+    expect(run("
       def foo(x)
         pointerof(x)
       end
 
       foo(1)
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens nilable pointer type (1)" do
-    run("
+    expect(run("
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
       a = 1 == 2 ? nil : p
@@ -166,11 +166,11 @@ describe "Code gen: pointer" do
       else
         4
       end
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens nilable pointer type (2)" do
-    run("
+    expect(run("
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
       a = 1 == 1 ? nil : p
@@ -179,11 +179,11 @@ describe "Code gen: pointer" do
       else
         4
       end
-      ").to_i.should eq(4)
+      ").to_i).to eq(4)
   end
 
   it "codegens nilable pointer type dispatch (1)" do
-    run("
+    expect(run("
       def foo(x : Pointer)
         x.value
       end
@@ -196,11 +196,11 @@ describe "Code gen: pointer" do
       p.value = 3
       a = 1 == 1 ? p : nil
       foo(a)
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens nilable pointer type dispatch (2)" do
-    run("
+    expect(run("
       def foo(x : Pointer)
         x.value
       end
@@ -213,11 +213,11 @@ describe "Code gen: pointer" do
       p.value = 3
       a = 1 == 1 ? nil : p
       foo(a)
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "assigns nil and pointer to nilable pointer type" do
-    run("
+    expect(run("
       class Foo
         def initialize
         end
@@ -242,18 +242,18 @@ describe "Code gen: pointer" do
       else
         2
       end
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "gets pointer to constant" do
-    run("
+    expect(run("
       FOO = 1
       pointerof(FOO).value
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "passes pointer of pointer to method" do
-    run("
+    expect(run("
       def foo(x)
         x.value.value
       end
@@ -262,28 +262,28 @@ describe "Code gen: pointer" do
       p.value = Pointer(Int32).malloc(1_u64)
       p.value.value = 1
       foo p
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codgens pointer as if condition inside union (1)" do
-    run(%(
+    expect(run(%(
       ptr = Pointer(Int32).new(0_u64) || Pointer(Float64).new(0_u64)
       if ptr
         1
       else
         2
       end
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "codgens pointer as if condition inside union (2)" do
-    run(%(
+    expect(run(%(
       if 1 == 1
         ptr = Pointer(Int32).new(0_u64)
       else
         ptr = 10
       end
       ptr ? 20 : 30
-      )).to_i.should eq(30)
+      )).to_i).to eq(30)
   end
 end

--- a/spec/compiler/codegen/previous_def_spec.cr
+++ b/spec/compiler/codegen/previous_def_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "codegen: previous_def" do
   it "codegens previous def" do
-    run(%(
+    expect(run(%(
       def foo
         1
       end
@@ -12,11 +12,11 @@ describe "codegen: previous_def" do
       end
 
       foo
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "codeges previous def when inside fun and forwards args" do
-    run(%(
+    expect(run(%(
       def foo(z)
         z + 1
       end
@@ -27,11 +27,11 @@ describe "codegen: previous_def" do
 
       x = foo(2)
       x.call(3)
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "codegens previous def when inside fun with self" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           @x = 1
@@ -49,6 +49,6 @@ describe "codegen: previous_def" do
       end
 
       Foo.new.bar.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -2,56 +2,56 @@ require "../../spec_helper"
 
 describe "Code gen: primitives" do
   it "codegens bool" do
-    run("true").to_b.should be_true
-    run("false").to_b.should be_false
+    expect(run("true").to_b).to be_true
+    expect(run("false").to_b).to be_false
   end
 
   it "codegens int" do
-    run("1").to_i.should eq(1)
+    expect(run("1").to_i).to eq(1)
   end
 
   it "codegens long" do
-    run("1_i64").to_i.should eq(1)
+    expect(run("1_i64").to_i).to eq(1)
   end
 
   it "codegens char" do
-    run("'a'").to_i.should eq('a'.ord)
+    expect(run("'a'").to_i).to eq('a'.ord)
   end
 
   it "codegens f32" do
-    run("2.5_f32").to_f32.should eq(2.5_f32)
+    expect(run("2.5_f32").to_f32).to eq(2.5_f32)
   end
 
   it "codegens f64" do
-    run("2.5_f64").to_f64.should eq(2.5_f64)
+    expect(run("2.5_f64").to_f64).to eq(2.5_f64)
   end
 
   it "codegens string" do
-    run(%("foo")).to_string.should eq("foo")
+    expect(run(%("foo")).to_string).to eq("foo")
   end
 
   it "codegens 1 + 2" do
-    run(%(1 + 2)).to_i.should eq(3)
+    expect(run(%(1 + 2)).to_i).to eq(3)
   end
 
   it "codegens 1 + 2" do
-    run(%(1 - 2)).to_i.should eq(-1)
+    expect(run(%(1 - 2)).to_i).to eq(-1)
   end
 
   it "codegens 2 * 3" do
-    run(%(2 * 3)).to_i.should eq(6)
+    expect(run(%(2 * 3)).to_i).to eq(6)
   end
 
   it "codegens 8.unsafe_div 3" do
-    run(%(8.unsafe_div 3)).to_i.should eq(2)
+    expect(run(%(8.unsafe_div 3)).to_i).to eq(2)
   end
 
   it "codegens 8.unsafe_mod 3" do
-    run(%(10.unsafe_mod 3)).to_i.should eq(1)
+    expect(run(%(10.unsafe_mod 3)).to_i).to eq(1)
   end
 
   it "defined method that calls primitive (bug)" do
-    run("
+    expect(run("
       struct Int64
         def foo
           to_u64
@@ -60,18 +60,18 @@ describe "Code gen: primitives" do
 
       a = 1_i64
       a.foo.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens __LINE__" do
-    run("
+    expect(run("
 
       __LINE__
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codeges crystal_type_id with union type" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -80,36 +80,36 @@ describe "Code gen: primitives" do
 
       f = Foo.allocate || Bar.allocate
       f.crystal_type_id == Foo.allocate.crystal_type_id
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "doesn't treat `(1 == 1) == true` as `1 == 1 == true` (#328)" do
-    run("(1 == 1) == true").to_b.should be_true
+    expect(run("(1 == 1) == true").to_b).to be_true
   end
 
   it "passes issue #328" do
-    run("((1 == 1) != (2 == 2))").to_b.should be_false
+    expect(run("((1 == 1) != (2 == 2))").to_b).to be_false
   end
 
   pending "codegens pointer of int" do
-    run(%(
+    expect(run(%(
       ptr = Pointer(Int).malloc(1_u64)
       ptr.value = 1
       ptr.value = 2_u8
       ptr.value = 3_u16
       ptr.value = 4_u32
       (ptr.value + 1).to_i32
-      )).to_i.should eq(5)
+      )).to_i).to eq(5)
   end
 
   pending "sums two numbers out of an [] of Number" do
-    run(%(
+    expect(run(%(
       p = Pointer(Number).malloc(2_u64)
       p.value = 1
       (p + 1_i64).value = 1.5
 
       (p.value + (p + 1_i64).value).to_f32
-      )).to_f32.should eq(2.5)
+      )).to_f32).to eq(2.5)
   end
 
   it "codegens crystal_type_id for class" do

--- a/spec/compiler/codegen/responds_to_spec.cr
+++ b/spec/compiler/codegen/responds_to_spec.cr
@@ -2,52 +2,52 @@ require "../../spec_helper"
 
 describe "Codegen: responds_to?" do
   it "codegens responds_to? true for simple type" do
-    run("1.responds_to?(:\"+\")").to_b.should be_true
+    expect(run("1.responds_to?(:\"+\")").to_b).to be_true
   end
 
   it "codegens responds_to? false for simple type" do
-    run("1.responds_to?(:foo)").to_b.should be_false
+    expect(run("1.responds_to?(:foo)").to_b).to be_false
   end
 
   it "codegens responds_to? with union gives true" do
-    run("(1 == 1 ? 1 : 'a').responds_to?(:\"+\")").to_b.should be_true
+    expect(run("(1 == 1 ? 1 : 'a').responds_to?(:\"+\")").to_b).to be_true
   end
 
   it "codegens responds_to? with union gives false" do
-    run("(1 == 1 ? 1 : 'a').responds_to?(:\"foo\")").to_b.should be_false
+    expect(run("(1 == 1 ? 1 : 'a').responds_to?(:\"foo\")").to_b).to be_false
   end
 
   it "codegens responds_to? with nilable gives true" do
-    run("struct Nil; def foo; end; end; (1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_true
+    expect(run("struct Nil; def foo; end; end; (1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b).to be_true
   end
 
   it "codegens responds_to? with nilable gives false becuase other type 1" do
-    run("(1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_false
+    expect(run("(1 == 1 ? nil : Reference.new).responds_to?(:foo)").to_b).to be_false
   end
 
   it "codegens responds_to? with nilable gives false becuase other type 2" do
-    run("class Reference; def foo; end; end; (1 == 2 ? nil : Reference.new).responds_to?(:foo)").to_b.should be_true
+    expect(run("class Reference; def foo; end; end; (1 == 2 ? nil : Reference.new).responds_to?(:foo)").to_b).to be_true
   end
 
   it "codegends responds_to? with generic class (1)" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def foo
         end
       end
 
       Foo(Int32).new.responds_to?(:foo)
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 
   it "codegends responds_to? with generic class (2)" do
-    run(%(
+    expect(run(%(
       class Foo(T)
         def foo
         end
       end
 
       Foo(Int32).new.responds_to?(:bar)
-      )).to_b.should be_false
+      )).to_b).to be_false
   end
 end

--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -2,35 +2,35 @@ require "../../spec_helper"
 
 describe "Code gen: return" do
   it "codegens return" do
-    run("def foo; return 1; end; foo").to_i.should eq(1)
+    expect(run("def foo; return 1; end; foo").to_i).to eq(1)
   end
 
   it "codegens return followed by another expression" do
-    run("def foo; return 1; 2; end; foo").to_i.should eq(1)
+    expect(run("def foo; return 1; 2; end; foo").to_i).to eq(1)
   end
 
   it "codegens return inside if" do
-    run("def foo; if 1 == 1; return 1; end; 2; end; foo").to_i.should eq(1)
+    expect(run("def foo; if 1 == 1; return 1; end; 2; end; foo").to_i).to eq(1)
   end
 
   it "return from function with union type" do
-    run("struct Char; def to_i; 2; end; end; def foo; return 1 if 1 == 1; 'a'; end; foo.to_i").to_i.should eq(1)
+    expect(run("struct Char; def to_i; 2; end; end; def foo; return 1 if 1 == 1; 'a'; end; foo.to_i").to_i).to eq(1)
   end
 
   it "return union" do
-    run("struct Char; def to_i; 2; end; end; def foo; 1 == 2 ? return 1 : return 'a'; end; foo.to_i").to_i.should eq(2)
+    expect(run("struct Char; def to_i; 2; end; end; def foo; 1 == 2 ? return 1 : return 'a'; end; foo.to_i").to_i).to eq(2)
   end
 
   it "return from function with nilable type" do
-    run("require \"nil\"; require \"reference\"; def foo; return Reference.new if 1 == 1; end; foo.nil?").to_b.should be_false
+    expect(run("require \"nil\"; require \"reference\"; def foo; return Reference.new if 1 == 1; end; foo.nil?").to_b).to be_false
   end
 
   it "return from function with nilable type 2" do
-    run("require \"nil\"; require \"reference\"; def foo; return Reference.new if 1 == 1; end; foo.nil?").to_b.should be_false
+    expect(run("require \"nil\"; require \"reference\"; def foo; return Reference.new if 1 == 1; end; foo.nil?").to_b).to be_false
   end
 
   it "returns empty from function" do
-    run("
+    expect(run("
       struct Nil; def to_i; 0; end; end
       def foo(x)
         return if x == 1
@@ -38,6 +38,6 @@ describe "Code gen: return" do
       end
 
       foo(2).to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -2,11 +2,11 @@ require "../../spec_helper"
 
 describe "Code gen: sizeof" do
   it "gets sizeof int" do
-    run("sizeof(Int32)").to_i.should eq(4)
+    expect(run("sizeof(Int32)").to_i).to eq(4)
   end
 
   it "gets sizeof struct" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x, @y, @z)
         end
@@ -15,12 +15,12 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       sizeof(Foo)
-      ").to_i.should eq(12)
+      ").to_i).to eq(12)
   end
 
   it "gets sizeof class" do
     # A class is represented as a pointer to its data
-    run("
+    expect(run("
       class Foo
         def initialize(@x, @y, @z)
         end
@@ -29,7 +29,7 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       sizeof(Foo)
-      ").to_i.should eq(sizeof(Void*))
+      ").to_i).to eq(sizeof(Void*))
   end
 
   it "gets sizeof union" do
@@ -49,14 +49,14 @@ describe "Code gen: sizeof" do
     #
     # In 32 bits structs are aligned to 4 bytes, so it remains the same.
     ifdef x86_64
-      size.should eq(16)
+      expect(size).to eq(16)
     else
-      size.should eq(12)
+      expect(size).to eq(12)
     end
   end
 
   it "gets instance_sizeof class" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x, @y, @z)
         end
@@ -65,7 +65,7 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       instance_sizeof(Foo)
-      ").to_i.should eq(16)
+      ").to_i).to eq(16)
   end
 
   it "gives error if using instance_sizeof on something that's not a class" do
@@ -74,11 +74,11 @@ describe "Code gen: sizeof" do
 
   it "gets sizeof Void" do
     # Same as the size of a byte
-    run("sizeof(Void)").to_i.should eq(1)
+    expect(run("sizeof(Void)").to_i).to eq(1)
   end
 
   it "gets sizeof NoReturn" do
     # Same as the size of a byte
-    run("sizeof(NoReturn)").to_i.should eq(1)
+    expect(run("sizeof(NoReturn)").to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/special_vars_spec.cr
+++ b/spec/compiler/codegen/special_vars_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe "Codegen: special vars" do
   ["$~", "$?"].each do |name|
     it "codegens #{name}" do
-      run(%(
+      expect(run(%(
         class Object; def not_nil!; self; end; end
 
         def foo(z)
@@ -12,11 +12,11 @@ describe "Codegen: special vars" do
 
         foo(2)
         #{name}
-        )).to_string.should eq("hey")
+        )).to_string).to eq("hey")
     end
 
     it "codegens #{name} with nilable (1)" do
-      run(%(
+      expect(run(%(
         require "prelude"
 
         def foo
@@ -32,11 +32,11 @@ describe "Codegen: special vars" do
         rescue ex
           "ouch"
         end
-        )).to_string.should eq("ouch")
+        )).to_string).to eq("ouch")
     end
 
     it "codegens #{name} with nilable (2)" do
-      run(%(
+      expect(run(%(
         require "prelude"
 
         def foo
@@ -52,12 +52,12 @@ describe "Codegen: special vars" do
         rescue ex
           "ouch"
         end
-        )).to_string.should eq("foo")
+        )).to_string).to eq("foo")
     end
   end
 
   it "codegens $~ two levels" do
-    run(%(
+    expect(run(%(
       class Object; def not_nil!; self; end; end
 
       def foo
@@ -71,6 +71,6 @@ describe "Codegen: special vars" do
 
       bar
       $?
-      )).to_string.should eq("hey")
+      )).to_string).to eq("hey")
   end
 end

--- a/spec/compiler/codegen/splat_spec.cr
+++ b/spec/compiler/codegen/splat_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: splat" do
   it "splats" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -12,11 +12,11 @@ describe "Code gen: splat" do
       end
 
       foo 1, 1, 1
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "splats with another arg" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -26,11 +26,11 @@ describe "Code gen: splat" do
       end
 
       foo 10, 1, 1
-      )).to_i.should eq(12)
+      )).to_i).to eq(12)
   end
 
   it "splats with two other args" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -40,22 +40,22 @@ describe "Code gen: splat" do
       end
 
       foo 10, 2, 20
-      )).to_i.should eq(31)
+      )).to_i).to eq(31)
   end
 
   it "splats on call" do
-    run(%(
+    expect(run(%(
       def foo(x, y)
         x + y
       end
 
       tuple = {1, 2}
       foo *tuple
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "splats without args" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -65,11 +65,11 @@ describe "Code gen: splat" do
       end
 
       foo
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "splats with default value" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -79,11 +79,11 @@ describe "Code gen: splat" do
       end
 
       foo
-      )).to_i.should eq(100)
+      )).to_i).to eq(100)
   end
 
   it "splats with default value (2)" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -93,11 +93,11 @@ describe "Code gen: splat" do
       end
 
       foo 10
-      )).to_i.should eq(110)
+      )).to_i).to eq(110)
   end
 
   it "splats with default value (3)" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def length; {{@length}}; end
       end
@@ -107,11 +107,11 @@ describe "Code gen: splat" do
       end
 
       foo 10, 20, 30, 40
-      )).to_i.should eq(32)
+      )).to_i).to eq(32)
   end
 
   it "splats in initialize" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(*args)
           @x, @y = args
@@ -128,6 +128,6 @@ describe "Code gen: splat" do
 
       foo = Foo.new 1, 2
       foo.x + foo.y
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 end

--- a/spec/compiler/codegen/ssa_spec.cr
+++ b/spec/compiler/codegen/ssa_spec.cr
@@ -2,15 +2,15 @@ require "../../spec_helper"
 
 describe "Code gen: ssa" do
   it "codegens a redefined var" do
-    run("
+    expect(run("
       a = 1.5
       a = 1
       a
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens a redefined var inside method" do
-    run("
+    expect(run("
       def foo
         a = 1.5
         a = 1
@@ -18,22 +18,22 @@ describe "Code gen: ssa" do
       end
 
       foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens a redefined var inside method with argument" do
-    run("
+    expect(run("
       def foo(a)
         a = 1
         a
       end
 
       foo 1.5
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens declaration of var inside then when false" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -44,11 +44,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       b.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens declaration of var inside then when true" do
-    run("
+    expect(run("
       struct Nil
         def to_i
           0
@@ -59,11 +59,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       b.to_i
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens a var that is re-assigned in a block" do
-    run(%(
+    expect(run(%(
       struct Char
         def to_i
           10
@@ -79,11 +79,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "codegens a var that is re-assigned in a block (1)" do
-    run(%(
+    expect(run(%(
       struct Char
         def to_i
           10
@@ -95,11 +95,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i
-      )).to_i.should eq(10)
+      )).to_i).to eq(10)
   end
 
   it "codegens a var that is re-assigned in a block (2)" do
-    run(%(
+    expect(run(%(
       struct Char
         def to_i
           10
@@ -111,11 +111,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens a var that is declared in a block (1)" do
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -126,11 +126,11 @@ describe "Code gen: ssa" do
         a = 1
       end
       a.to_i
-      )).to_i.should eq(0)
+      )).to_i).to eq(0)
   end
 
   it "codegens a var that is declared in a block (2)" do
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -143,11 +143,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       a.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens ssa bug with if/else on var" do
-    run(%(
+    expect(run(%(
       a = 1 || nil
       if a && false
         b = 2
@@ -157,11 +157,11 @@ describe "Code gen: ssa" do
         b = 4
       end
       b
-      )).to_i.should eq(3)
+      )).to_i).to eq(3)
   end
 
   it "codegens ssa bug (1)" do
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -182,13 +182,13 @@ describe "Code gen: ssa" do
         1
       end
       a.to_i
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens ssa bug (2)" do
     # This shows a bug where a block variable (coconio in this case)
     # wasn't reset to nil before each block iteration.
-    run(%(
+    expect(run(%(
       struct Nil
         def to_i
           0
@@ -209,6 +209,6 @@ describe "Code gen: ssa" do
         a += coconio.to_i
       end
       a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/struct_spec.cr
+++ b/spec/compiler/codegen/struct_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: struct" do
   it "creates structs" do
-    run("
+    expect(run("
       struct Foo
       end
 
       f = Foo.allocate
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "creates structs with instance var" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -24,11 +24,11 @@ describe "Code gen: struct" do
 
       f = Foo.new(1)
       f.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "assigning a struct makes a copy (1)" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -47,11 +47,11 @@ describe "Code gen: struct" do
       g.x = 2
 
       g.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "assigning a struct makes a copy (2)" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -70,11 +70,11 @@ describe "Code gen: struct" do
       g.x = 2
 
       f.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "passes a struct as a parameter makes a copy" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -96,11 +96,11 @@ describe "Code gen: struct" do
       foo(f)
 
       f.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "passes a generic struct as a parameter makes a copy" do
-    run("
+    expect(run("
       struct Foo(T)
         def initialize(@x)
         end
@@ -122,11 +122,11 @@ describe "Code gen: struct" do
       foo(f)
 
       f.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "returns struct as a copy" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -148,11 +148,11 @@ describe "Code gen: struct" do
 
       g = foo(f)
       g.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "creates struct in def" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -167,11 +167,11 @@ describe "Code gen: struct" do
       end
 
       foo.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "declares const struct" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -184,11 +184,11 @@ describe "Code gen: struct" do
       FOO = Foo.new(1)
 
       FOO.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "uses struct in if" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -206,11 +206,11 @@ describe "Code gen: struct" do
         $foo = FOO
       end
       $foo.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "uses nilable struct" do
-    run("
+    expect(run("
       struct Nil
         def nil?
           true
@@ -228,11 +228,11 @@ describe "Code gen: struct" do
 
       f = Foo.new || nil
       f.nil? ? 1 : 2
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "returns self" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -250,11 +250,11 @@ describe "Code gen: struct" do
       f = Foo.new(1)
       g = f.foo
       g.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "returns self with block" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -273,11 +273,11 @@ describe "Code gen: struct" do
       f = Foo.new(1)
       g = f.foo { }
       g.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "does phi of struct" do
-    run("
+    expect(run("
       struct Foo
         def initialize(@x)
         end
@@ -293,11 +293,11 @@ describe "Code gen: struct" do
             Foo.new(1)
           end
       x.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "allows assinging to struct argument (bug)" do
-    run("
+    expect(run("
       struct Foo
         def bar
           2
@@ -309,6 +309,6 @@ describe "Code gen: struct" do
       end
 
       foo(Foo.new)
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/super_spec.cr
+++ b/spec/compiler/codegen/super_spec.cr
@@ -2,19 +2,19 @@ require "../../spec_helper"
 
 describe "Codegen: super" do
   it "codegens super without arguments" do
-    run("class Foo; def foo; 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i.should eq(1)
+    expect(run("class Foo; def foo; 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i).to eq(1)
   end
 
   it "codegens super without arguments but parent has arguments" do
-    run("class Foo; def foo(x); x + 1; end; end; class Bar < Foo; def foo(x); super; end; end; Bar.new.foo(1)").to_i.should eq(2)
+    expect(run("class Foo; def foo(x); x + 1; end; end; class Bar < Foo; def foo(x); super; end; end; Bar.new.foo(1)").to_i).to eq(2)
   end
 
   it "codegens super without arguments and instance variable" do
-    run("class Foo; def foo; @x = 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i.should eq(1)
+    expect(run("class Foo; def foo; @x = 1; end; end; class Bar < Foo; def foo; super; end; end; Bar.new.foo").to_i).to eq(1)
   end
 
   it "codegens super that calls subclass method" do
-    run("
+    expect(run("
       class Foo
         def foo
           bar
@@ -37,11 +37,11 @@ describe "Codegen: super" do
 
       b = Bar.new
       b.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens super that calls subclass method 2" do
-    run("
+    expect(run("
       class Foo
         def foo
           self.bar
@@ -64,11 +64,11 @@ describe "Codegen: super" do
 
       b = Bar.new
       b.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens super that calls subclass method 3" do
-    run("
+    expect(run("
       class Foo
         def foo
           self.bar
@@ -91,11 +91,11 @@ describe "Codegen: super" do
 
       b = Foo.new || Bar.new
       b.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens super that calls subclass method 4" do
-    run("
+    expect(run("
       class Foo
         def foo
           self.bar
@@ -118,11 +118,11 @@ describe "Codegen: super" do
 
       b = Bar.new || Foo.new
       b.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens super that calls subclass method 5" do
-    run("
+    expect(run("
       module Mod
         def add_def
           another
@@ -154,11 +154,11 @@ describe "Codegen: super" do
 
       c = PrimitiveType.new || IntegerType.new
       c.add_def
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens super that calls subclass method 6" do
-    run("
+    expect(run("
       module Mod
         def add_def
           another
@@ -190,11 +190,11 @@ describe "Codegen: super" do
 
       c = IntegerType.new || PrimitiveType.new
       c.add_def
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens super inside closure" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -212,11 +212,11 @@ describe "Codegen: super" do
 
       f = Bar.new(1).foo
       f.call
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens super inside closure forwarding args" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -234,7 +234,7 @@ describe "Codegen: super" do
 
       f = Bar.new(1).foo(2)
       f.call(3)
-      )).to_i.should eq(6)
+      )).to_i).to eq(6)
   end
 
   it "build super on generic class (bug)" do
@@ -256,7 +256,7 @@ describe "Codegen: super" do
   end
 
   it "calls super in module method (#556)" do
-    run(%(
+    expect(run(%(
       class Parent
         def a
           1
@@ -274,11 +274,11 @@ describe "Codegen: super" do
       end
 
       Child.new.a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "calls super in generic module method" do
-    run(%(
+    expect(run(%(
       class Parent
         def a
           1
@@ -296,6 +296,6 @@ describe "Codegen: super" do
       end
 
       Child.new.a
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 end

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -2,29 +2,29 @@ require "../../spec_helper"
 
 describe "Code gen: tuple" do
   it "codegens tuple [0]" do
-    run("{1, true}[0]").to_i.should eq(1)
+    expect(run("{1, true}[0]").to_i).to eq(1)
   end
 
   it "codegens tuple [1]" do
-    run("{1, true}[1]").to_b.should be_true
+    expect(run("{1, true}[1]").to_b).to be_true
   end
 
   it "codegens tuple [1] (2)" do
-    run("{true, 3}[1]").to_i.should eq(3)
+    expect(run("{true, 3}[1]").to_i).to eq(3)
   end
 
   it "passed tuple to def" do
-    run("
+    expect(run("
       def foo(t)
         t[1]
       end
 
       foo({1, 2, 3})
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "accesses a tuple type and creates instance from it" do
-    run("
+    expect(run("
       struct Tuple
         def types
           T
@@ -43,11 +43,11 @@ describe "Code gen: tuple" do
       t = {Foo.new(1)}
       f = t.types[0].new(2)
       f.x
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "allows malloc pointer of tuple" do
-    run("
+    expect(run("
       struct Pointer
         def self.malloc(size : Int)
           malloc(size.to_u64)
@@ -62,20 +62,20 @@ describe "Code gen: tuple" do
 
       p = foo({1, 2})
       p.value[0] + p.value[1]
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens tuple union (bug because union size was computed incorrectly)" do
-    run(%(
+    expect(run(%(
       require "prelude"
       x = 1 == 1 ? {1, 1, 1} : {1}
       i = 2
       x[i]
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens tuple class" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize(@x)
         end
@@ -96,11 +96,11 @@ describe "Code gen: tuple" do
       foo_class = tuple_class[0]
       foo2 = foo_class.new(2)
       foo2.x
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "gets length at compile time" do
-    run(%(
+    expect(run(%(
       struct Tuple
         def my_length
           {{ @length }}
@@ -108,6 +108,6 @@ describe "Code gen: tuple" do
       end
 
       {1, 1}.my_length
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -2,35 +2,35 @@ require "../../spec_helper"
 
 describe "Code gen: union type" do
   it "codegens union type when obj is union and no args" do
-    run("a = 1; a = 2.5_f32; a.to_f").to_f64.should eq(2.5)
+    expect(run("a = 1; a = 2.5_f32; a.to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type when obj is union and arg is union" do
-    run("a = 1; a = 1.5_f32; (a + a).to_f").to_f64.should eq(3)
+    expect(run("a = 1; a = 1.5_f32; (a + a).to_f").to_f64).to eq(3)
   end
 
   it "codegens union type when obj is not union but arg is" do
-    run("a = 1; b = 2; b = 1.5_f32; (a + b).to_f").to_f64.should eq(2.5)
+    expect(run("a = 1; b = 2; b = 1.5_f32; (a + b).to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type when obj union but arg is not" do
-    run("a = 1; b = 2; b = 1.5_f32; (b + a).to_f").to_f64.should eq(2.5)
+    expect(run("a = 1; b = 2; b = 1.5_f32; (b + a).to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type when no obj" do
-    run("def foo(x); x; end; a = 1; a = 2.5_f32; foo(a).to_f").to_f64.should eq(2.5)
+    expect(run("def foo(x); x; end; a = 1; a = 2.5_f32; foo(a).to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type when no obj and restrictions" do
-    run("def foo(x : Int); 1.5; end; def foo(x : Float); 2.5; end; a = 1; a = 3.5_f32; foo(a).to_f").to_f64.should eq(2.5)
+    expect(run("def foo(x : Int); 1.5; end; def foo(x : Float); 2.5; end; a = 1; a = 3.5_f32; foo(a).to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type as return value" do
-    run("def foo; a = 1; a = 2.5_f32; a; end; foo.to_f").to_f64.should eq(2.5)
+    expect(run("def foo; a = 1; a = 2.5_f32; a; end; foo.to_f").to_f64).to eq(2.5)
   end
 
   it "codegens union type for instance var" do
-    run("
+    expect(run("
       class Foo
         def initialize(value)
           @value = value
@@ -42,11 +42,11 @@ describe "Code gen: union type" do
       f = Foo.new(1)
       f.value = 1.5_f32
       (f.value + f.value).to_f
-    ").to_f64.should eq(3)
+    ").to_f64).to eq(3)
   end
 
   it "codegens if with same nested union" do
-    run("
+    expect(run("
       if true
         if true
           1
@@ -60,11 +60,11 @@ describe "Code gen: union type" do
           2.5_f32
         end
       end.to_i
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "assigns union to union" do
-    run("
+    expect(run("
       require \"prelude\"
 
       struct Char
@@ -88,11 +88,11 @@ describe "Code gen: union type" do
       f.foo 1
       f.foo 'a'
       f.x.to_i
-      ").to_i.should eq(97)
+      ").to_i).to eq(97)
   end
 
   it "assigns union to larger union" do
-    run("
+    expect(run("
       require \"prelude\"
       a = 1
       a = 1.1_f32
@@ -100,7 +100,7 @@ describe "Code gen: union type" do
       b = 'd'
       a = b
       a.to_s
-    ").to_string.should eq("d")
+    ").to_string).to eq("d")
   end
 
   it "assigns union to larger union when source is nilable 1" do
@@ -112,18 +112,18 @@ describe "Code gen: union type" do
       a = b
       a.to_s
     ").to_string
-    value.includes?("Reference").should be_true
+    expect(value.includes?("Reference")).to be_true
   end
 
   it "assigns union to larger union when source is nilable 2" do
-    run("
+    expect(run("
       require \"prelude\"
       a = 1
       b = Reference.new
       b = nil
       a = b
       a.to_s
-    ").to_string.should eq("")
+    ").to_string).to eq("")
   end
 
   it "dispatch call to object method on nilable" do
@@ -139,7 +139,7 @@ describe "Code gen: union type" do
   end
 
   it "sorts restrictions when there are unions" do
-    run("
+    expect(run("
       class Middle
       end
 
@@ -170,11 +170,11 @@ describe "Code gen: union type" do
 
       t = Top.new || Another1.new
       type_id t
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens union to_s" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       def foo(x : T)
@@ -183,6 +183,6 @@ describe "Code gen: union type" do
 
       a = 1 || 1.5
       foo(a)
-      )).to_string.should eq("(Int32 | Float64)")
+      )).to_string).to eq("(Int32 | Float64)")
   end
 end

--- a/spec/compiler/codegen/until_spec.cr
+++ b/spec/compiler/codegen/until_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Codegen: until" do
   it "codegens until" do
-    run(%(
+    expect(run(%(
       require "bool"
 
       a = 1
@@ -10,11 +10,11 @@ describe "Codegen: until" do
         a = a + 1
       end
       a
-    )).to_i.should eq(10)
+    )).to_i).to eq(10)
   end
 
   it "codegens until as modifier" do
-    run(%(
+    expect(run(%(
       require "bool"
 
       a = 1
@@ -22,6 +22,6 @@ describe "Codegen: until" do
         a += 1
       end until a >= 1
       a
-    )).to_i.should eq(2)
+    )).to_i).to eq(2)
   end
 end

--- a/spec/compiler/codegen/untyped_expression_spec.cr
+++ b/spec/compiler/codegen/untyped_expression_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: untyped expression spec" do
   it "raises if class was never instantiated" do
-    run(%(
+    expect(run(%(
       require "prelude"
 
       class Foo
@@ -20,6 +20,6 @@ describe "Code gen: untyped expression spec" do
       rescue ex
         ex.message.includes?("Foo in `foo` was never instantiated")
       end
-      )).to_b.should be_true
+      )).to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/var_spec.cr
+++ b/spec/compiler/codegen/var_spec.cr
@@ -2,11 +2,11 @@ require "../../spec_helper"
 
 describe "Code gen: var" do
   it "codegens var" do
-    run("a = 1; 1.5; a").to_i.should eq(1)
+    expect(run("a = 1; 1.5; a").to_i).to eq(1)
   end
 
   it "codegens ivar assignment when not-nil type filter applies" do
-    run("
+    expect(run("
       class Foo
         def foo
           if @a
@@ -18,11 +18,11 @@ describe "Code gen: var" do
 
       foo = Foo.new
       foo.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens bug with instance vars and ssa" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @angle = 0
@@ -39,11 +39,11 @@ describe "Code gen: var" do
 
       f = Foo.new
       f.foo
-      ").to_i.should eq(-1)
+      ").to_i).to eq(-1)
   end
 
   it "codegens bug with var, while, if, break and ssa" do
-    run("
+    expect(run("
       a = 1
       a = 2
 
@@ -56,11 +56,11 @@ describe "Code gen: var" do
       end
 
       a
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens bug with union of int, nil and string (1): assigning nil to union must fill all zeros" do
-    run(%(
+    expect(run(%(
       struct Nil
         def foo
           1
@@ -80,11 +80,11 @@ describe "Code gen: var" do
         x = "a"
       end
       x.foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens bug with union of int, nil and string (2): assigning nil to union must fill all zeros" do
-    run(%(
+    expect(run(%(
       struct Nil
         def foo
           1
@@ -104,7 +104,7 @@ describe "Code gen: var" do
         x = "a"
       end
       x.foo
-      )).to_i.should eq(1)
+      )).to_i).to eq(1)
   end
 
   it "codegens assignment that can never be reached" do

--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: virtual type" do
   it "call base method" do
-    run("
+    expect(run("
       class Foo
         def coco
           1
@@ -15,11 +15,11 @@ describe "Code gen: virtual type" do
       a = Foo.new
       a = Bar.new
       a.coco
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "call overwritten method" do
-    run("
+    expect(run("
       class Foo
         def coco
           1
@@ -35,11 +35,11 @@ describe "Code gen: virtual type" do
       a = Foo.new
       a = Bar.new
       a.coco
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "call base overwritten method" do
-    run("
+    expect(run("
       class Foo
         def coco
           1
@@ -55,11 +55,11 @@ describe "Code gen: virtual type" do
       a = Bar.new
       a = Foo.new
       a.coco
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "dispatch call with virtual type argument" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -77,11 +77,11 @@ describe "Code gen: virtual type" do
       a = Bar.new
       a = Foo.new
       coco(a)
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "can belong to union" do
-    run("
+    expect(run("
       class Foo
         def foo; 1; end
       end
@@ -94,11 +94,11 @@ describe "Code gen: virtual type" do
       x = Bar.new
       x = Baz.new
       x.foo
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "lookup instance variables in parent types" do
-    run("
+    expect(run("
       class Foo
         def initialize
           @x = 1
@@ -116,11 +116,11 @@ describe "Code gen: virtual type" do
 
       a = Bar.new || Foo.new
       a.foo
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "assign instance variable in virtual type" do
-    run("
+    expect(run("
       class Foo
         def foo
           @x = 1
@@ -132,11 +132,11 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "codegens non-virtual call that calls virtual call to another virtual call" do
-    run("
+    expect(run("
       class Foo
         def foo
           foo2
@@ -155,11 +155,11 @@ describe "Code gen: virtual type" do
 
       bar = Bar.new
       bar.bar
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "casts virtual type to base virtual type" do
-    run("
+    expect(run("
       class Object
         def bar
           1
@@ -177,7 +177,7 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens call to Object#to_s from virtual type" do
@@ -208,7 +208,7 @@ describe "Code gen: virtual type" do
   end
 
   it "codegens virtual call with explicit self" do
-    run("
+    expect(run("
       class Foo
         def foo
           self.bar
@@ -224,11 +224,11 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens virtual call with explicit self and nilable type" do
-    run("
+    expect(run("
       class Foo
         def foo
           self.bar
@@ -250,7 +250,7 @@ describe "Code gen: virtual type" do
 
       f = Bar.new || nil
       f.foo.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "initializes ivars to nil even if object never instantiated" do
@@ -289,7 +289,7 @@ describe "Code gen: virtual type" do
   end
 
   it "doesn't lookup in Value+ when virtual type is Object+" do
-    run("
+    expect(run("
       require \"bool\"
       require \"reference\"
 
@@ -304,11 +304,11 @@ describe "Code gen: virtual type" do
 
       a = Foo.new
       a.foo
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 
   it "correctly dispatch call with block when the obj is a virtual type" do
-    run("
+    expect(run("
       class Foo
         def each
           yield self
@@ -331,11 +331,11 @@ describe "Code gen: virtual type" do
       y = 0
       a.each {|x| y = x.foo}
       y
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "dispatch call with nilable virtual arg" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -356,11 +356,11 @@ describe "Code gen: virtual type" do
 
       x = lala
       foo(x)
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   pending "calls class method 1" do
-    run("
+    expect(run("
       class Foo
         def self.foo
           1
@@ -374,11 +374,11 @@ describe "Code gen: virtual type" do
       end
 
       (Foo.new || Bar.new).class.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   pending "calls class method 2" do
-    run("
+    expect(run("
       class Foo
         def self.foo
           1
@@ -392,11 +392,11 @@ describe "Code gen: virtual type" do
       end
 
       (Bar.new || Foo.new).class.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   pending "calls class method 3" do
-    run("
+    expect(run("
       class Base
         def self.foo
           1
@@ -413,11 +413,11 @@ describe "Code gen: virtual type" do
       end
 
       (Foo.new || Base.new).class.foo
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "dispatches on virtual metaclass (1)" do
-    run("
+    expect(run("
       class Foo
         def self.coco
           1
@@ -432,11 +432,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Foo || Bar
       some_long_var.coco
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "dispatches on virtual metaclass (2)" do
-    run("
+    expect(run("
       class Foo
         def self.coco
           1
@@ -451,11 +451,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Bar || Foo
       some_long_var.coco
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "dispatches on virtual metaclass (3)" do
-    run("
+    expect(run("
       class Foo
         def self.coco
           1
@@ -473,11 +473,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Baz || Foo
       some_long_var.coco
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "codegens new for simple type, then for virtual" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -493,11 +493,11 @@ describe "Code gen: virtual type" do
       x = Foo.new(1)
       y = (Foo || Bar).new(1)
       y.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens new twice for virtual" do
-    run("
+    expect(run("
       class Foo
         def initialize(@x)
         end
@@ -513,11 +513,11 @@ describe "Code gen: virtual type" do
       y = (Foo || Bar).new(1)
       y = (Foo || Bar).new(1)
       y.x
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens allocate for virtual type with custom new" do
-    run("
+    expect(run("
       class Foo
         def self.new
           allocate
@@ -536,11 +536,11 @@ describe "Code gen: virtual type" do
 
       foo = (Bar || Foo).new
       foo.foo
-      ").to_i.should eq(2)
+      ").to_i).to eq(2)
   end
 
   it "returns type with virtual type def type" do
-    run("
+    expect(run("
       class Foo
         def foo
           1
@@ -559,11 +559,11 @@ describe "Code gen: virtual type" do
       end
 
       foo.foo
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "casts virtual type to union" do
-    run("
+    expect(run("
       class Foo
       end
 
@@ -589,11 +589,11 @@ describe "Code gen: virtual type" do
 
       f = Baz.new || Bar.new
       x(f)
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "casts union to virtual" do
-    run("
+    expect(run("
       module Moo
       end
 
@@ -620,6 +620,6 @@ describe "Code gen: virtual type" do
 
       reference = Bar.new || Baz.new
       reference.object_id == foo(reference)
-      ").to_b.should be_true
+      ").to_b).to be_true
   end
 end

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -2,18 +2,18 @@ require "../../spec_helper"
 
 describe "Code gen: void" do
   it "codegens void assignment" do
-    run("
+    expect(run("
       fun foo : Void
       end
 
       a = foo
       a
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens void assignment in case" do
-    run("
+    expect(run("
       require \"prelude\"
 
       fun foo : Void
@@ -30,11 +30,11 @@ describe "Code gen: void" do
 
       bar
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens void assignment in case with local variable" do
-    run("
+    expect(run("
       require \"prelude\"
 
       fun foo : Void
@@ -52,7 +52,7 @@ describe "Code gen: void" do
 
       bar
       1
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "codegens unreachable code" do

--- a/spec/compiler/codegen/while_spec.cr
+++ b/spec/compiler/codegen/while_spec.cr
@@ -6,23 +6,23 @@ describe "Codegen: while" do
   end
 
   it "codegens while with false" do
-    run("a = 1; while false; a = 2; end; a").to_i.should eq(1)
+    expect(run("a = 1; while false; a = 2; end; a").to_i).to eq(1)
   end
 
   it "codegens while with non-false condition" do
-    run("a = 1; while a < 10; a = a + 1; end; a").to_i.should eq(10)
+    expect(run("a = 1; while a < 10; a = a + 1; end; a").to_i).to eq(10)
   end
 
   it "codegens while as modifier" do
-    run("a = 1; begin; a += 1; end while false; a").to_i.should eq(2)
+    expect(run("a = 1; begin; a += 1; end while false; a").to_i).to eq(2)
   end
 
   it "break without value" do
-    run("a = 0; while a < 10; a += 1; break; end; a").to_i.should eq(1)
+    expect(run("a = 0; while a < 10; a += 1; break; end; a").to_i).to eq(1)
   end
 
   it "conditional break without value" do
-    run("a = 0; while a < 10; a += 1; break if a > 5; end; a").to_i.should eq(6)
+    expect(run("a = 0; while a < 10; a += 1; break if a > 5; end; a").to_i).to eq(6)
   end
 
   it "codegens endless while" do
@@ -30,17 +30,17 @@ describe "Codegen: while" do
   end
 
   it "codegens while with declared var 1" do
-    run("
+    expect(run("
       require \"nil\"
       while 1 == 2
         a = 2
       end
       a.to_i
-      ").to_i.should eq(0)
+      ").to_i).to eq(0)
   end
 
   it "codegens while with declared var 2" do
-    run("
+    expect(run("
       require \"nil\"
       while 1 == 1
         a = 2
@@ -50,11 +50,11 @@ describe "Codegen: while" do
         end
       end
       a.to_i
-      ").to_i.should eq(3)
+      ").to_i).to eq(3)
   end
 
   it "codegens while with declared var 3" do
-    run("
+    expect(run("
       require \"nil\"
       while 1 == 1
         a = 1
@@ -65,11 +65,11 @@ describe "Codegen: while" do
         end
       end
       a.to_i
-      ").to_i.should eq(1)
+      ").to_i).to eq(1)
   end
 
   it "skip block with next" do
-    run("
+    expect(run("
       i = 0
       x = 0
 
@@ -79,6 +79,6 @@ describe "Codegen: while" do
         x += i
       end
       x
-    ").to_i.should eq(25)
+    ").to_i).to eq(25)
   end
 end

--- a/spec/compiler/codegen/yield_with_scope_spec.cr
+++ b/spec/compiler/codegen/yield_with_scope_spec.cr
@@ -2,18 +2,18 @@ require "../../spec_helper"
 
 describe "Type inference: yield with scope" do
   it "uses scope in global method" do
-    run("
+    expect(run("
       require \"prelude\"
       def foo; with 1 yield; end
 
       foo do
         succ
       end
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "uses scope in instance method" do
-    run("
+    expect(run("
       require \"prelude\"
       def foo; with 1 yield; end
 
@@ -30,11 +30,11 @@ describe "Type inference: yield with scope" do
       end
 
       Foo.new.test
-    ").to_i.should eq(2)
+    ").to_i).to eq(2)
   end
 
   it "it uses self for instance method" do
-    run("
+    expect(run("
       require \"prelude\"
       def foo; with 1 yield; end
 
@@ -51,11 +51,11 @@ describe "Type inference: yield with scope" do
       end
 
       Foo.new.test
-    ").to_i.should eq(10)
+    ").to_i).to eq(10)
   end
 
   it "it invokes global method inside block of yield scope" do
-    run("
+    expect(run("
       require \"prelude\"
 
       def foo
@@ -69,11 +69,11 @@ describe "Type inference: yield with scope" do
       foo do
         plus_two abs
       end
-    ").to_i.should eq(3)
+    ").to_i).to eq(3)
   end
 
   it "generate right code when yielding struct as scope" do
-    run("
+    expect(run("
       struct Foo
         def bar; end
       end
@@ -84,7 +84,7 @@ describe "Type inference: yield with scope" do
       end
 
       foo { bar }
-    ").to_i.should eq(1)
+    ").to_i).to eq(1)
   end
 
   it "doesn't explode if specifying &block but never using it (#181)" do
@@ -103,7 +103,7 @@ describe "Type inference: yield with scope" do
   end
 
   it "uses instance variable of enclosing scope" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo
           with self yield
@@ -123,11 +123,11 @@ describe "Type inference: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "uses method of enclosing scope" do
-    run(%(
+    expect(run(%(
       class Foo
         def foo
           with self yield
@@ -147,11 +147,11 @@ describe "Type inference: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 
   it "uses method of with object" do
-    run(%(
+    expect(run(%(
       class Foo
         def initialize
           @x = 1
@@ -175,6 +175,6 @@ describe "Type inference: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      )).to_i).to eq(2)
   end
 end

--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -8,8 +8,8 @@ describe "Compiler" do
 
     Crystal::Command.run ["build", "#{__DIR__}/data/compiler_sample", "-o", tempfile.path]
 
-    File.exists?(tempfile.path).should be_true
+    expect(File.exists?(tempfile.path)).to be_true
 
-    `#{tempfile.path}`.should eq("Hello!")
+    expect(`#{tempfile.path}`).to eq("Hello!")
   end
 end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -25,60 +25,60 @@ module Crystal
     run_init_project("app", "example_app", "tmp/example_app", "John Smith")
 
     describe_file "example/.gitignore" do |gitignore|
-      gitignore.should contain("/.deps/")
-      gitignore.should contain("/.deps.lock")
-      gitignore.should contain("/libs/")
-      gitignore.should contain("/.crystal/")
+      expect(gitignore).to contain("/.deps/")
+      expect(gitignore).to contain("/.deps.lock")
+      expect(gitignore).to contain("/libs/")
+      expect(gitignore).to contain("/.crystal/")
     end
 
     describe_file "example_app/.gitignore" do |gitignore|
-      gitignore.should contain("/.deps/")
-      gitignore.should_not contain("/.deps.lock")
-      gitignore.should contain("/libs/")
-      gitignore.should contain("/.crystal/")
+      expect(gitignore).to contain("/.deps/")
+      expect(gitignore).to_not contain("/.deps.lock")
+      expect(gitignore).to contain("/libs/")
+      expect(gitignore).to contain("/.crystal/")
     end
 
     describe_file "example/LICENSE" do |license|
-      license.should match %r{Copyright \(c\) \d+ John Smith}
+      expect(license).to match %r{Copyright \(c\) \d+ John Smith}
     end
 
     describe_file "example/README.md" do |readme|
-      readme.should contain("# example")
+      expect(readme).to contain("# example")
 
-      readme.should contain(%{```crystal
+      expect(readme).to contain(%{```crystal
 deps do
   github "[your-github-name]/example"
 end
 ```})
 
-      readme.should contain(%{require "example"})
-      readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example/fork )})
-      readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
+      expect(readme).to contain(%{require "example"})
+      expect(readme).to contain(%{1. Fork it ( https://github.com/[your-github-name]/example/fork )})
+      expect(readme).to contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
     end
 
     describe_file "example/Projectfile" do |projectfile|
-      projectfile.should eq(%{deps do\nend\n})
+      expect(projectfile).to eq(%{deps do\nend\n})
     end
 
     describe_file "example/.travis.yml" do |travis|
       parsed = YAML.load(travis) as Hash
 
-      parsed["language"].should eq("c")
+      expect(parsed["language"]).to eq("c")
 
-      (parsed["before_install"] as String)
-        .should contain("curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash")
+      expect(parsed["before_install"] as String)
+        .to contain("curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash")
 
-      (parsed["before_install"] as String)
-        .should contain("sudo apt-get -q update")
+      expect(parsed["before_install"] as String)
+        .to contain("sudo apt-get -q update")
 
-      (parsed["install"] as String)
-        .should contain("sudo apt-get install crystal")
+      expect(parsed["install"] as String)
+        .to contain("sudo apt-get install crystal")
 
-      parsed["script"].should eq(["crystal spec"])
+      expect(parsed["script"]).to eq(["crystal spec"])
     end
 
     describe_file "example/src/example.cr" do |example|
-      example.should eq(%{require "./example/*"
+      expect(example).to eq(%{require "./example/*"
 
 module Example
   # TODO Put your code here
@@ -87,26 +87,26 @@ end
     end
 
     describe_file "example/src/example/version.cr" do |version|
-      version.should eq(%{module Example
+      expect(version).to eq(%{module Example
   VERSION = "0.0.1"
 end
 })
     end
 
     describe_file "example/spec/spec_helper.cr" do |example|
-      example.should eq(%{require "spec"
+      expect(example).to eq(%{require "spec"
 require "../src/example"
 })
     end
 
     describe_file "example/spec/example_spec.cr" do |example|
-      example.should eq(%{require "./spec_helper"
+      expect(example).to eq(%{require "./spec_helper"
 
 describe Example do
   # TODO: Write tests
 
   it "works" do
-    false.should eq(true)
+    expect(false).to eq(true)
   end
 end
 })

--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -4,19 +4,19 @@ describe Crystal::CrystalPath do
   it "finds file with .cr extension" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "test_files/file_one.cr"
-    matches.should eq(["#{__DIR__}/test_files/file_one.cr"])
+    expect(matches).to eq(["#{__DIR__}/test_files/file_one.cr"])
   end
 
   it "finds file without .cr extension" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "test_files/file_one"
-    matches.should eq(["#{__DIR__}/test_files/file_one.cr"])
+    expect(matches).to eq(["#{__DIR__}/test_files/file_one.cr"])
   end
 
   it "finds all files with *" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "test_files/*"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/file_one.cr",
       "#{__DIR__}/test_files/file_two.cr",
       ])
@@ -25,7 +25,7 @@ describe Crystal::CrystalPath do
   it "finds all files with **" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "test_files/**"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/file_one.cr",
       "#{__DIR__}/test_files/file_two.cr",
       "#{__DIR__}/test_files/test_folder/file_three.cr",
@@ -36,7 +36,7 @@ describe Crystal::CrystalPath do
   it "finds file in directory with its basename" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "test_files/test_folder"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/test_folder/test_folder.cr",
       ])
   end
@@ -51,7 +51,7 @@ describe Crystal::CrystalPath do
   it "finds file relative to another one if using ./" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "./file_two.cr", relative_to: "#{__DIR__}/test_files/file_one.cr"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/file_two.cr",
       ])
   end
@@ -66,7 +66,7 @@ describe Crystal::CrystalPath do
   it "finds file relative to another one with directory if using ./" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "./test_folder/file_three.cr", relative_to: "#{__DIR__}/test_files/file_one.cr"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/test_folder/file_three.cr",
       ])
   end
@@ -81,7 +81,7 @@ describe Crystal::CrystalPath do
   it "finds files with * relative to another one if using ./" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "./test_folder/*", relative_to: "#{__DIR__}/test_files/file_one.cr"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/test_folder/file_three.cr",
       "#{__DIR__}/test_files/test_folder/test_folder.cr",
       ])
@@ -90,7 +90,7 @@ describe Crystal::CrystalPath do
   it "finds files with ** relative to another one" do
     path = Crystal::CrystalPath.new(__DIR__)
     matches = path.find "../**", relative_to: "#{__DIR__}/test_files/test_folder/file_three.cr"
-    matches.should eq([
+    expect(matches).to eq([
       "#{__DIR__}/test_files/file_one.cr",
       "#{__DIR__}/test_files/file_two.cr",
       "#{__DIR__}/test_files/test_folder/file_three.cr",

--- a/spec/compiler/lexer/lexer_comment_spec.cr
+++ b/spec/compiler/lexer/lexer_comment_spec.cr
@@ -5,10 +5,10 @@ describe "Lexer comments" do
     lexer = Lexer.new(%(# Hello\n1))
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    expect(token.type).to eq(:NEWLINE)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
   end
 
   it "lexes with comments enabled" do
@@ -16,14 +16,14 @@ describe "Lexer comments" do
     lexer.comments_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:COMMENT)
-    token.value.should eq("# Hello")
+    expect(token.type).to eq(:COMMENT)
+    expect(token.value).to eq("# Hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    expect(token.type).to eq(:NEWLINE)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
   end
 
   it "lexes with comments enabled (2)" do
@@ -31,17 +31,17 @@ describe "Lexer comments" do
     lexer.comments_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    expect(token.type).to eq(:SPACE)
 
     token = lexer.next_token
-    token.type.should eq(:COMMENT)
-    token.value.should eq("# Hello")
+    expect(token.type).to eq(:COMMENT)
+    expect(token.value).to eq("# Hello")
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "lexes correct number of spaces" do
@@ -49,16 +49,16 @@ describe "Lexer comments" do
     lexer.count_whitespace = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.value.should eq("   ")
+    expect(token.type).to eq(:SPACE)
+    expect(token.value).to eq("   ")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 end

--- a/spec/compiler/lexer/lexer_doc_spec.cr
+++ b/spec/compiler/lexer/lexer_doc_spec.cr
@@ -6,8 +6,8 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should be_nil
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to be_nil
   end
 
   it "lexes with doc enabled but without docs" do
@@ -15,8 +15,8 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should be_nil
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to be_nil
   end
 
   it "lexes with doc enabled and docs" do
@@ -24,12 +24,12 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to eq("hello")
   end
 
   it "lexes with doc enabled and docs, two line comment" do
@@ -37,12 +37,12 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello\nworld")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello\nworld")
   end
 
   it "lexes with doc enabled and docs, two line comment with leading whitespace" do
@@ -50,20 +50,20 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:SPACE)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello\nworld")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello\nworld")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should eq("hello\nworld")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to eq("hello\nworld")
   end
 
   it "lexes with doc enabled and docs, one line comment with two newlines and another comment" do
@@ -71,20 +71,20 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should be_nil
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to be_nil
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.doc.should be_nil
+    expect(token.type).to eq(:SPACE)
+    expect(token.doc).to be_nil
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("world")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("world")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should eq("world")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to eq("world")
   end
 
   it "resets doc after non newline or space token" do
@@ -92,19 +92,19 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should eq("hello")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.doc.should be_nil
+    expect(token.type).to eq(:SPACE)
+    expect(token.doc).to be_nil
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.doc.should be_nil
+    expect(token.type).to eq(:NUMBER)
+    expect(token.doc).to be_nil
   end
 end

--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -5,38 +5,38 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(hello end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("hello ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with expression" do
     lexer = Lexer.new(%(hello {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("hello ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
     token_before_expression = token.clone
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("world")
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(" ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   ["begin", "do", "if", "unless", "class", "struct", "module", "def", "while", "until", "case", "macro", "fun", "lib", "union", "ifdef", "macro def"].each do |keyword|
@@ -44,32 +44,32 @@ describe "Lexer macro" do
       lexer = Lexer.new(%(hello\n  #{keyword} {{world}} end end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq("hello\n  #{keyword} ")
-      token.macro_state.nest.should eq(1)
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq("hello\n  #{keyword} ")
+      expect(token.macro_state.nest).to eq(1)
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_EXPRESSION_START)
+      expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
       token_before_expression = token.clone
 
       token = lexer.next_token
-      token.type.should eq(:IDENT)
-      token.value.should eq("world")
+      expect(token.type).to eq(:IDENT)
+      expect(token.value).to eq("world")
 
-      lexer.next_token.type.should eq(:"}")
-      lexer.next_token.type.should eq(:"}")
+      expect(lexer.next_token.type).to eq(:"}")
+      expect(lexer.next_token.type).to eq(:"}")
 
       token = lexer.next_macro_token(token_before_expression.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq(" ")
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq(" ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq("end ")
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq("end ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      expect(token.type).to eq(:MACRO_END)
     end
   end
 
@@ -77,202 +77,202 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(hello enum {{world}} end end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("hello ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("enum ")
-    token.macro_state.nest.should eq(1)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("enum ")
+    expect(token.macro_state.nest).to eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
     token_before_expression = token.clone
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("world")
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(" ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("end ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("end ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro without nested if" do
     lexer = Lexer.new(%(helloif {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("helloif ")
-    token.macro_state.nest.should eq(0)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("helloif ")
+    expect(token.macro_state.nest).to eq(0)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
     token_before_expression = token.clone
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("world")
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(" ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
     it "lexes macro with nested abstract def" do
       lexer = Lexer.new(%(hello\n  abstract def {{world}} end end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq("hello\n  abstract def ")
-      token.macro_state.nest.should eq(0)
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq("hello\n  abstract def ")
+      expect(token.macro_state.nest).to eq(0)
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_EXPRESSION_START)
+      expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
       token_before_expression = token.clone
 
       token = lexer.next_token
-      token.type.should eq(:IDENT)
-      token.value.should eq("world")
+      expect(token.type).to eq(:IDENT)
+      expect(token.value).to eq("world")
 
-      lexer.next_token.type.should eq(:"}")
-      lexer.next_token.type.should eq(:"}")
+      expect(lexer.next_token.type).to eq(:"}")
+      expect(lexer.next_token.type).to eq(:"}")
 
       token = lexer.next_macro_token(token_before_expression.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq(" ")
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq(" ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      expect(token.type).to eq(:MACRO_END)
     end
 
   it "reaches end" do
     lexer = Lexer.new(%(fail))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("fail")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("fail")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "keeps correct column and line numbers" do
     lexer = Lexer.new("\nfoo\nbarf{{var}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("\nfoo\nbarf")
-    token.column_number.should eq(1)
-    token.line_number.should eq(1)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("\nfoo\nbarf")
+    expect(token.column_number).to eq(1)
+    expect(token.line_number).to eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
     token_before_expression = token.clone
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("var")
-    token.line_number.should eq(3)
-    token.column_number.should eq(7)
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("var")
+    expect(token.line_number).to eq(3)
+    expect(token.column_number).to eq(7)
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("\n")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("\n")
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with control" do
     lexer = Lexer.new("foo{% if ")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("foo")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("foo")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_CONTROL_START)
+    expect(token.type).to eq(:MACRO_CONTROL_START)
   end
 
   it "skips whitespace" do
     lexer = Lexer.new("   \n    coco")
 
     token = lexer.next_macro_token(Token::MacroState.default, true)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("coco")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("coco")
   end
 
   it "lexes macro with embedded string" do
     lexer = Lexer.new(%(good " end " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(%(good " end " day ))
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(%(good " end " day ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with embedded string and backslash" do
     lexer = Lexer.new("good \" end \\\" \" day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("good \" end \\\" \" day ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("good \" end \\\" \" day ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with embedded string and expression" do
     lexer = Lexer.new(%(good " end {{foo}} " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(%(good " end ))
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(%(good " end ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    expect(token.type).to eq(:MACRO_EXPRESSION_START)
 
     macro_state = token.macro_state
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("foo")
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("foo")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
+    expect(lexer.next_token.type).to eq(:"}")
 
     token = lexer.next_macro_token(macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(%( " day ))
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(%( " day ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   [{"(", ")"}, {"[", "]"}, {"<", ">"}].each do |tuple|
@@ -280,22 +280,22 @@ describe "Lexer macro" do
       lexer = Lexer.new("good %#{tuple[0]} end #{tuple[1]} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq("good %#{tuple[0]} end #{tuple[1]} day ")
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq("good %#{tuple[0]} end #{tuple[1]} day ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      expect(token.type).to eq(:MACRO_END)
     end
 
     it "lexes macro with embedded string with %#{tuple[0]} ignores begin" do
       lexer = Lexer.new("good %#{tuple[0]} begin #{tuple[1]} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
-      token.value.should eq("good %#{tuple[0]} begin #{tuple[1]} day ")
+      expect(token.type).to eq(:MACRO_LITERAL)
+      expect(token.value).to eq("good %#{tuple[0]} begin #{tuple[1]} day ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      expect(token.type).to eq(:MACRO_END)
     end
   end
 
@@ -303,147 +303,147 @@ describe "Lexer macro" do
     lexer = Lexer.new("good %( ( ) end ) day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("good %( ( ) end ) day ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("good %( ( ) end ) day ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with comments" do
     lexer = Lexer.new("good # end\n day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("good ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("good ")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("\n day ")
-    token.line_number.should eq(2)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("\n day ")
+    expect(token.line_number).to eq(2)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with curly escape" do
     lexer = Lexer.new("good \\{{world}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("good ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("good ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("{")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("{")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("{world}}\n")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("{world}}\n")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with if as suffix" do
     lexer = Lexer.new("foo if bar end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("foo if bar ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("foo if bar ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with if as suffix after return" do
     lexer = Lexer.new("return if @end end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("return if @end ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("return if @end ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with semicolon before end" do
     lexer = Lexer.new(";end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(";")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(";")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro with if after assign" do
     lexer = Lexer.new("x = if 1; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("x = if 1; 2; ")
-    token.macro_state.nest.should eq(1)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("x = if 1; 2; ")
+    expect(token.macro_state.nest).to eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("else; 3; ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("else; 3; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("end; ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("end; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro var" do
     lexer = Lexer.new("x = if %var; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("x = if ")
-    token.macro_state.nest.should eq(1)
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("x = if ")
+    expect(token.macro_state.nest).to eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_VAR)
-    token.value.should eq("var")
+    expect(token.type).to eq(:MACRO_VAR)
+    expect(token.value).to eq("var")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("; 2; ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("; 2; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("else; 3; ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("else; 3; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq("end; ")
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq("end; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 
   it "lexes macro var inside string" do
     lexer = Lexer.new(%(" %var " end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(%(" ))
-    token.macro_state.nest.should eq(0)
-    token.macro_state.delimiter_state.not_nil!.nest.should eq('"')
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(%(" ))
+    expect(token.macro_state.nest).to eq(0)
+    expect(token.macro_state.delimiter_state.not_nil!.nest).to eq('"')
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_VAR)
-    token.value.should eq("var")
+    expect(token.type).to eq(:MACRO_VAR)
+    expect(token.value).to eq("var")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
-    token.value.should eq(%( " ))
+    expect(token.type).to eq(:MACRO_LITERAL)
+    expect(token.value).to eq(%( " ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    expect(token.type).to eq(:MACRO_END)
   end
 end

--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -6,71 +6,71 @@ module LexerObjects
 
     def string_should_be_delimited_by(expected_start, expected_end)
       string_should_start_correctly
-      token.delimiter_state.nest.should eq(expected_start)
-      token.delimiter_state.end.should eq(expected_end)
-      token.delimiter_state.open_count.should eq(0)
+      expect(token.delimiter_state.nest).to eq(expected_start)
+      expect(token.delimiter_state.end).to eq(expected_end)
+      expect(token.delimiter_state.open_count).to eq(0)
     end
 
     def string_should_start_correctly
       @token = lexer.next_token
-      token.type.should eq(:DELIMITER_START)
+      expect(token.type).to eq(:DELIMITER_START)
     end
 
     def next_token_should_be(expected_type, expected_value = nil)
       @token = lexer.next_token
-      token.type.should eq(expected_type)
+      expect(token.type).to eq(expected_type)
       if expected_value
-        token.value.should eq(expected_value)
+        expect(token.value).to eq(expected_value)
       end
     end
 
     def next_unicode_tokens_should_be(expected_unicode_codes : Array)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
-      (token.value as String).chars.map(&.ord).should eq(expected_unicode_codes)
+      expect(token.type).to eq(:STRING)
+      expect((token.value as String).chars.map(&.ord)).to eq(expected_unicode_codes)
     end
 
     def next_unicode_tokens_should_be(expected_unicode_codes)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
-      (token.value as String).char_at(0).ord.should eq(expected_unicode_codes)
+      expect(token.type).to eq(:STRING)
+      expect((token.value as String).char_at(0).ord).to eq(expected_unicode_codes)
     end
 
     def next_string_token_should_be(expected_string)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq(expected_string)
+      expect(token.type).to eq(:STRING)
+      expect(token.value).to eq(expected_string)
     end
 
     def next_string_token_should_be_opening
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq(token.delimiter_state.nest.to_s)
-      token.delimiter_state.open_count.should eq(1)
+      expect(token.type).to eq(:STRING)
+      expect(token.value).to eq(token.delimiter_state.nest.to_s)
+      expect(token.delimiter_state.open_count).to eq(1)
     end
 
     def next_string_token_should_be_closing
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
-      token.value.should eq(token.delimiter_state.end.to_s)
-      token.delimiter_state.open_count.should eq(0)
+      expect(token.type).to eq(:STRING)
+      expect(token.value).to eq(token.delimiter_state.end.to_s)
+      expect(token.delimiter_state.open_count).to eq(0)
     end
 
     def string_should_have_an_interpolation_of(interpolated_variable_name)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:INTERPOLATION_START)
+      expect(token.type).to eq(:INTERPOLATION_START)
 
       @token = lexer.next_token
-      token.type.should eq(:IDENT)
-      token.value.should eq(interpolated_variable_name)
+      expect(token.type).to eq(:IDENT)
+      expect(token.value).to eq(interpolated_variable_name)
 
       @token = lexer.next_token
-      token.type.should eq(:"}")
+      expect(token.type).to eq(:"}")
     end
 
     def token_should_be_at(line = nil, column = nil)
-      token.line_number.should eq(line) if line
-      token.column_number.should eq(column) if column
+      expect(token.line_number).to eq(line) if line
+      expect(token.column_number).to eq(column) if column
     end
 
     def next_token_should_be_at(line = nil, column = nil)
@@ -80,7 +80,7 @@ module LexerObjects
 
     def string_should_end_correctly(eof = true)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:DELIMITER_END)
+      expect(token.type).to eq(:DELIMITER_END)
       if eof
         should_have_reached_eof
       end
@@ -88,7 +88,7 @@ module LexerObjects
 
     def should_have_reached_eof
       @token = lexer.next_token
-      token.type.should eq(:EOF)
+      expect(token.type).to eq(:EOF)
     end
 
     private getter :lexer, :token

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -4,7 +4,7 @@ private def it_lexes(string, type)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(type)
+    expect(token.type).to eq(type)
   end
 end
 
@@ -12,8 +12,8 @@ private def it_lexes(string, type, value)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(type)
-    token.value.should eq(value)
+    expect(token.type).to eq(type)
+    expect(token.value).to eq(value)
   end
 end
 
@@ -21,9 +21,9 @@ private def it_lexes(string, type, value, number_kind)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(type)
-    token.value.should eq(value)
-    token.number_kind.should eq(number_kind)
+    expect(token.type).to eq(type)
+    expect(token.value).to eq(value)
+    expect(token.number_kind).to eq(number_kind)
   end
 end
 
@@ -77,8 +77,8 @@ private def it_lexes_char(string, value)
   it "lexes #{string}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).should eq(value)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char)).to eq(value)
   end
 end
 
@@ -261,72 +261,72 @@ describe "Lexer" do
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token
-    token.type.should eq(:"!")
+    expect(token.type).to eq(:"!")
     token = lexer.next_token
-    token.type.should eq(:INSTANCE_VAR)
-    token.value.should eq("@foo")
+    expect(token.type).to eq(:INSTANCE_VAR)
+    expect(token.value).to eq("@foo")
   end
 
   it "lexes space after keyword" do
     lexer = Lexer.new "end 1"
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq(:end)
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq(:end)
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    expect(token.type).to eq(:SPACE)
   end
 
   it "lexes space after char" do
     lexer = Lexer.new "'a' "
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    token.value.should eq('a')
+    expect(token.type).to eq(:CHAR)
+    expect(token.value).to eq('a')
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    expect(token.type).to eq(:SPACE)
   end
 
   it "lexes comment and token" do
     lexer = Lexer.new "# comment\n="
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    expect(token.type).to eq(:NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:"=")
+    expect(token.type).to eq(:"=")
   end
 
   it "lexes comment at the end" do
     lexer = Lexer.new "# comment"
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "lexes __LINE__" do
     lexer = Lexer.new "__LINE__"
     token = lexer.next_token
-    token.type.should eq(:__LINE__)
+    expect(token.type).to eq(:__LINE__)
   end
 
   it "lexes __FILE__" do
     lexer = Lexer.new "__FILE__"
     lexer.filename = "foo"
     token = lexer.next_token
-    token.type.should eq(:__FILE__)
+    expect(token.type).to eq(:__FILE__)
   end
 
   it "lexes __DIR__" do
     lexer = Lexer.new "__DIR__"
     token = lexer.next_token
-    token.type.should eq(:__DIR__)
+    expect(token.type).to eq(:__DIR__)
   end
 
   it "lexes dot and ident" do
     lexer = Lexer.new ".read"
     token = lexer.next_token
-    token.type.should eq(:".")
+    expect(token.type).to eq(:".")
     token = lexer.next_token
-    token.type.should eq(:IDENT)
-    token.value.should eq("read")
+    expect(token.type).to eq(:IDENT)
+    expect(token.value).to eq("read")
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   assert_syntax_error "/foo", "unterminated regular expression"
@@ -335,31 +335,31 @@ describe "Lexer" do
   it "lexes utf-8 char" do
     lexer = Lexer.new "'á'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(225)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(225)
   end
 
   it "lexes utf-8 multibyte char" do
     lexer = Lexer.new "'日'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(26085)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(26085)
   end
 
   it "doesn't raise if slash r with slash n" do
     lexer = Lexer.new("\r\n1")
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    expect(token.type).to eq(:NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
   end
 
   it "doesn't raise if many slash r with slash n" do
     lexer = Lexer.new("\r\n\r\n\r\n1")
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    expect(token.type).to eq(:NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    expect(token.type).to eq(:NUMBER)
   end
 
   assert_syntax_error "\r1", "expected '\\n' after '\\r'"
@@ -367,38 +367,38 @@ describe "Lexer" do
   it "lexes char with unicode codepoint" do
     lexer = Lexer.new "'\\uFEDA'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(0xFEDA)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(0xFEDA)
   end
 
   it "lexes char with unicode codepoint and curly with zeros" do
     lexer = Lexer.new "'\\u{0}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(0)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(0)
   end
 
   it "lexes char with unicode codepoint and curly" do
     lexer = Lexer.new "'\\u{A5}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(0xA5)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(0xA5)
   end
 
   it "lexes char with unicode codepoint and curly with six hex digits" do
     lexer = Lexer.new "'\\u{10FFFF}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
-    (token.value as Char).ord.should eq(0x10FFFF)
+    expect(token.type).to eq(:CHAR)
+    expect((token.value as Char).ord).to eq(0x10FFFF)
   end
 
   it "lexes float then zero (bug)" do
     lexer = Lexer.new "2.5 0"
-    lexer.next_token.number_kind.should eq(:f64)
-    lexer.next_token.type.should eq(:SPACE)
+    expect(lexer.next_token.number_kind).to eq(:f64)
+    expect(lexer.next_token.type).to eq(:SPACE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.number_kind.should eq(:i32)
+    expect(token.type).to eq(:NUMBER)
+    expect(token.number_kind).to eq(:i32)
   end
 
   assert_syntax_error "'\\uFEDZ'", "expected hexadecimal character in unicode escape"

--- a/spec/compiler/lexer/lexer_string_array_spec.cr
+++ b/spec/compiler/lexer/lexer_string_array_spec.cr
@@ -2,18 +2,18 @@ require "../../spec_helper"
 
 private def it_should_be_valid_string_array_lexer(lexer)
   token = lexer.next_token
-  token.type.should eq(:STRING_ARRAY_START)
+  expect(token.type).to eq(:STRING_ARRAY_START)
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING)
-  token.value.should eq("one")
+  expect(token.type).to eq(:STRING)
+  expect(token.value).to eq("one")
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING)
-  token.value.should eq("two")
+  expect(token.type).to eq(:STRING)
+  expect(token.value).to eq("two")
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING_ARRAY_END)
+  expect(token.type).to eq(:STRING_ARRAY_END)
 end
 
 describe "Lexer string array" do
@@ -27,18 +27,18 @@ describe "Lexer string array" do
     lexer = Lexer.new("%w(one \n two)")
 
     token = lexer.next_token
-    token.type.should eq(:STRING_ARRAY_START)
+    expect(token.type).to eq(:STRING_ARRAY_START)
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
-    token.value.should eq("one")
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("one")
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
-    token.value.should eq("two")
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("two")
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING_ARRAY_END)
+    expect(token.type).to eq(:STRING_ARRAY_END)
   end
 
   it "lexes string array with new line gives correct column for next token" do
@@ -50,8 +50,8 @@ describe "Lexer string array" do
     lexer.next_string_array_token
 
     token = lexer.next_token
-    token.line_number.should eq(2)
-    token.column_number.should eq(6)
+    expect(token.line_number).to eq(2)
+    expect(token.column_number).to eq(6)
   end
 
   context "using { as delimiter" do

--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -2,24 +2,24 @@ require "../../spec_helper"
 
 private def assert_token_column_number(lexer, type, column_number)
   token = lexer.next_token
-  token.type.should eq(type)
-  token.column_number.should eq(column_number)
+  expect(token.type).to eq(type)
+  expect(token.column_number).to eq(column_number)
 end
 
 describe "Lexer: location" do
   it "stores line numbers" do
     lexer = Lexer.new "1\n2"
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.line_number.should eq(1)
+    expect(token.type).to eq(:NUMBER)
+    expect(token.line_number).to eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
-    token.line_number.should eq(1)
+    expect(token.type).to eq(:NEWLINE)
+    expect(token.line_number).to eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.line_number.should eq(2)
+    expect(token.type).to eq(:NUMBER)
+    expect(token.line_number).to eq(2)
   end
 
   it "stores column numbers" do
@@ -41,45 +41,45 @@ describe "Lexer: location" do
     lexer.filename = "bar"
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.line_number.should eq(1)
-    token.column_number.should eq(1)
-    token.filename.should eq("bar")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(1)
+    expect(token.filename).to eq("bar")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.line_number.should eq(1)
-    token.column_number.should eq(2)
+    expect(token.type).to eq(:SPACE)
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(2)
 
     token = lexer.next_token
-    token.type.should eq(:"+")
-    token.line_number.should eq(1)
-    token.column_number.should eq(3)
+    expect(token.type).to eq(:"+")
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(3)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
-    token.line_number.should eq(1)
-    token.column_number.should eq(4)
+    expect(token.type).to eq(:SPACE)
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(4)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
-    token.line_number.should eq(12)
-    token.column_number.should eq(34)
-    token.filename.should eq("foo")
+    expect(token.type).to eq(:NUMBER)
+    expect(token.line_number).to eq(12)
+    expect(token.column_number).to eq(34)
+    expect(token.filename).to eq("foo")
   end
 
   it "assigns correct loc location to node" do
     exps = Parser.parse(%[(#<loc:"foo.txt",2,3>1 + 2)]) as Expressions
     node = exps.expressions.first
     location = node.location.not_nil!
-    location.line_number.should eq(2)
-    location.column_number.should eq(3)
-    location.filename.should eq("foo.txt")
+    expect(location.line_number).to eq(2)
+    expect(location.column_number).to eq(3)
+    expect(location.filename).to eq("foo.txt")
   end
 
   it "parses var/call right after loc (#491)" do
     exps = Parser.parse(%[(#<loc:"foo.txt",2,3>msg)]) as Expressions
     exp = exps.expressions.first as Call
-    exp.name.should eq("msg")
+    expect(exp.name).to eq("msg")
   end
 end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -5,154 +5,154 @@ describe "Normalize: def" do
     a_def = parse("def foo(x, y = 1, z = 2); x + y + z; end") as Def
     actual = a_def.expand_default_arguments(1)
     expected = parse("def foo(x); foo(x, 1, 2); end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands a def on request with default arguments (2)" do
     a_def = parse("def foo(x, y = 1, z = 2); x + y + z; end") as Def
     actual = a_def.expand_default_arguments(2)
     expected = parse("def foo(x, y); foo(x, y, 2); end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands a def on request with default arguments that yields" do
     a_def = parse("def foo(x, y = 1, z = 2); yield x + y + z; end") as Def
     actual = a_def.expand_default_arguments(1)
     expected = parse("def foo(x); y = 1; z = 2; yield x + y + z; end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands a def on request with default arguments that yields (2)" do
     a_def = parse("def foo(x, y = 1, z = 2); yield x + y + z; end") as Def
     actual = a_def.expand_default_arguments(2)
     expected = parse("def foo(x, y); z = 2; yield x + y + z; end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands a def on request with default arguments and type restrictions" do
     a_def = parse("def foo(x, y = 1 : Int32, z = 2 : Int64); x + y + z; end") as Def
     actual = a_def.expand_default_arguments(1)
     expected = parse("def foo(x); y = 1; z = 2; x + y + z; end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands a def on request with default arguments and type restrictions (2)" do
     a_def = parse("def foo(x, y = 1 : Int32, z = 2 : Int64); x + y + z; end") as Def
     actual = a_def.expand_default_arguments(2)
     expected = parse("def foo(x, y : Int32); z = 2; x + y + z; end")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands with splat" do
     a_def = parse("def foo(*args); args; end") as Def
     actual = a_def.expand_default_arguments(3)
     expected = parse("def foo(_arg0, _arg1, _arg2)\n  args = {_arg0, _arg1, _arg2}\n  args\nend")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands with splat with one arg before" do
     a_def = parse("def foo(x, *args); args; end") as Def
     actual = a_def.expand_default_arguments(3)
     expected = parse("def foo(x, _arg0, _arg1)\n  args = {_arg0, _arg1}\n  args\nend")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands with splat with one arg after" do
     a_def = parse("def foo(*args, x); args; end") as Def
     actual = a_def.expand_default_arguments(3)
     expected = parse("def foo(_arg0, _arg1, x)\n  args = {_arg0, _arg1}\n  args\nend")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands with splat with one arg before and after" do
     a_def = parse("def foo(x, *args, z); args; end") as Def
     actual = a_def.expand_default_arguments(3)
     expected = parse("def foo(x, _arg0, z)\n  args = {_arg0}\n  args\nend")
-    actual.should eq(expected)
+    expect(actual).to eq(expected)
   end
 
   it "expands with splat and zero" do
     a_def = parse("def foo(*args); args; end") as Def
     actual = a_def.expand_default_arguments(0)
-    actual.to_s.should eq("def foo\n  args = {}\n  args\nend")
+    expect(actual.to_s).to eq("def foo\n  args = {}\n  args\nend")
   end
 
   it "expands with splat and default argument" do
     a_def = parse("def foo(x = 1, *args); args; end") as Def
     actual = a_def.expand_default_arguments(0)
-    actual.to_s.should eq("def foo\n  x = 1\n  args = {}\n  args\nend")
+    expect(actual.to_s).to eq("def foo\n  x = 1\n  args = {}\n  args\nend")
   end
 
   it "expands with named argument" do
     a_def = parse("def foo(x = 1, y = 2); x + y; end") as Def
     actual = a_def.expand_default_arguments(0, ["y"])
-    actual.to_s.should eq("def foo:y(y)\n  foo(1, y)\nend")
+    expect(actual.to_s).to eq("def foo:y(y)\n  foo(1, y)\nend")
   end
 
   it "expands with two named argument" do
     a_def = parse("def foo(x = 1, y = 2); x + y; end") as Def
     actual = a_def.expand_default_arguments(0, ["y", "x"])
-    actual.to_s.should eq("def foo:y:x(y, x)\n  foo(x, y)\nend")
+    expect(actual.to_s).to eq("def foo:y:x(y, x)\n  foo(x, y)\nend")
   end
 
   it "expands with two named argument and one not" do
     a_def = parse("def foo(x, y = 2, z = 3); x + y; end") as Def
     actual = a_def.expand_default_arguments(1, ["z"])
-    actual.to_s.should eq("def foo:z(x, z)\n  foo(x, 2, z)\nend")
+    expect(actual.to_s).to eq("def foo:z(x, z)\n  foo(x, 2, z)\nend")
   end
 
   it "expands with named argument and yield" do
     a_def = parse("def foo(x = 1, y = 2); yield x + y; end") as Def
     actual = a_def.expand_default_arguments(0, ["y"])
-    actual.to_s.should eq("def foo:y(y)\n  x = 1\n  yield x + y\nend")
+    expect(actual.to_s).to eq("def foo:y(y)\n  x = 1\n  yield x + y\nend")
   end
 
   # Small optimizations: no need to create a separate def in these cases
   it "expands with one named arg that is the only one (1)" do
     a_def = parse("def foo(x = 1); x; end") as Def
     other_def = a_def.expand_default_arguments(0, ["x"])
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with one named arg that is the only one (2)" do
     a_def = parse("def foo(x, y = 1); x; end") as Def
     other_def = a_def.expand_default_arguments(1, ["y"])
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with more named arg which come in the correct order" do
     a_def = parse("def foo(x, y = 1, z = 2); x; end") as Def
     other_def = a_def.expand_default_arguments(1, ["y", "z"])
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with magic constant" do
     a_def = parse("def foo(x, y = __LINE__); x; end") as Def
     other_def = a_def.expand_default_arguments(1)
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with magic constant specifying one when all are magic" do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); x; end") as Def
     other_def = a_def.expand_default_arguments(2)
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with magic constant specifying one when not all are magic" do
     a_def = parse("def foo(x, z = 1, line = __LINE__); x; end") as Def
     other_def = a_def.expand_default_arguments(2)
-    other_def.should be(a_def)
+    expect(other_def).to be(a_def)
   end
 
   it "expands with magic constant with named arg" do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); x; end") as Def
     other_def = a_def.expand_default_arguments(1, ["line"])
-    other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  foo(x, file, line)\nend")
+    expect(other_def.to_s).to eq("def foo:line(x, line, file = __FILE__)\n  foo(x, file, line)\nend")
   end
 
   it "expands with magic constant with named arg with yield" do
     a_def = parse("def foo(x, file = __FILE__, line = __LINE__); yield x, file, line; end") as Def
     other_def = a_def.expand_default_arguments(1, ["line"])
-    other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  yield x, file, line\nend")
+    expect(other_def.to_s).to eq("def foo:line(x, line, file = __FILE__)\n  yield x, file, line\nend")
   end
 end

--- a/spec/compiler/parser/parser_doc_spec.cr
+++ b/spec/compiler/parser/parser_doc_spec.cr
@@ -28,7 +28,7 @@ describe "Parser doc" do
         ))
       parser.wants_doc = true
       node = parser.parse
-      node.doc.should eq("This is Foo.\nUse it well.")
+      expect(node.doc).to eq("This is Foo.\nUse it well.")
     end
   end
 
@@ -48,12 +48,12 @@ describe "Parser doc" do
     nodes = parser.parse as Expressions
 
     foo = nodes[0] as Def
-    foo.doc.should eq("doc 1")
+    expect(foo.doc).to eq("doc 1")
 
     bar = foo.body as Call
-    bar.doc.should be_nil
+    expect(bar.doc).to be_nil
 
     baz = nodes[1] as Def
-    baz.doc.should eq("doc 3")
+    expect(baz.doc).to eq("doc 3")
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -123,7 +123,7 @@ private def it_parses(string, expected_node, file = __FILE__, line = __LINE__)
     parser = Parser.new(string)
     parser.filename = "/foo/bar/baz.cr"
     node = parser.parse
-    node.should eq(Expressions.from expected_node)
+    expect(node).to eq(Expressions.from expected_node)
   end
 end
 
@@ -1022,22 +1022,22 @@ describe "Parser" do
 
   it "keeps instance variables declared in def" do
     node = Parser.parse("def foo; @x = 1; @y = 2; @x = 3; @z; end") as Def
-    node.instance_vars.should eq(Set.new(["@x", "@y", "@z"]))
+    expect(node.instance_vars).to eq(Set.new(["@x", "@y", "@z"]))
   end
 
   it "keeps instance variables declared in def in multi-assign" do
     node = Parser.parse("def foo; @x, @y = 1, 2; end") as Def
-    node.instance_vars.should eq(Set.new(["@x", "@y"]))
+    expect(node.instance_vars).to eq(Set.new(["@x", "@y"]))
   end
 
   it "keeps instance variables declared in def with ||= and &&=" do
     node = Parser.parse("def foo; @x ||= 1; @y &&= 1; end") as Def
-    node.instance_vars.should eq(Set.new(["@x", "@y"]))
+    expect(node.instance_vars).to eq(Set.new(["@x", "@y"]))
   end
 
   it "keeps instance variables declared in def with declare var" do
     node = Parser.parse("def foo; @x :: Int32; end") as Def
-    node.instance_vars.should eq(Set.new(["@x"]))
+    expect(node.instance_vars).to eq(Set.new(["@x"]))
   end
 
   assert_syntax_error "def foo(x = 1, y); end",

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 private def expect_to_s(original, expected = original, file = __FILE__, line = __LINE__)
   it "does to_s of #{original.inspect}", file, line do
-    Parser.parse(original).to_s.should eq(expected), file, line
+    expect(Parser.parse(original).to_s).to eq(expected), file, line
   end
 end
 

--- a/spec/compiler/type_inference/alias_spec.cr
+++ b/spec/compiler/type_inference/alias_spec.cr
@@ -56,8 +56,8 @@ describe "type inference: alias" do
     foo_alias = foo.instantiate([a] of TypeVar)
 
     aliased_type = a.aliased_type as UnionType
-    aliased_type.union_types[0].should eq(mod.int32)
-    aliased_type.union_types[1].should eq(foo_alias)
+    expect(aliased_type.union_types[0]).to eq(mod.int32)
+    expect(aliased_type.union_types[1]).to eq(foo_alias)
   end
 
   it "allows recursive array with alias" do

--- a/spec/compiler/type_inference/block_spec.cr
+++ b/spec/compiler/type_inference/block_spec.cr
@@ -19,7 +19,7 @@ describe "Block inference" do
       end
     ") as Expressions
     result = infer_type input
-    (input.last as Call).block.not_nil!.body.type.should eq(result.program.int32)
+    expect((input.last as Call).block.not_nil!.body.type).to eq(result.program.int32)
   end
 
   it "infer type of block argument" do
@@ -34,7 +34,7 @@ describe "Block inference" do
     ") as Expressions
     result = infer_type input
     mod = result.program
-    (input.last as Call).block.not_nil!.args[0].type.should eq(mod.int32)
+    expect((input.last as Call).block.not_nil!.args[0].type).to eq(mod.int32)
   end
 
   it "infer type of local variable" do
@@ -114,8 +114,8 @@ describe "Block inference" do
     end
     mod = result.program
     type = result.node.type as GenericClassInstanceType
-    type.type_vars["T"].type.should eq(mod.float64)
-    type.instance_vars["@x"].type.should eq(mod.float64)
+    expect(type.type_vars["T"].type).to eq(mod.float64)
+    expect(type.instance_vars["@x"].type).to eq(mod.float64)
   end
 
   it "infers type of block before call taking other args free vars into account" do

--- a/spec/compiler/type_inference/c_struct_spec.cr
+++ b/spec/compiler/type_inference/c_struct_spec.cr
@@ -6,8 +6,8 @@ describe "Type inference: struct" do
     mod = result.program
 
     bar = mod.types["LibFoo"].types["Bar"] as CStructType
-    bar.vars["x"].type.should eq(mod.int32)
-    bar.vars["y"].type.should eq(mod.float64)
+    expect(bar.vars["x"].type).to eq(mod.int32)
+    expect(bar.vars["y"].type).to eq(mod.float64)
   end
 
   it "types Struct#new" do
@@ -256,6 +256,6 @@ describe "Type inference: struct" do
       end
       ))
     foo_struct = result.program.types["LibFoo"].types["Struct"] as CStructType
-    foo_struct.packed.should be_true
+    expect(foo_struct.packed).to be_true
   end
 end

--- a/spec/compiler/type_inference/c_union_spec.cr
+++ b/spec/compiler/type_inference/c_union_spec.cr
@@ -5,8 +5,8 @@ describe "Type inference: c union" do
     result = assert_type("lib LibFoo; union Bar; x : Int32; y : Float64; end; end; LibFoo::Bar") { types["LibFoo"].types["Bar"].metaclass }
     mod = result.program
     bar = mod.types["LibFoo"].types["Bar"] as CUnionType
-    bar.vars["x"].type.should eq(mod.int32)
-    bar.vars["y"].type.should eq(mod.float64)
+    expect(bar.vars["x"].type).to eq(mod.int32)
+    expect(bar.vars["y"].type).to eq(mod.float64)
   end
 
   it "types Union#new" do

--- a/spec/compiler/type_inference/class_spec.cr
+++ b/spec/compiler/type_inference/class_spec.cr
@@ -33,7 +33,7 @@ describe "Type inference: class" do
     end
     mod = result.program
     type = result.node.type as GenericClassInstanceType
-    type.instance_vars["@coco"].type.should eq(mod.union_of(mod.nil, mod.int32))
+    expect(type.instance_vars["@coco"].type).to eq(mod.union_of(mod.nil, mod.int32))
   end
 
   it "types generic of generic type" do
@@ -73,11 +73,11 @@ describe "Type inference: class" do
     mod, node = result.program, result.node as Expressions
     foo = mod.types["Foo"] as GenericClassType
 
-    node[1].type.should eq(foo.instantiate([mod.int32] of TypeVar))
-    (node[1].type as InstanceVarContainer).instance_vars["@coco"].type.should eq(mod.union_of(mod.nil, mod.int32))
+    expect(node[1].type).to eq(foo.instantiate([mod.int32] of TypeVar))
+    expect((node[1].type as InstanceVarContainer).instance_vars["@coco"].type).to eq(mod.union_of(mod.nil, mod.int32))
 
-    node[3].type.should eq(foo.instantiate([mod.float64] of TypeVar))
-    (node[3].type as InstanceVarContainer).instance_vars["@coco"].type.should eq(mod.union_of(mod.nil, mod.float64))
+    expect(node[3].type).to eq(foo.instantiate([mod.float64] of TypeVar))
+    expect((node[3].type as InstanceVarContainer).instance_vars["@coco"].type).to eq(mod.union_of(mod.nil, mod.float64))
   end
 
   it "types instance variable on getter" do
@@ -103,8 +103,8 @@ describe "Type inference: class" do
     result = infer_type input
     mod, node = result.program, result.node as Expressions
 
-    node[3].type.should eq(mod.union_of(mod.nil, mod.int32))
-    input.last.type.should eq(mod.union_of(mod.nil, mod.float64))
+    expect(node[3].type).to eq(mod.union_of(mod.nil, mod.int32))
+    expect(input.last.type).to eq(mod.union_of(mod.nil, mod.float64))
   end
 
   it "types recursive type" do
@@ -127,8 +127,8 @@ describe "Type inference: class" do
     mod, input = result.program, result.node as Expressions
     node = mod.types["Node"] as NonGenericClassType
 
-    node.lookup_instance_var("@next").type.should eq(mod.union_of(mod.nil, node))
-    input.last.type.should eq(node)
+    expect(node.lookup_instance_var("@next").type).to eq(mod.union_of(mod.nil, node))
+    expect(input.last.type).to eq(node)
   end
 
   it "types self inside method call without obj" do
@@ -214,8 +214,8 @@ describe "Type inference: class" do
       end
     mod = result.program
     type = result.node.type as GenericClassInstanceType
-    type.type_vars["T"].type.should eq(mod.int32)
-    type.instance_vars["@value"].type.should eq(mod.int32)
+    expect(type.type_vars["T"].type).to eq(mod.int32)
+    expect(type.instance_vars["@value"].type).to eq(mod.int32)
   end
 
   it "does automatic type inference of new for generic types 2" do
@@ -233,8 +233,8 @@ describe "Type inference: class" do
     end
     mod = result.program
     type = result.node.type as GenericClassInstanceType
-    type.type_vars["T"].type.should eq(mod.bool)
-    type.instance_vars["@value"].type.should eq(mod.bool)
+    expect(type.type_vars["T"].type).to eq(mod.bool)
+    expect(type.instance_vars["@value"].type).to eq(mod.bool)
   end
 
   it "does automatic type inference of new for nested generic type" do
@@ -252,8 +252,8 @@ describe "Type inference: class" do
     result = infer_type nodes
     mod = result.program
     type = nodes.last.type as GenericClassInstanceType
-    type.type_vars["T"].type.should eq(mod.int32)
-    type.instance_vars["@x"].type.should eq(mod.int32)
+    expect(type.type_vars["T"].type).to eq(mod.int32)
+    expect(type.instance_vars["@x"].type).to eq(mod.int32)
   end
 
   it "reports uninitialized constant" do
@@ -631,7 +631,7 @@ describe "Type inference: class" do
       B.new(A.new).foo
       ") { int32 }
     b = result.program.types["B"] as InstanceVarContainer
-    b.instance_vars.length.should eq(0)
+    expect(b.instance_vars.length).to eq(0)
   end
 
   it "doesn't mark instance variable as nilable if calling another initialize" do

--- a/spec/compiler/type_inference/closure_spec.cr
+++ b/spec/compiler/type_inference/closure_spec.cr
@@ -9,14 +9,14 @@ describe "Type inference: closure" do
     result = assert_type("x = 1; -> { x }; x") { int32 }
     program = result.program
     var = program.vars["x"]
-    var.closured.should be_true
+    expect(var.closured).to be_true
   end
 
   it "marks variable as closured in program on assign" do
     result = assert_type("x = 1; -> { x = 1 }; x") { int32 }
     program = result.program
     var = program.vars["x"]
-    var.closured.should be_true
+    expect(var.closured).to be_true
   end
 
   it "marks variable as closured in def" do
@@ -25,7 +25,7 @@ describe "Type inference: closure" do
     call = node.expressions.last as Call
     target_def = call.target_def
     var = target_def.vars.not_nil!["x"]
-    var.closured.should be_true
+    expect(var.closured).to be_true
   end
 
   it "marks variable as closured in block" do
@@ -44,7 +44,7 @@ describe "Type inference: closure" do
     call = node.expressions.last as Call
     block = call.block.not_nil!
     var = block.vars.not_nil!["x"]
-    var.closured.should be_true
+    expect(var.closured).to be_true
   end
 
   it "unifies types of closured var (1)" do
@@ -77,7 +77,7 @@ describe "Type inference: closure" do
       ") { int32 }
     program = result.program
     var = program.vars.not_nil!["a"]
-    var.closured.should be_true
+    expect(var.closured).to be_true
   end
 
   it "doesn't mark var as closured if only used in block" do
@@ -92,7 +92,7 @@ describe "Type inference: closure" do
       ") { int32 }
     program = result.program
     var = program.vars["x"]
-    var.closured.should be_false
+    expect(var.closured).to be_false
   end
 
   it "doesn't mark var as closured if only used in two block" do
@@ -112,7 +112,7 @@ describe "Type inference: closure" do
     call = node[1] as Call
     block = call.block.not_nil!
     var = block.vars.not_nil!["x"]
-    var.closured.should be_false
+    expect(var.closured).to be_false
   end
 
   it "doesn't mark self var as closured, but marks method as self closured" do
@@ -130,8 +130,8 @@ describe "Type inference: closure" do
     call = node.expressions[-2] as Call
     target_def = call.target_def
     var = target_def.vars.not_nil!["self"]
-    var.closured.should be_false
-    target_def.self_closured.should be_true
+    expect(var.closured).to be_false
+    expect(target_def.self_closured).to be_true
   end
 
   it "marks method as self closured if instance var is read" do
@@ -147,7 +147,7 @@ describe "Type inference: closure" do
     ") { int32 }
     node = result.node as Expressions
     call = node.expressions[-2] as Call
-    call.target_def.self_closured.should be_true
+    expect(call.target_def.self_closured).to be_true
   end
 
   it "marks method as self closured if instance var is written" do
@@ -163,7 +163,7 @@ describe "Type inference: closure" do
     ") { int32 }
     node = result.node as Expressions
     call = node.expressions[-2] as Call
-    call.target_def.self_closured.should be_true
+    expect(call.target_def.self_closured).to be_true
   end
 
   it "marks method as self closured if explicit self call is made" do
@@ -182,7 +182,7 @@ describe "Type inference: closure" do
     ") { int32 }
     node = result.node as Expressions
     call = node.expressions[-2] as Call
-    call.target_def.self_closured.should be_true
+    expect(call.target_def.self_closured).to be_true
   end
 
   it "marks method as self closured if implicit self call is made" do
@@ -201,7 +201,7 @@ describe "Type inference: closure" do
     ") { int32 }
     node = result.node as Expressions
     call = node.expressions[-2] as Call
-    call.target_def.self_closured.should be_true
+    expect(call.target_def.self_closured).to be_true
   end
 
   it "marks method as self closured if used inside a block" do
@@ -221,7 +221,7 @@ describe "Type inference: closure" do
     ") { int32 }
     node = result.node as Expressions
     call = node.expressions[-2] as Call
-    call.target_def.self_closured.should be_true
+    expect(call.target_def.self_closured).to be_true
   end
 
   it "errors if sending closured fun literal to C" do
@@ -442,7 +442,7 @@ describe "Type inference: closure" do
       ->{ a = 1; ->{ a } }
       )) { fun_of(fun_of(int32)) }
     fn = result.node as FunLiteral
-    fn.def.closure.should be_false
+    expect(fn.def.closure).to be_false
   end
 
   it "marks outer fun inside a block as closured" do
@@ -455,7 +455,7 @@ describe "Type inference: closure" do
       ->{ ->{ foo { a } } }
       )) { fun_of(fun_of(int32)) }
     fn = (result.node as Expressions).last as FunLiteral
-    fn.def.closure.should be_true
+    expect(fn.def.closure).to be_true
   end
 
   it "marks outer fun as closured when using self" do
@@ -470,9 +470,9 @@ describe "Type inference: closure" do
       )) { fun_of(fun_of(types["Foo"])) }
     call = (result.node as Expressions).last as Call
     a_def = call.target_def
-    a_def.self_closured.should be_true
+    expect(a_def.self_closured).to be_true
     fn = (a_def.body as FunLiteral)
-    fn.def.closure.should be_true
+    expect(fn.def.closure).to be_true
   end
 
   it "can use fun typedef as block type" do

--- a/spec/compiler/type_inference/const_spec.cr
+++ b/spec/compiler/type_inference/const_spec.cr
@@ -5,7 +5,7 @@ describe "Type inference: const" do
     input = parse("A = 1") as Assign
     result = infer_type input
     mod = result.program
-    input.target.type?.should be_nil # Don't type value until needed
+    expect(input.target.type?).to be_nil # Don't type value until needed
   end
 
   it "types a constant reference" do

--- a/spec/compiler/type_inference/declare_var_spec.cr
+++ b/spec/compiler/type_inference/declare_var_spec.cr
@@ -24,7 +24,7 @@ describe "Type inference: declare var" do
     mod = result.program
 
     foo = mod.types["Foo"] as NonGenericClassType
-    foo.instance_vars["@x"].type.should eq(mod.int32)
+    expect(foo.instance_vars["@x"].type).to eq(mod.int32)
   end
 
   it "declares instance var of generic class" do
@@ -36,7 +36,7 @@ describe "Type inference: declare var" do
       Foo(Int32).new") do
         foo = types["Foo"] as GenericClassType
         foo_i32 = foo.instantiate([int32] of TypeVar)
-        foo_i32.lookup_instance_var("@x").type.should eq(int32)
+        expect(foo_i32.lookup_instance_var("@x").type).to eq(int32)
         foo_i32
     end
   end
@@ -55,7 +55,7 @@ describe "Type inference: declare var" do
       f") do
         foo = types["Foo"] as GenericClassType
         foo_i32 = foo.instantiate([int32] of TypeVar)
-        foo_i32.lookup_instance_var("@x").type.should eq(int32)
+        expect(foo_i32.lookup_instance_var("@x").type).to eq(int32)
         foo_i32
     end
   end

--- a/spec/compiler/type_inference/def_spec.cr
+++ b/spec/compiler/type_inference/def_spec.cr
@@ -22,8 +22,8 @@ describe "Type inference: def" do
     result = infer_type input
     mod, input = result.program, result.node as Expressions
 
-    input[1].type.should eq(mod.int32)
-    input[2].type.should eq(mod.float64)
+    expect(input[1].type).to eq(mod.int32)
+    expect(input[2].type).to eq(mod.float64)
   end
 
   it "types a call with an argument uses a new scope" do
@@ -34,7 +34,7 @@ describe "Type inference: def" do
     input = parse "struct Int; def foo; 2.5; end; end; 1.foo"
     result = infer_type input
     mod, input = result.program, result.node as Expressions
-    (input.last as Call).target_def.owner.should eq(mod.int32)
+    expect((input.last as Call).target_def.owner).to eq(mod.int32)
   end
 
   it "types putchar with Char" do
@@ -95,8 +95,8 @@ describe "Type inference: def" do
     mod, input = result.program, result.node as Expressions
 
     call = input.last as Call
-    call.type.should eq(mod.union_of(mod.int32, mod.nil))
-    call.target_def.body.type.should eq(mod.nil)
+    expect(call.type).to eq(mod.union_of(mod.int32, mod.nil))
+    expect(call.target_def.body.type).to eq(mod.nil)
   end
 
   it "reports undefined method" do

--- a/spec/compiler/type_inference/dependencies_spec.cr
+++ b/spec/compiler/type_inference/dependencies_spec.cr
@@ -3,16 +3,16 @@ require "../../spec_helper"
 describe "Crystal::Dependencies" do
   it "is empty" do
     deps = Dependencies.new
-    deps.length.should eq(0)
-    deps.to_a.should eq([] of ASTNode)
+    expect(deps.length).to eq(0)
+    expect(deps.to_a).to eq([] of ASTNode)
   end
 
   it "pushes one" do
     deps = Dependencies.new
     node = NilLiteral.new
     deps.push node
-    deps.length.should eq(1)
-    deps.to_a.map(&.object_id).should eq([node.object_id])
+    expect(deps.length).to eq(1)
+    expect(deps.to_a.map(&.object_id)).to eq([node.object_id])
   end
 
   it "pushes two" do
@@ -21,8 +21,8 @@ describe "Crystal::Dependencies" do
     node2 = NilLiteral.new
     deps.push node1
     deps.push node2
-    deps.length.should eq(2)
-    deps.to_a.map(&.object_id).should eq([node1.object_id, node2.object_id])
+    expect(deps.length).to eq(2)
+    expect(deps.to_a.map(&.object_id)).to eq([node1.object_id, node2.object_id])
   end
 
   it "pushes three" do
@@ -33,7 +33,7 @@ describe "Crystal::Dependencies" do
     deps.push node1
     deps.push node2
     deps.push node3
-    deps.length.should eq(3)
-    deps.to_a.map(&.object_id).should eq([node1.object_id, node2.object_id, node3.object_id])
+    expect(deps.length).to eq(3)
+    expect(deps.to_a.map(&.object_id)).to eq([node1.object_id, node2.object_id, node3.object_id])
   end
 end

--- a/spec/compiler/type_inference/did_you_mean_spec.cr
+++ b/spec/compiler/type_inference/did_you_mean_spec.cr
@@ -114,7 +114,7 @@ describe "Type inference: did you mean" do
       infer_type nodes
       fail "TypeException wasn't raised"
     rescue ex : Crystal::TypeException
-      ex.to_s.includes?("did you mean").should be_false
+      expect(ex.to_s.includes?("did you mean")).to be_false
     end
   end
 

--- a/spec/compiler/type_inference/doc_spec.cr
+++ b/spec/compiler/type_inference/doc_spec.cr
@@ -9,8 +9,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
-    foo.locations.length.should eq(1)
+    expect(foo.doc).to eq("Hello")
+    expect(foo.locations.length).to eq(1)
   end
 
   it "stores doc for abstract class" do
@@ -21,7 +21,7 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
+    expect(foo.doc).to eq("Hello")
   end
 
   it "stores doc for struct" do
@@ -32,8 +32,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
-    foo.locations.length.should eq(1)
+    expect(foo.doc).to eq("Hello")
+    expect(foo.locations.length).to eq(1)
   end
 
   it "stores doc for module" do
@@ -44,8 +44,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
-    foo.locations.length.should eq(1)
+    expect(foo.doc).to eq("Hello")
+    expect(foo.locations.length).to eq(1)
   end
 
   it "stores doc for def" do
@@ -59,7 +59,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.lookup_defs("bar").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for def when using ditto" do
@@ -77,7 +77,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.lookup_defs("bar2").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for def with visibility" do
@@ -91,7 +91,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.lookup_defs("bar").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for def with attribute" do
@@ -106,7 +106,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.lookup_defs("bar").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for abstract def" do
@@ -119,7 +119,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.lookup_defs("bar").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for macro" do
@@ -133,7 +133,7 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     bar = foo.metaclass.lookup_macros("bar").not_nil!.first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
   end
 
   it "stores doc for fun def" do
@@ -145,7 +145,7 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.lookup_defs("foo").first
-    foo.doc.should eq("Hello")
+    expect(foo.doc).to eq("Hello")
   end
 
   it "stores doc for enum" do
@@ -156,8 +156,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
-    foo.locations.length.should eq(1)
+    expect(foo.doc).to eq("Hello")
+    expect(foo.locations.length).to eq(1)
   end
 
   it "stores doc for enum with @[Flags]" do
@@ -169,7 +169,7 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
+    expect(foo.doc).to eq("Hello")
   end
 
   it "stores doc for enum member" do
@@ -182,8 +182,8 @@ describe "Type inference: doc" do
     program = result.program
     foo = program.types["Foo"]
     a = foo.types["A"]
-    a.doc.should eq("Hello")
-    a.locations.length.should eq(1)
+    expect(a.doc).to eq("Hello")
+    expect(a.locations.length).to eq(1)
   end
 
   it "stores doc for constant" do
@@ -193,8 +193,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     a = program.types["A"]
-    a.doc.should eq("Hello")
-    a.locations.length.should eq(1)
+    expect(a.doc).to eq("Hello")
+    expect(a.locations.length).to eq(1)
   end
 
   it "stores doc for alias" do
@@ -204,8 +204,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     a = program.types["A"]
-    a.doc.should eq("Hello")
-    a.locations.length.should eq(1)
+    expect(a.doc).to eq("Hello")
+    expect(a.locations.length).to eq(1)
   end
 
   it "stores doc for nodes defined in macro call" do
@@ -230,10 +230,10 @@ describe "Type inference: doc" do
     foo = program.types["Foo"]
 
     bar = foo.lookup_defs("bar").first
-    bar.doc.should eq("Hello")
+    expect(bar.doc).to eq("Hello")
 
     bar_assign = foo.lookup_defs("bar=").first
-    bar_assign.doc.should eq("Hello")
+    expect(bar_assign.doc).to eq("Hello")
   end
 
   it "stores doc for nodes defined in macro call (2)" do
@@ -248,7 +248,7 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
+    expect(foo.doc).to eq("Hello")
   end
 
   it "stores doc for class if reopening" do
@@ -262,8 +262,8 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
-    foo.locations.length.should eq(2)
+    expect(foo.doc).to eq("Hello")
+    expect(foo.locations.length).to eq(2)
   end
 
   it "stores doc for module if reopening" do
@@ -277,7 +277,7 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.doc.should eq("Hello")
+    expect(foo.doc).to eq("Hello")
   end
 
   it "stores locations for auto-generated module" do
@@ -287,6 +287,6 @@ describe "Type inference: doc" do
     ), wants_doc: true
     program = result.program
     foo = program.types["Foo"]
-    foo.locations.length.should eq(1)
+    expect(foo.locations.length).to eq(1)
   end
 end

--- a/spec/compiler/type_inference/exception_spec.cr
+++ b/spec/compiler/type_inference/exception_spec.cr
@@ -58,7 +58,7 @@ describe "Type inference: exception" do
     mod = result.program
     a_def = mod.lookup_first_def("foo", false)
     def_instance = mod.lookup_def_instance DefInstanceKey.new(a_def.object_id, [] of Type, nil, nil)
-    def_instance.not_nil!.raises.should be_true
+    expect(def_instance.not_nil!.raises).to be_true
   end
 
   it "types exception var with no types" do
@@ -200,7 +200,7 @@ describe "Type inference: exception" do
     mod = result.program
     eh = (result.node as Expressions).expressions[-1]
     call_p_n = (eh as ExceptionHandler).ensure.not_nil! as Call
-    call_p_n.args.first.type.should eq(mod.union_of(mod.int32, mod.nil))
+    expect(call_p_n.args.first.type).to eq(mod.union_of(mod.int32, mod.nil))
   end
 
   it "types var as nilable inside ensure (2)" do
@@ -218,7 +218,7 @@ describe "Type inference: exception" do
     mod = result.program
     eh = (result.node as Expressions).expressions[-1]
     call_p_n = (eh as ExceptionHandler).ensure.not_nil! as Call
-    call_p_n.args.first.type.should eq(mod.union_of(mod.int32, mod.nil))
+    expect(call_p_n.args.first.type).to eq(mod.union_of(mod.int32, mod.nil))
   end
 
   it "marks fun as raises" do
@@ -229,7 +229,7 @@ describe "Type inference: exception" do
       )) { int32 }
     mod = result.program
     a_def = mod.lookup_first_def("foo", false)
-    a_def.not_nil!.raises.should be_true
+    expect(a_def.not_nil!.raises).to be_true
   end
 
   it "marks def as raises" do
@@ -243,13 +243,13 @@ describe "Type inference: exception" do
       )) { int32 }
     mod = result.program
     a_def = mod.lookup_first_def("foo", false)
-    a_def.not_nil!.raises.should be_true
+    expect(a_def.not_nil!.raises).to be_true
   end
 
   it "marks fun literal as raises" do
     result = assert_type("->{ 1 }.call") { int32 }
     call = result.node as Call
-    call.target_def.raises.should be_true
+    expect(call.target_def.raises).to be_true
   end
 
   it "shadows local variable (1)" do

--- a/spec/compiler/type_inference/fun_spec.cr
+++ b/spec/compiler/type_inference/fun_spec.cr
@@ -259,7 +259,7 @@ describe "Type inference: fun" do
 
   it "types nil or fun type" do
     result = assert_type("1 == 1 ? nil : ->{}") { |mod| union_of(mod.nil, mod.fun_of(mod.nil)) }
-    result.node.type.should be_a(NilableFunType)
+    expect(result.node.type).to be_a(NilableFunType)
   end
 
   it "undefs fun" do
@@ -506,7 +506,7 @@ describe "Type inference: fun" do
       end
       ))
     foo = result.program.types["LibFoo"].lookup_first_def("foo", nil) as External
-    foo.call_convention.should eq(LLVM::CallConvention::X86_StdCall)
+    expect(foo.call_convention).to eq(LLVM::CallConvention::X86_StdCall)
   end
 
   it "errors if wrong number of arguments for CallConvention" do

--- a/spec/compiler/type_inference/global_spec.cr
+++ b/spec/compiler/type_inference/global_spec.cr
@@ -6,9 +6,9 @@ describe "Global inference" do
     result = infer_type node
     mod, node = result.program, result.node as Assign
 
-    node.type.should eq(mod.int32)
-    node.target.type.should eq(mod.int32)
-    node.value.type.should eq(mod.int32)
+    expect(node.type).to eq(mod.int32)
+    expect(node.target.type).to eq(mod.int32)
+    expect(node.value.type).to eq(mod.int32)
   end
 
   it "infers type of global assign with union" do
@@ -16,8 +16,8 @@ describe "Global inference" do
     result = infer_type nodes
     mod, node = result.program, result.node as Expressions
 
-    (node[0] as Assign).target.type.should eq(mod.union_of(mod.int32, mod.char))
-    (node[1] as Assign).target.type.should eq(mod.union_of(mod.int32, mod.char))
+    expect((node[0] as Assign).target.type).to eq(mod.union_of(mod.int32, mod.char))
+    expect((node[1] as Assign).target.type).to eq(mod.union_of(mod.int32, mod.char))
   end
 
   it "infers type of global reference" do

--- a/spec/compiler/type_inference/initialize_spec.cr
+++ b/spec/compiler/type_inference/initialize_spec.cr
@@ -25,8 +25,8 @@ describe "Type inference: initialize" do
     result = infer_type node
     mod = result.program
     foo = mod.types["Foo"] as NonGenericClassType
-    foo.instance_vars["@baz"].type.should eq(mod.union_of(mod.nil, mod.types["Baz"]))
-    foo.instance_vars["@another"].type.should eq(mod.int32)
+    expect(foo.instance_vars["@baz"].type).to eq(mod.union_of(mod.nil, mod.types["Baz"]))
+    expect(foo.instance_vars["@another"].type).to eq(mod.int32)
   end
 
   it "types instance vars as nilable if doesn't invoke super in initialize with deep subclass" do
@@ -59,8 +59,8 @@ describe "Type inference: initialize" do
     result = infer_type node
     mod = result.program
     foo = mod.types["Foo"] as NonGenericClassType
-    foo.instance_vars["@baz"].type.should eq(mod.union_of(mod.nil, mod.types["Baz"]))
-    foo.instance_vars["@another"].type.should eq(mod.int32)
+    expect(foo.instance_vars["@baz"].type).to eq(mod.union_of(mod.nil, mod.types["Baz"]))
+    expect(foo.instance_vars["@another"].type).to eq(mod.int32)
   end
 
   it "types instance vars as nilable if doesn't invoke super with default arguments" do
@@ -87,8 +87,8 @@ describe "Type inference: initialize" do
     result = infer_type node
     mod = result.program
     foo = mod.types["Foo"] as NonGenericClassType
-    foo.instance_vars["@baz"].type.should eq(mod.types["Baz"])
-    foo.instance_vars["@another"].type.should eq(mod.int32)
+    expect(foo.instance_vars["@baz"].type).to eq(mod.types["Baz"])
+    expect(foo.instance_vars["@another"].type).to eq(mod.int32)
   end
 
   it "checks instance vars of included modules" do
@@ -119,10 +119,10 @@ describe "Type inference: initialize" do
     mod = result.program
 
     foo = mod.types["Foo"] as NonGenericClassType
-    foo.instance_vars["@x"].type.should eq(mod.union_of(mod.nil, mod.int32, mod.char))
+    expect(foo.instance_vars["@x"].type).to eq(mod.union_of(mod.nil, mod.int32, mod.char))
 
     bar = mod.types["Bar"] as NonGenericClassType
-    bar.instance_vars.length.should eq(0)
+    expect(bar.instance_vars.length).to eq(0)
   end
 
   it "errors when instance variable never assigned" do

--- a/spec/compiler/type_inference/is_a_spec.cr
+++ b/spec/compiler/type_inference/is_a_spec.cr
@@ -14,7 +14,7 @@ describe "Type inference: is_a?" do
       "
     result = infer_type nodes
     mod, nodes = result.program, result.node as Expressions
-    (nodes.last as If).then.type.should eq(mod.int32)
+    expect((nodes.last as If).then.type).to eq(mod.int32)
   end
 
   it "restricts type inside if scope 2" do
@@ -36,7 +36,7 @@ describe "Type inference: is_a?" do
     mod, nodes = result.program, result.node as Expressions
 
     foo = mod.types["Foo"] as GenericClassType
-    (nodes.last as If).then.type.should eq(foo.instantiate([mod.int32] of TypeVar))
+    expect((nodes.last as If).then.type).to eq(foo.instantiate([mod.int32] of TypeVar))
   end
 
   it "restricts type inside if scope 3" do
@@ -55,7 +55,7 @@ describe "Type inference: is_a?" do
 
     result = infer_type nodes
     mod, nodes = result.program, result.node as Expressions
-    (nodes.last as If).then.type.should eq(mod.types["Foo"])
+    expect((nodes.last as If).then.type).to eq(mod.types["Foo"])
   end
 
   it "restricts other types inside if else" do

--- a/spec/compiler/type_inference/lib_spec.cr
+++ b/spec/compiler/type_inference/lib_spec.cr
@@ -130,7 +130,7 @@ describe "Type inference: lib" do
     mod = result.program
     lib_type = mod.types["LibC"] as LibType
     foo = lib_type.lookup_first_def("foo", false) as External
-    foo.real_name.should eq("bar")
+    expect(foo.real_name).to eq("bar")
   end
 
   it "error if passing type to LibC with to_unsafe but type doesn't match" do
@@ -360,9 +360,9 @@ it "errors if unknown named arg" do
       ))
     sdl = result.program.types["LibSDL"] as LibType
     attrs = sdl.link_attributes.not_nil!
-    attrs.length.should eq(2)
-    attrs[0].lib.should eq("SDL")
-    attrs[1].lib.should eq("SDLMain")
+    expect(attrs.length).to eq(2)
+    expect(attrs[0].lib).to eq("SDL")
+    expect(attrs[1].lib).to eq("SDLMain")
   end
 
   it "supports forward references (#399)" do
@@ -419,9 +419,9 @@ it "errors if unknown named arg" do
       ))
     sdl = result.program.types["LibSDL"] as LibType
     attrs = sdl.link_attributes.not_nil!
-    attrs.length.should eq(2)
-    attrs[0].lib.should eq("SDL")
-    attrs[1].lib.should eq("SDLMain")
+    expect(attrs.length).to eq(2)
+    expect(attrs[0].lib).to eq("SDL")
+    expect(attrs[1].lib).to eq("SDLMain")
   end
 
   it "reopens lib and adds same link attributes" do
@@ -439,7 +439,7 @@ it "errors if unknown named arg" do
       ))
     sdl = result.program.types["LibSDL"] as LibType
     attrs = sdl.link_attributes.not_nil!
-    attrs.length.should eq(1)
-    attrs[0].lib.should eq("SDL")
+    expect(attrs.length).to eq(1)
+    expect(attrs[0].lib).to eq("SDL")
   end
 end

--- a/spec/compiler/type_inference/macro_spec.cr
+++ b/spec/compiler/type_inference/macro_spec.cr
@@ -5,7 +5,7 @@ describe "Type inference: macro" do
     input = parse "macro foo; 1; end; foo"
     result = infer_type input
     node = result.node as Expressions
-    (node.last as Call).expanded.should eq(parse "1")
+    expect((node.last as Call).expanded).to eq(parse "1")
   end
 
   it "errors if macro uses undefined variable" do
@@ -344,7 +344,7 @@ describe "Type inference: macro" do
     begin
       infer_type nodes
     rescue ex : TypeException
-      ex.to_s.should_not match(/did you mean/)
+      expect(ex.to_s).to_not match(/did you mean/)
     end
   end
 

--- a/spec/compiler/type_inference/module_spec.cr
+++ b/spec/compiler/type_inference/module_spec.cr
@@ -231,7 +231,7 @@ describe "Type inference: module" do
       Foo
       ") {
       foo = types["Foo"]
-      foo.module?.should be_true
+      expect(foo.module?).to be_true
       foo.metaclass
     }
   end
@@ -243,7 +243,7 @@ describe "Type inference: module" do
       Foo
       ") {
       foo = types["Foo"]
-      foo.module?.should be_true
+      expect(foo.module?).to be_true
       foo.metaclass
     }
   end

--- a/spec/compiler/type_inference/pointer_spec.cr
+++ b/spec/compiler/type_inference/pointer_spec.cr
@@ -57,7 +57,7 @@ describe "Type inference: pointer" do
 
   it "types nil or pointer type" do
     result = assert_type("1 == 1 ? nil : Pointer(Int32).new(0_u64)") { |mod| union_of(mod.nil, mod.pointer_of(mod.int32)) }
-    result.node.type.should be_a(NilablePointerType)
+    expect(result.node.type).to be_a(NilablePointerType)
   end
 
   it "types nil or pointer type with typedef" do
@@ -68,7 +68,7 @@ describe "Type inference: pointer" do
       end
       LibC.foo
       )) { |mod| union_of(mod.nil, mod.types["LibC"].types["T"]) }
-    result.node.type.should be_a(NilablePointerType)
+    expect(result.node.type).to be_a(NilablePointerType)
   end
 
   it "types pointer of constant" do

--- a/spec/compiler/type_inference/reflection_spec.cr
+++ b/spec/compiler/type_inference/reflection_spec.cr
@@ -27,6 +27,6 @@ describe "Type inference: reflection" do
     result = infer_type input
     mod = result.program
 
-    (mod.types["Bar"].metaclass as ClassType).superclass.should eq(mod.types["Foo"].metaclass)
+    expect((mod.types["Bar"].metaclass as ClassType).superclass).to eq(mod.types["Foo"].metaclass)
   end
 end

--- a/spec/compiler/type_inference/responds_to_spec.cr
+++ b/spec/compiler/type_inference/responds_to_spec.cr
@@ -14,7 +14,7 @@ describe "Type inference: responds_to?" do
       "
     result = infer_type nodes
     mod, nodes = result.program, result.node as Expressions
-    (nodes.last as If).then.type.should eq(mod.int32)
+    expect((nodes.last as If).then.type).to eq(mod.int32)
   end
 
   it "restricts other types inside if else" do

--- a/spec/compiler/type_inference/restrictions_spec.cr
+++ b/spec/compiler/type_inference/restrictions_spec.cr
@@ -14,17 +14,17 @@ describe "Restrictions" do
   describe "restrict" do
     it "restricts type with same type" do
       mod = Program.new
-      mod.int32.restrict(mod.int32, MatchContext.new(mod, mod)).should eq(mod.int32)
+      expect(mod.int32.restrict(mod.int32, MatchContext.new(mod, mod))).to eq(mod.int32)
     end
 
     it "restricts type with another type" do
       mod = Program.new
-      mod.int32.restrict(mod.int16, MatchContext.new(mod, mod)).should be_nil
+      expect(mod.int32.restrict(mod.int16, MatchContext.new(mod, mod))).to be_nil
     end
 
     it "restricts type with superclass" do
       mod = Program.new
-      mod.int32.restrict(mod.value, MatchContext.new(mod, mod)).should eq(mod.int32)
+      expect(mod.int32.restrict(mod.value, MatchContext.new(mod, mod))).to eq(mod.int32)
     end
 
     it "restricts type with included module" do
@@ -38,7 +38,7 @@ describe "Restrictions" do
         end
       ")
 
-      mod.types["Foo"].restrict(mod.types["Mod"], MatchContext.new(mod, mod)).should eq(mod.types["Foo"])
+      expect(mod.types["Foo"].restrict(mod.types["Mod"], MatchContext.new(mod, mod))).to eq(mod.types["Foo"])
     end
 
     it "restricts virtual type with included module 1" do
@@ -48,7 +48,7 @@ describe "Restrictions" do
         class A; include M; end
       ")
 
-      mod.t("A+").restrict(mod.t("M"), MatchContext.new(mod, mod)).should eq(mod.t("A+"))
+      expect(mod.t("A+").restrict(mod.t("M"), MatchContext.new(mod, mod))).to eq(mod.t("A+"))
     end
 
     it "restricts virtual type with included module 2" do
@@ -62,7 +62,7 @@ describe "Restrictions" do
         class E < A; end
       ")
 
-      mod.t("A+").restrict(mod.t("M"), MatchContext.new(mod, mod)).should eq(mod.union_of(mod.t("B+"), mod.t("C+")))
+      expect(mod.t("A+").restrict(mod.t("M"), MatchContext.new(mod, mod))).to eq(mod.union_of(mod.t("B+"), mod.t("C+")))
     end
   end
 

--- a/spec/compiler/type_inference/struct_spec.cr
+++ b/spec/compiler/type_inference/struct_spec.cr
@@ -8,7 +8,7 @@ describe "Type inference: struct" do
       Foo
       ") do
       str = types["Foo"] as NonGenericClassType
-      str.struct?.should be_true
+      expect(str.struct?).to be_true
       str.metaclass
     end
   end
@@ -20,10 +20,10 @@ describe "Type inference: struct" do
       Foo(Int32)
       ") do
       str = types["Foo"] as GenericClassType
-      str.struct?.should be_true
+      expect(str.struct?).to be_true
 
       str_inst = str.instantiate([int32] of TypeVar )
-      str_inst.struct?.should be_true
+      expect(str_inst.struct?).to be_true
       str_inst.metaclass
     end
   end
@@ -50,7 +50,7 @@ describe "Type inference: struct" do
       Foo.new || nil
       ") do | mod|
         type = union_of(types["Foo"], mod.nil)
-        type.should_not be_a(NilableType)
+        expect(type).to_not be_a(NilableType)
         type
       end
   end

--- a/spec/compiler/type_inference/super_spec.cr
+++ b/spec/compiler/type_inference/super_spec.cr
@@ -12,7 +12,7 @@ describe "Type inference: super" do
     mod, type = result.program, result.node.type as NonGenericClassType
 
     superclass = type.superclass as NonGenericClassType
-    superclass.instance_vars["@x"].type.should eq(mod.union_of(mod.nil, mod.int32))
+    expect(superclass.instance_vars["@x"].type).to eq(mod.union_of(mod.nil, mod.int32))
   end
 
   it "types super without arguments but parent has arguments" do
@@ -38,11 +38,11 @@ describe "Type inference: super" do
     result = infer_type nodes
     mod, type = result.program, result.node.type as NonGenericClassType
 
-    type.should eq(mod.types["Baz"])
+    expect(type).to eq(mod.types["Baz"])
 
     superclass = type.superclass as NonGenericClassType
     superclass2 = superclass.superclass as NonGenericClassType
-    superclass2.instance_vars["@x"].type.should eq(mod.int32)
+    expect(superclass2.instance_vars["@x"].type).to eq(mod.int32)
   end
 
   it "types super when container method is defined in parent class two levels up" do

--- a/spec/compiler/type_inference/var_spec.cr
+++ b/spec/compiler/type_inference/var_spec.cr
@@ -8,9 +8,9 @@ describe "Type inference: var" do
     result = infer_type input
     mod = result.program
     node = result.node as Assign
-    node.target.type.should eq(mod.int32)
-    node.value.type.should eq(mod.int32)
-    node.type.should eq(mod.int32)
+    expect(node.target.type).to eq(mod.int32)
+    expect(node.value.type).to eq(mod.int32)
+    expect(node.type).to eq(mod.int32)
   end
 
   it "types a variable" do
@@ -18,8 +18,8 @@ describe "Type inference: var" do
     result = infer_type input
     mod = result.program
     node = result.node as Expressions
-    node.last.type.should eq(mod.int32)
-    node.type.should eq(mod.int32)
+    expect(node.last.type).to eq(mod.int32)
+    expect(node.type).to eq(mod.int32)
   end
 
   it "reports undefined local variable or method" do

--- a/spec/compiler/type_inference/virtual_spec.cr
+++ b/spec/compiler/type_inference/virtual_spec.cr
@@ -108,7 +108,7 @@ describe "Type inference: virtual" do
       ")
     result = infer_type nodes
     mod, nodes = result.program, result.node as Expressions
-    (nodes.last as Call).target_defs.not_nil!.length.should eq(1)
+    expect((nodes.last as Call).target_defs.not_nil!.length).to eq(1)
   end
 
   it "dispatches virtual method with overload" do
@@ -131,7 +131,7 @@ describe "Type inference: virtual" do
       ")
     result = infer_type nodes
     mod, nodes = result.program, result.node as Expressions
-    (nodes.last as Call).target_defs.not_nil!.length.should eq(2)
+    expect((nodes.last as Call).target_defs.not_nil!.length).to eq(2)
   end
 
   it "works with restriction alpha" do
@@ -202,10 +202,10 @@ describe "Type inference: virtual" do
     mod = result.program
 
     var = mod.types["Var"] as InstanceVarContainer
-    var.instance_vars.length.should eq(0)
+    expect(var.instance_vars.length).to eq(0)
 
     base = mod.types["Base"] as InstanceVarContainer
-    base.instance_vars["@x"].type.should eq(mod.union_of(mod.nil, mod.int32))
+    expect(base.instance_vars["@x"].type).to eq(mod.union_of(mod.nil, mod.int32))
   end
 
   it "types inspect" do

--- a/spec/compiler/type_inference/yield_with_scope_spec.cr
+++ b/spec/compiler/type_inference/yield_with_scope_spec.cr
@@ -22,7 +22,7 @@ describe "Type inference: yield with scope" do
     mod, input = result.program, result.node as Expressions
     call = input.last as Call
     assign = call.block.not_nil!.body as Assign
-    assign.target.type.should eq(mod.int32)
+    expect(assign.target.type).to eq(mod.int32)
   end
 
   it "infer type of block body with yield scope" do
@@ -35,7 +35,7 @@ describe "Type inference: yield with scope" do
     "
     result = infer_type input
     mod, input = result.program, result.node as Expressions
-    (input.last as Call).block.not_nil!.body.type.should eq(mod.int64)
+    expect((input.last as Call).block.not_nil!.body.type).to eq(mod.int64)
   end
 
   it "infer type of block body with yield scope and arguments" do
@@ -48,7 +48,7 @@ describe "Type inference: yield with scope" do
     "
     result = infer_type input
     mod, input = result.program, result.node as Expressions
-    (input.last as Call).block.not_nil!.body.type.should eq(mod.float64)
+    expect((input.last as Call).block.not_nil!.body.type).to eq(mod.float64)
   end
 
   it "passes #229" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -38,9 +38,9 @@ def assert_type(str, flags = nil)
   input = program.infer_type input
   expected_type = with program yield program
   if input.is_a?(Expressions)
-    input.last.type.should eq(expected_type)
+    expect(input.last.type).to eq(expected_type)
   else
-    input.type.should eq(expected_type)
+    expect(input.type).to eq(expected_type)
   end
   InferTypeResult.new(program, input)
 end
@@ -63,19 +63,19 @@ def assert_normalize(from, to, flags = nil)
   normalizer = Normalizer.new(program)
   from_nodes = Parser.parse(from)
   to_nodes = normalizer.normalize(from_nodes)
-  to_nodes.to_s.strip.should eq(to.strip)
+  expect(to_nodes.to_s.strip).to eq(to.strip)
 end
 
 def assert_expand(from, to)
   from_nodes = Parser.parse(from)
   to_nodes = LiteralExpander.new(Program.new).expand(from_nodes)
-  to_nodes.to_s.strip.should eq(to.strip)
+  expect(to_nodes.to_s.strip).to eq(to.strip)
 end
 
 def assert_after_type_inference(before, after)
   node = Parser.parse(before)
   result = infer_type node
-  result.node.to_s.strip.should eq(after.strip)
+  expect(result.node.to_s.strip).to eq(after.strip)
 end
 
 def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__)
@@ -84,9 +84,9 @@ def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile =
       parse str
       fail "expected SyntaxException to be raised", metafile, metaline
     rescue ex : SyntaxException
-      ex.message.not_nil!.includes?(message).should be_true, metafile, metaline if message
-      ex.line_number.should eq(line), metafile, metaline if line
-      ex.column_number.should eq(column), metafile, metaline if column
+      expect(ex.message.not_nil!.includes?(message)).to be_true, metafile, metaline if message
+      expect(ex.line_number).to eq(line), metafile, metaline if line
+      expect(ex.column_number).to eq(column), metafile, metaline if column
     end
   end
 end
@@ -111,7 +111,7 @@ def assert_macro(macro_args, macro_body, expected)
   result = program.expand_macro program, a_macro, call
   result = result.source
   result = result[0 .. -2] if result.ends_with?(';')
-  result.should eq(expected)
+  expect(result).to eq(expected)
 end
 
 def parse(string, wants_doc = false)

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -5,14 +5,14 @@ alias RecursiveArray = Array(RecursiveArray)
 describe "Array" do
   describe "==" do
     it "compares empty" do
-      ([] of Int32).should eq([] of Int32)
-      [1].should_not eq([] of Int32)
-      ([] of Int32).should_not eq([1])
+      expect(([] of Int32)).to eq([] of Int32)
+      expect([1]).to_not eq([] of Int32)
+      expect(([] of Int32)).to_not eq([1])
     end
 
     it "compares elements" do
-      [1, 2, 3].should eq([1, 2, 3])
-      [1, 2, 3].should_not eq([3, 2, 1])
+      expect([1, 2, 3]).to eq([1, 2, 3])
+      expect([1, 2, 3]).to_not eq([3, 2, 1])
     end
 
     it "compares other" do
@@ -20,76 +20,76 @@ describe "Array" do
       b = [1, 2, 3]
       c = [1, 2, 3, 4]
       d = [1, 2, 4]
-      (a == b).should be_true
-      (b == c).should be_false
-      (a == d).should be_false
+      expect((a == b)).to be_true
+      expect((b == c)).to be_false
+      expect((a == d)).to be_false
     end
   end
 
   it "does &" do
-    ([1, 2, 3] & [] of Int32).should eq([] of Int32)
-    ([] of Int32 & [1, 2, 3]).should eq([] of Int32)
-    ([1, 2, 3] & [3, 2, 4]).should eq([2, 3])
-    ([1, 2, 3, 1, 2, 3] & [3, 2, 4, 3, 2, 4]).should eq([2, 3])
-    ([1, 2, 3, 1, 2, 3, nil, nil] & [3, 2, 4, 3, 2, 4, nil]).should eq([2, 3, nil])
+    expect(([1, 2, 3] & [] of Int32)).to eq([] of Int32)
+    expect(([] of Int32 & [1, 2, 3])).to eq([] of Int32)
+    expect(([1, 2, 3] & [3, 2, 4])).to eq([2, 3])
+    expect(([1, 2, 3, 1, 2, 3] & [3, 2, 4, 3, 2, 4])).to eq([2, 3])
+    expect(([1, 2, 3, 1, 2, 3, nil, nil] & [3, 2, 4, 3, 2, 4, nil])).to eq([2, 3, nil])
   end
 
   it "does |" do
-    ([1, 2, 3] | [5, 3, 2, 4]).should eq([1, 2, 3, 5, 4])
-    ([1, 1, 2, 3, 3] | [4, 5, 5, 6]).should eq([1, 2, 3, 4, 5, 6])
+    expect(([1, 2, 3] | [5, 3, 2, 4])).to eq([1, 2, 3, 5, 4])
+    expect(([1, 1, 2, 3, 3] | [4, 5, 5, 6])).to eq([1, 2, 3, 4, 5, 6])
   end
 
   it "does +" do
     a = [1, 2, 3]
     b = [4, 5]
     c = a + b
-    c.length.should eq(5)
-    0.upto(4) { |i| c[i].should eq(i + 1) }
+    expect(c.length).to eq(5)
+    0.upto(4) { |i| expect(c[i]).to eq(i + 1) }
   end
 
   it "does -" do
-    ([1, 2, 3, 4, 5] - [4, 2]).should eq([1, 3, 5])
+    expect(([1, 2, 3, 4, 5] - [4, 2])).to eq([1, 3, 5])
   end
 
   describe "[]" do
     it "gets on positive index" do
-      [1, 2, 3][1].should eq(2)
+      expect([1, 2, 3][1]).to eq(2)
     end
 
     it "gets on negative index" do
-      [1, 2, 3][-1].should eq(3)
+      expect([1, 2, 3][-1]).to eq(3)
     end
 
     it "gets on inclusive range" do
-      [1, 2, 3, 4, 5, 6][1 .. 4].should eq([2, 3, 4, 5])
+      expect([1, 2, 3, 4, 5, 6][1 .. 4]).to eq([2, 3, 4, 5])
     end
 
     it "gets on inclusive range with negative indices" do
-      [1, 2, 3, 4, 5, 6][-5 .. -2].should eq([2, 3, 4, 5])
+      expect([1, 2, 3, 4, 5, 6][-5 .. -2]).to eq([2, 3, 4, 5])
     end
 
     it "gets on exclusive range" do
-      [1, 2, 3, 4, 5, 6][1 ... 4].should eq([2, 3, 4])
+      expect([1, 2, 3, 4, 5, 6][1 ... 4]).to eq([2, 3, 4])
     end
 
     it "gets on exclusive range with negative indices" do
-      [1, 2, 3, 4, 5, 6][-5 ... -2].should eq([2, 3, 4])
+      expect([1, 2, 3, 4, 5, 6][-5 ... -2]).to eq([2, 3, 4])
     end
 
     it "gets on empty range" do
-      [1, 2, 3][3 .. 1].should eq([] of Int32)
+      expect([1, 2, 3][3 .. 1]).to eq([] of Int32)
     end
 
     it "gets with start and count" do
-      [1, 2, 3, 4, 5, 6][1, 3].should eq([2, 3, 4])
+      expect([1, 2, 3, 4, 5, 6][1, 3]).to eq([2, 3, 4])
     end
 
     it "gets with start and count exceeding length" do
-      [1, 2, 3][1, 3].should eq([2, 3])
+      expect([1, 2, 3][1, 3]).to eq([2, 3])
     end
 
     it "gets with negative start " do
-      [1, 2, 3, 4, 5, 6][-4, 2].should eq([3, 4])
+      expect([1, 2, 3, 4, 5, 6][-4, 2]).to eq([3, 4])
     end
 
     it "raises on index out of bounds" do
@@ -106,30 +106,30 @@ describe "Array" do
 
     it "gets 0, 0 on empty array" do
       a = [] of Int32
-      a[0, 0].should eq(a)
+      expect(a[0, 0]).to eq(a)
     end
 
     it "gets 0 ... 0 on empty array" do
       a = [] of Int32
-      a[0 .. 0].should eq(a)
+      expect(a[0 .. 0]).to eq(a)
     end
 
     it "gets nilable" do
-      [1, 2, 3][2]?.should eq(3)
-      [1, 2, 3][3]?.should be_nil
+      expect([1, 2, 3][2]?).to eq(3)
+      expect([1, 2, 3][3]?).to be_nil
     end
 
     it "same access by at" do
-      [1, 2, 3][1].should eq([1,2,3].at(1))
+      expect([1, 2, 3][1]).to eq([1,2,3].at(1))
     end
 
     it "doesn't exceed limits" do
-      [1][0..3].should eq([1])
+      expect([1][0..3]).to eq([1])
     end
 
     it "returns empty if at end" do
-      [1][1, 0].should eq([] of Int32)
-      [1][1, 10].should eq([] of Int32)
+      expect([1][1, 0]).to eq([] of Int32)
+      expect([1][1, 10]).to eq([] of Int32)
     end
   end
 
@@ -137,48 +137,48 @@ describe "Array" do
     it "sets on positive index" do
       a = [1, 2, 3]
       a[1] = 4
-      a[1].should eq(4)
+      expect(a[1]).to eq(4)
     end
 
     it "sets on negative index" do
       a = [1, 2, 3]
       a[-1] = 4
-      a[2].should eq(4)
+      expect(a[2]).to eq(4)
     end
   end
 
   it "does clear" do
     a = [1, 2, 3]
     a.clear
-    a.should eq([] of Int32)
+    expect(a).to eq([] of Int32)
   end
 
   it "does clone" do
     x = {1 => 2}
     a = [x]
     b = a.clone
-    b.should eq(a)
-    a.object_id.should_not eq(b.object_id)
-    a[0].object_id.should_not eq(b[0].object_id)
+    expect(b).to eq(a)
+    expect(a.object_id).to_not eq(b.object_id)
+    expect(a[0].object_id).to_not eq(b[0].object_id)
   end
 
   it "does compact" do
     a = [1, nil, 2, nil, 3]
-    b = a.compact.should eq([1, 2, 3])
-    a.should eq([1, nil, 2, nil, 3])
+    expect(b = a.compact).to eq([1, 2, 3])
+    expect(a).to eq([1, nil, 2, nil, 3])
   end
 
   describe "compact!" do
     it "returns true if removed" do
       a = [1, nil, 2, nil, 3]
-      b = a.compact!.should be_true
-      a.should eq([1, 2, 3])
+      expect(b = a.compact!).to be_true
+      expect(a).to eq([1, 2, 3])
     end
 
     it "returns false if not removed" do
       a = [1]
-      b = a.compact!.should be_false
-      a.should eq([1])
+      expect(b = a.compact!).to be_false
+      expect(a).to eq([1])
     end
   end
 
@@ -186,47 +186,47 @@ describe "Array" do
     it "concats small arrays" do
       a = [1, 2, 3]
       a.concat([4, 5, 6])
-      a.should eq([1, 2, 3, 4, 5, 6])
+      expect(a).to eq([1, 2, 3, 4, 5, 6])
     end
 
     it "concats large arrays" do
       a = [1, 2, 3]
       a.concat((4..1000).to_a)
-      a.should eq((1..1000).to_a)
+      expect(a).to eq((1..1000).to_a)
     end
 
     it "concats enumerable" do
       a = [1, 2, 3]
       a.concat((4..1000))
-      a.should eq((1..1000).to_a)
+      expect(a).to eq((1..1000).to_a)
     end
   end
 
   describe "delete" do
     it "deletes many" do
       a = [1, 2, 3, 1, 2, 3]
-      a.delete(2).should be_true
-      a.should eq([1, 3, 1, 3])
+      expect(a.delete(2)).to be_true
+      expect(a).to eq([1, 3, 1, 3])
     end
 
     it "delete not found" do
       a = [1, 2]
-      a.delete(4).should be_false
-      a.should eq([1, 2])
+      expect(a.delete(4)).to be_false
+      expect(a).to eq([1, 2])
     end
   end
 
   describe "delete_at" do
     it "deletes positive index" do
       a = [1, 2, 3, 4]
-      a.delete_at(1).should eq(2)
-      a.should eq([1, 3, 4])
+      expect(a.delete_at(1)).to eq(2)
+      expect(a).to eq([1, 3, 4])
     end
 
     it "deletes negative index" do
       a = [1, 2, 3, 4]
-      a.delete_at(-3).should eq(2)
-      a.should eq([1, 3, 4])
+      expect(a.delete_at(-3)).to eq(2)
+      expect(a).to eq([1, 3, 4])
     end
 
     it "deletes out of bounds" do
@@ -241,7 +241,7 @@ describe "Array" do
     it "deletes many" do
       a = [1, 2, 3, 1, 2, 3]
       a.delete_if { |i| i > 2 }
-      a.should eq([1, 2, 1, 2])
+      expect(a).to eq([1, 2, 1, 2])
     end
   end
 
@@ -249,28 +249,28 @@ describe "Array" do
     x = {1 => 2}
     a = [x]
     b = a.dup
-    b.should eq([x])
-    a.object_id.should_not eq(b.object_id)
-    a[0].object_id.should eq(b[0].object_id)
+    expect(b).to eq([x])
+    expect(a.object_id).to_not eq(b.object_id)
+    expect(a[0].object_id).to eq(b[0].object_id)
     b << {3 => 4}
-    a.should eq([x])
+    expect(a).to eq([x])
   end
 
   it "does each_index" do
     a = [1, 1, 1]
     b = 0
     a.each_index { |i| b += i }
-    b.should eq(3)
+    expect(b).to eq(3)
   end
 
   describe "empty" do
     it "is empty" do
-      ([] of Int32).empty?.should be_true
-      [1].empty?.should be_false
+      expect(([] of Int32).empty?).to be_true
+      expect([1].empty?).to be_false
     end
 
     it "is not empty" do
-      [1].empty?.should be_false
+      expect([1].empty?).to be_false
     end
   end
 
@@ -280,62 +280,62 @@ describe "Array" do
     c = [5, 7, 3]
     d = [1, 3, 2, 4]
     f = ->(x : Int32, y : Int32) { (x % 2) == (y % 2) }
-    a.equals?(b, &f).should be_true
-    a.equals?(c, &f).should be_false
-    a.equals?(d, &f).should be_false
+    expect(a.equals?(b, &f)).to be_true
+    expect(a.equals?(c, &f)).to be_false
+    expect(a.equals?(d, &f)).to be_false
   end
 
   describe "fill" do
     it "replaces all values" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'x']
-      a.fill('x').should eq(expected)
+      expect(a.fill('x')).to eq(expected)
     end
 
     it "replaces only values between index and size" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
-      a.fill('x', 0, 2).should eq(expected)
+      expect(a.fill('x', 0, 2)).to eq(expected)
     end
 
     it "replaces only values between index and size (2)" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
-      a.fill('x', 1, 2).should eq(expected)
+      expect(a.fill('x', 1, 2)).to eq(expected)
     end
 
     it "replaces all values from index onwards" do
       a = ['a', 'b', 'c']
       expected = ['a', 'x', 'x']
-      a.fill('x', -2).should eq(expected)
+      expect(a.fill('x', -2)).to eq(expected)
     end
 
     it "replaces only values between negative index and size" do
       a = ['a', 'b', 'c']
       expected = ['a', 'b', 'x']
-      a.fill('x', -1, 1).should eq(expected)
+      expect(a.fill('x', -1, 1)).to eq(expected)
     end
 
     it "replaces only values in range" do
       a = ['a', 'b', 'c']
       expected = ['x', 'x', 'c']
-      a.fill('x', -3..1).should eq(expected)
+      expect(a.fill('x', -3..1)).to eq(expected)
     end
 
     it "works with a block" do
       a = [3, 6, 9]
-      a.clone.fill { 0 }.should eq([0, 0, 0])
-      a.clone.fill { |i| i }.should eq([0, 1, 2])
-      a.clone.fill(1) { |i| (i ** i).to_i }.should eq([3, 1, 4])
-      a.clone.fill(1, 1) { |i| (i ** i).to_i }.should eq([3, 1, 9])
-      a.clone.fill(1..1) { |i| (i ** i).to_i }.should eq([3, 1, 9])
+      expect(a.clone.fill { 0 }).to eq([0, 0, 0])
+      expect(a.clone.fill { |i| i }).to eq([0, 1, 2])
+      expect(a.clone.fill(1) { |i| (i ** i).to_i }).to eq([3, 1, 4])
+      expect(a.clone.fill(1, 1) { |i| (i ** i).to_i }).to eq([3, 1, 9])
+      expect(a.clone.fill(1..1) { |i| (i ** i).to_i }).to eq([3, 1, 9])
     end
   end
 
   describe "first" do
     it "gets first when non empty" do
       a = [1, 2, 3]
-      a.first.should eq(1)
+      expect(a.first).to eq(1)
     end
 
     it "raises when empty" do
@@ -348,41 +348,41 @@ describe "Array" do
   describe "first?" do
     it "gets first? when non empty" do
       a = [1, 2, 3]
-      a.first?.should eq(1)
+      expect(a.first?).to eq(1)
     end
 
     it "gives nil when empty" do
-      ([] of Int32).first?.should be_nil
+      expect(([] of Int32).first?).to be_nil
     end
   end
 
   describe "flat_map" do
     it "does example 1" do
-      [1, 2, 3, 4].flat_map { |e| [e, -e] }.should eq([1, -1, 2, -2, 3, -3, 4, -4])
+      expect([1, 2, 3, 4].flat_map { |e| [e, -e] }).to eq([1, -1, 2, -2, 3, -3, 4, -4])
     end
 
     it "does example 2" do
-      [[1, 2], [3, 4]].flat_map { |e| e + [100] }.should eq([1, 2, 100, 3, 4, 100])
+      expect([[1, 2], [3, 4]].flat_map { |e| e + [100] }).to eq([1, 2, 100, 3, 4, 100])
     end
   end
 
   it "does hash" do
     a = [1, 2, [3]]
     b = [1, 2, [3]]
-    a.hash.should eq(b.hash)
+    expect(a.hash).to eq(b.hash)
   end
 
   describe "index" do
     it "performs without a block" do
       a = [1, 2, 3]
-      a.index(3).should eq(2)
-      a.index(4).should be_nil
+      expect(a.index(3)).to eq(2)
+      expect(a.index(4)).to be_nil
     end
 
     it "performs with a block" do
       a = [1, 2, 3]
-      a.index { |i| i > 1 }.should eq(1)
-      a.index { |i| i > 3 }.should be_nil
+      expect(a.index { |i| i > 1 }).to eq(1)
+      expect(a.index { |i| i > 3 }).to be_nil
     end
 
     it "raises if out of bounds" do
@@ -396,22 +396,22 @@ describe "Array" do
     it "inserts with positive index" do
       a = [1, 3, 4]
       expected = [1, 2, 3, 4]
-      a.insert(1, 2).should eq(expected)
-      a.should eq(expected)
+      expect(a.insert(1, 2)).to eq(expected)
+      expect(a).to eq(expected)
     end
 
     it "inserts with negative index" do
       a = [1, 2, 3]
       expected = [1, 2, 3, 4]
-      a.insert(-1, 4).should eq(expected)
-      a.should eq(expected)
+      expect(a.insert(-1, 4)).to eq(expected)
+      expect(a).to eq(expected)
     end
 
     it "inserts with negative index (2)" do
       a = [1, 2, 3]
       expected = [4, 1, 2, 3]
-      a.insert(-4, 4).should eq(expected)
-      a.should eq(expected)
+      expect(a.insert(-4, 4)).to eq(expected)
+      expect(a).to eq(expected)
     end
 
     it "inserts out of range" do
@@ -424,13 +424,13 @@ describe "Array" do
   end
 
   describe "inspect" do
-    assert { [1, 2, 3].inspect.should eq("[1, 2, 3]") }
+    assert { expect([1, 2, 3].inspect).to eq("[1, 2, 3]") }
   end
 
   describe "last" do
     it "gets last when non empty" do
       a = [1, 2, 3]
-      a.last.should eq(3)
+      expect(a.last).to eq(3)
     end
 
     it "raises when empty" do
@@ -442,31 +442,31 @@ describe "Array" do
 
   describe "length" do
     it "has length 0" do
-      ([] of Int32).length.should eq(0)
+      expect(([] of Int32).length).to eq(0)
     end
 
     it "has length 2" do
-      [1, 2].length.should eq(2)
+      expect([1, 2].length).to eq(2)
     end
   end
 
   it "does map" do
     a = [1, 2, 3]
-    a.map { |x| x * 2 }.should eq([2, 4, 6])
-    a.should eq([1, 2, 3])
+    expect(a.map { |x| x * 2 }).to eq([2, 4, 6])
+    expect(a).to eq([1, 2, 3])
   end
 
   it "does map!" do
     a = [1, 2, 3]
     a.map! { |x| x * 2 }
-    a.should eq([2, 4, 6])
+    expect(a).to eq([2, 4, 6])
   end
 
   describe "pop" do
     it "pops when non empty" do
       a = [1, 2, 3]
-      a.pop.should eq(3)
-      a.should eq([1, 2])
+      expect(a.pop).to eq(3)
+      expect(a).to eq([1, 2])
     end
 
     it "raises when empty" do
@@ -478,15 +478,15 @@ describe "Array" do
     it "pops many elements" do
       a = [1, 2, 3, 4, 5]
       b = a.pop(3)
-      b.should eq([3, 4, 5])
-      a.should eq([1, 2])
+      expect(b).to eq([3, 4, 5])
+      expect(a).to eq([1, 2])
     end
 
     it "pops more elements that what is available" do
       a = [1, 2, 3, 4, 5]
       b = a.pop(10)
-      b.should eq([1, 2, 3, 4, 5])
-      a.should eq([] of Int32)
+      expect(b).to eq([1, 2, 3, 4, 5])
+      expect(a).to eq([] of Int32)
     end
 
     it "pops negative count raises" do
@@ -500,60 +500,60 @@ describe "Array" do
   it "does product" do
     r = [] of Int32
     [1,2,3].product([5,6]) { |a, b| r << a; r << b }
-    r.should eq([1,5,1,6,2,5,2,6,3,5,3,6])
+    expect(r).to eq([1,5,1,6,2,5,2,6,3,5,3,6])
   end
 
   it "does replace" do
     a = [1, 2, 3]
     b = [1]
     b.replace a
-    b.should eq(a)
+    expect(b).to eq(a)
   end
 
   it "does reverse with an odd number of elements" do
     a = [1, 2, 3]
-    a.reverse.should eq([3, 2, 1])
-    a.should eq([1, 2, 3])
+    expect(a.reverse).to eq([3, 2, 1])
+    expect(a).to eq([1, 2, 3])
   end
 
   it "does reverse with an even number of elements" do
     a = [1, 2, 3, 4]
-    a.reverse.should eq([4, 3, 2, 1])
-    a.should eq([1, 2, 3, 4])
+    expect(a.reverse).to eq([4, 3, 2, 1])
+    expect(a).to eq([1, 2, 3, 4])
   end
 
   it "does reverse! with an odd number of elements" do
     a = [1, 2, 3, 4, 5]
     a.reverse!
-    a.should eq([5, 4, 3, 2, 1])
+    expect(a).to eq([5, 4, 3, 2, 1])
   end
 
   it "does reverse! with an even number of elements" do
     a = [1, 2, 3, 4, 5, 6]
     a.reverse!
-    a.should eq([6, 5, 4, 3, 2, 1])
+    expect(a).to eq([6, 5, 4, 3, 2, 1])
   end
 
   describe "rindex" do
     it "performs without a block" do
       a = [1, 2, 3, 4, 5, 3, 6]
-      a.rindex(3).should eq(5)
-      a.rindex(7).should be_nil
+      expect(a.rindex(3)).to eq(5)
+      expect(a.rindex(7)).to be_nil
     end
 
     it "performs with a block" do
       a = [1, 2, 3, 4, 5, 3, 6]
-      a.rindex { |i| i > 1 }.should eq(6)
-      a.rindex { |i| i > 6 }.should be_nil
+      expect(a.rindex { |i| i > 1 }).to eq(6)
+      expect(a.rindex { |i| i > 6 }).to be_nil
     end
   end
 
   describe "sample" do
     it "sample" do
-      [1].sample.should eq(1)
+      expect([1].sample).to eq(1)
 
       x = [1, 2, 3].sample
-      [1, 2, 3].includes?(x).should be_true
+      expect([1, 2, 3].includes?(x)).to be_true
     end
 
     it "gets sample of negative count elements raises" do
@@ -563,38 +563,38 @@ describe "Array" do
     end
 
     it "gets sample of 0 elements" do
-      [1].sample(0).should eq([] of Int32)
+      expect([1].sample(0)).to eq([] of Int32)
     end
 
     it "gets sample of 1 elements" do
-      [1].sample(1).should eq([1])
+      expect([1].sample(1)).to eq([1])
 
       x = [1, 2, 3].sample(1)
-      x.length.should eq(1)
+      expect(x.length).to eq(1)
       x = x.first
-      [1, 2, 3].includes?(x).should be_true
+      expect([1, 2, 3].includes?(x)).to be_true
     end
 
     it "gets sample of k elements out of n" do
       a = [1, 2, 3, 4, 5]
       b = a.sample(3)
       set = Set.new(b)
-      set.length.should eq(3)
+      expect(set.length).to eq(3)
 
       set.each do |e|
-        a.includes?(e).should be_true
+        expect(a.includes?(e)).to be_true
       end
     end
 
     it "gets sample of k elements out of n, where k > n" do
       a = [1, 2, 3, 4, 5]
       b = a.sample(10)
-      b.length.should eq(5)
+      expect(b.length).to eq(5)
       set = Set.new(b)
-      set.length.should eq(5)
+      expect(set.length).to eq(5)
 
       set.each do |e|
-        a.includes?(e).should be_true
+        expect(a.includes?(e)).to be_true
       end
     end
   end
@@ -602,8 +602,8 @@ describe "Array" do
   describe "shift" do
     it "shifts when non empty" do
       a = [1, 2, 3]
-      a.shift.should eq(1)
-      a.should eq([2, 3])
+      expect(a.shift).to eq(1)
+      expect(a).to eq([2, 3])
     end
 
     it "raises when empty" do
@@ -615,15 +615,15 @@ describe "Array" do
     it "shifts many elements" do
       a = [1, 2, 3, 4, 5]
       b = a.shift(3)
-      b.should eq([1, 2, 3])
-      a.should eq([4, 5])
+      expect(b).to eq([1, 2, 3])
+      expect(a).to eq([4, 5])
     end
 
     it "shifts more than what is available" do
       a = [1, 2, 3, 4, 5]
       b = a.shift(10)
-      b.should eq([1, 2, 3, 4, 5])
-      a.should eq([] of Int32)
+      expect(b).to eq([1, 2, 3, 4, 5])
+      expect(a).to eq([] of Int32)
     end
 
     it "shifts negative count raises" do
@@ -639,16 +639,16 @@ describe "Array" do
       a = [1, 2, 3]
       a.shuffle!
       b = [1, 2, 3]
-      3.times { a.includes?(b.shift).should be_true }
+      3.times { expect(a.includes?(b.shift)).to be_true }
     end
 
     it "shuffle" do
       a = [1, 2, 3]
       b = a.shuffle
-      a.same?(b).should be_false
-      a.should eq([1, 2, 3])
+      expect(a.same?(b)).to be_false
+      expect(a).to eq([1, 2, 3])
 
-      3.times { b.includes?(a.shift).should be_true }
+      3.times { expect(b.includes?(a.shift)).to be_true }
     end
   end
 
@@ -656,40 +656,40 @@ describe "Array" do
     it "sort! without block" do
       a = [3, 4, 1, 2, 5, 6]
       a.sort!
-      a.should eq([1, 2, 3, 4, 5, 6])
+      expect(a).to eq([1, 2, 3, 4, 5, 6])
     end
 
     it "sort without block" do
       a = [3, 4, 1, 2, 5, 6]
       b = a.sort
-      b.should eq([1, 2, 3, 4, 5, 6])
-      a.should_not eq(b)
+      expect(b).to eq([1, 2, 3, 4, 5, 6])
+      expect(a).to_not eq(b)
     end
 
     it "sort! with a block" do
       a = ["foo", "a", "hello"]
       a.sort! { |x, y| x.length <=> y.length }
-      a.should eq(["a", "foo", "hello"])
+      expect(a).to eq(["a", "foo", "hello"])
     end
 
     it "sort with a block" do
       a = ["foo", "a", "hello"]
       b = a.sort { |x, y| x.length <=> y.length }
-      b.should eq(["a", "foo", "hello"])
-      a.should_not eq(b)
+      expect(b).to eq(["a", "foo", "hello"])
+      expect(a).to_not eq(b)
     end
 
     it "sorts by!" do
       a = ["foo", "a", "hello"]
       a.sort_by! &.length
-      a.should eq(["a", "foo", "hello"])
+      expect(a).to eq(["a", "foo", "hello"])
     end
 
     it "sorts by" do
       a = ["foo", "a", "hello"]
       b = a.sort_by &.length
-      b.should eq(["a", "foo", "hello"])
-      a.should_not eq(b)
+      expect(b).to eq(["a", "foo", "hello"])
+      expect(a).to_not eq(b)
     end
   end
 
@@ -697,13 +697,13 @@ describe "Array" do
     it "swaps" do
       a = [1, 2, 3]
       a.swap(0, 2)
-      a.should eq([3, 2, 1])
+      expect(a).to eq([3, 2, 1])
     end
 
     it "swaps with negative indices" do
       a = [1, 2, 3]
       a.swap(-3, -1)
-      a.should eq([3, 2, 1])
+      expect(a).to eq([3, 2, 1])
     end
 
     it "swaps but raises out of bounds on left" do
@@ -723,13 +723,13 @@ describe "Array" do
 
   describe "to_s" do
     it "does to_s" do
-      assert { [1, 2, 3].to_s.should eq("[1, 2, 3]") }
+      assert { expect([1, 2, 3].to_s).to eq("[1, 2, 3]") }
     end
 
     it "does with recursive" do
       ary = [] of RecursiveArray
       ary << ary
-      ary.to_s.should eq("[[...]]")
+      expect(ary.to_s).to eq("[[...]]")
     end
   end
 
@@ -737,22 +737,22 @@ describe "Array" do
     it "uniqs without block" do
       a = [1, 2, 2, 3, 1, 4, 5, 3]
       b = a.uniq
-      b.should eq([1, 2, 3, 4, 5])
-      a.same?(b).should be_false
+      expect(b).to eq([1, 2, 3, 4, 5])
+      expect(a.same?(b)).to be_false
     end
 
     it "uniqs with block" do
       a = [-1, 1, 0, 2, -2]
       b = a.uniq &.abs
-      b.should eq([-1, 0, 2])
-      a.same?(b).should be_false
+      expect(b).to eq([-1, 0, 2])
+      expect(a.same?(b)).to be_false
     end
 
     it "uniqs with true" do
       a = [1, 2, 3]
       b = a.uniq { true }
-      b.should eq([1])
-      a.same?(b).should be_false
+      expect(b).to eq([1])
+      expect(a.same?(b)).to be_false
     end
   end
 
@@ -760,33 +760,33 @@ describe "Array" do
     it "uniqs without block" do
       a = [1, 2, 2, 3, 1, 4, 5, 3]
       a.uniq!
-      a.should eq([1, 2, 3, 4, 5])
+      expect(a).to eq([1, 2, 3, 4, 5])
     end
 
     it "uniqs with block" do
       a = [-1, 1, 0, 2, -2]
       a.uniq! &.abs
-      a.should eq([-1, 0, 2])
+      expect(a).to eq([-1, 0, 2])
     end
 
     it "uniqs with true" do
       a = [1, 2, 3]
       a.uniq! { true }
-      a.should eq([1])
+      expect(a).to eq([1])
     end
   end
 
   it "does unshift" do
     a = [2, 3]
     expected = [1, 2, 3]
-    a.unshift(1).should eq(expected)
-    a.should eq(expected)
+    expect(a.unshift(1)).to eq(expected)
+    expect(a).to eq(expected)
   end
 
   it "does update" do
     a = [1, 2, 3]
     a.update(1) { |x| x * 2 }
-    a.should eq([1, 4, 3])
+    expect(a).to eq([1, 4, 3])
   end
 
   it "does <=>" do
@@ -794,18 +794,18 @@ describe "Array" do
     b = [4, 5, 6]
     c = [1, 2]
 
-    (a <=> b).should be < 1
-    (a <=> c).should be > 0
-    (b <=> c).should be > 0
-    (b <=> a).should be > 0
-    (c <=> a).should be < 0
-    (c <=> b).should be < 0
-    (a <=> a).should eq(0)
+    expect((a <=> b)).to be < 1
+    expect((a <=> c)).to be > 0
+    expect((b <=> c)).to be > 0
+    expect((b <=> a)).to be > 0
+    expect((c <=> a)).to be < 0
+    expect((c <=> b)).to be < 0
+    expect((a <=> a)).to eq(0)
 
-    ([8] <=> [1, 2, 3]).should be > 0
-    ([8] <=> [8, 1, 2]).should be < 0
+    expect(([8] <=> [1, 2, 3])).to be > 0
+    expect(([8] <=> [8, 1, 2])).to be < 0
 
-    [[1, 2, 3], [4, 5], [8], [1, 2, 3, 4]].sort.should eq([[1, 2, 3], [1, 2, 3, 4], [4, 5], [8]])
+    expect([[1, 2, 3], [4, 5], [8], [1, 2, 3, 4]].sort).to eq([[1, 2, 3], [1, 2, 3, 4], [4, 5], [8]])
   end
 
   it "does each while modifying array" do
@@ -815,7 +815,7 @@ describe "Array" do
       count += 1
       a.clear
     end
-    count.should eq(1)
+    expect(count).to eq(1)
   end
 
   it "does each index while modifying array" do
@@ -825,7 +825,7 @@ describe "Array" do
       count += 1
       a.clear
     end
-    count.should eq(1)
+    expect(count).to eq(1)
   end
 
   describe "zip" do
@@ -833,7 +833,7 @@ describe "Array" do
       it "yields pairs of self's elements and passed array" do
         a, b, r = [1, 2, 3], [4, 5, 6], ""
         a.zip(b) { |x, y| r += "#{x}:#{y}," }
-        r.should eq("1:4,2:5,3:6,")
+        expect(r).to eq("1:4,2:5,3:6,")
       end
     end
 
@@ -842,7 +842,7 @@ describe "Array" do
         it "returns an array of paired elements (tuples)" do
           a, b = [1, 2, 3], ["a", "b", "c"]
           r = a.zip(b)
-          r.should eq([{1, "a"}, {2, "b"}, {3, "c"}])
+          expect(r).to eq([{1, "a"}, {2, "b"}, {3, "c"}])
         end
       end
     end
@@ -851,8 +851,8 @@ describe "Array" do
   it "does compact_map" do
     a = [1, 2, 3, 4, 5]
     b = a.compact_map { |e| e.divisible_by?(2) ? e : nil }
-    b.length.should eq(2)
-    b.should eq([2, 4])
+    expect(b.length).to eq(2)
+    expect(b).to eq([2, 4])
   end
 
   it "does compact_map with false" do
@@ -864,8 +864,8 @@ describe "Array" do
       else        false
       end
     end
-    b.length.should eq(2)
-    b.should eq([1, false])
+    expect(b.length).to eq(2)
+    expect(b).to eq([1, false])
   end
 
   it "builds from buffer" do
@@ -874,27 +874,27 @@ describe "Array" do
       buffer[1] = 2
       2
     end
-    ary.length.should eq(2)
-    ary.should eq([1, 2])
+    expect(ary.length).to eq(2)
+    expect(ary).to eq([1, 2])
   end
 
   it "does select!" do
     ary = [1, 2, 3, 4]
     ary2 = ary.select! { |x| x % 2 == 0 }
-    ary2.should be(ary)
-    ary2.should eq([2, 4])
+    expect(ary2).to be(ary)
+    expect(ary2).to eq([2, 4])
   end
 
   it "does reject!" do
     ary = [1, 2, 3, 4]
     ary2 = ary.reject! { |x| x % 2 == 0 }
-    ary2.should be(ary)
-    ary2.should eq([1, 3])
+    expect(ary2).to be(ary)
+    expect(ary2).to eq([1, 3])
   end
 
   it "does map_with_index" do
     ary = [1, 1, 2, 2]
     ary2 = ary.map_with_index { |e, i| e + i }
-    ary2.should eq([1, 2, 4, 5])
+    expect(ary2).to eq([1, 2, 4, 5])
   end
 end

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -9,25 +9,25 @@ describe "Base64" do
            "abcdefg" => "YWJjZGVmZw==\n"}
     eqs.each do |a, b|
       it "encode #{a.inspect} to #{b.inspect}" do
-        Base64.encode64(a).should eq(b)
+        expect(Base64.encode64(a)).to eq(b)
       end
       it "decode from #{b.inspect} to #{a.inspect}" do
-        Base64.decode64(b).should eq(a)
+        expect(Base64.decode64(b)).to eq(a)
       end
     end
   end
 
   it "encodes byte slice" do
     slice = Slice(UInt8).new(5) { 1_u8 }
-    Base64.encode64(slice).should eq("AQEBAQE=\n")
-    Base64.strict_encode64(slice).should eq("AQEBAQE=")
+    expect(Base64.encode64(slice)).to eq("AQEBAQE=\n")
+    expect(Base64.strict_encode64(slice)).to eq("AQEBAQE=")
   end
 
   it "encodes static array" do
     array :: StaticArray(UInt8, 5)
     (0...5).each { |i| array[i] = 1_u8 }
-    Base64.encode64(array).should eq("AQEBAQE=\n")
-    Base64.strict_encode64(array).should eq("AQEBAQE=")
+    expect(Base64.encode64(array)).to eq("AQEBAQE=\n")
+    expect(Base64.strict_encode64(array)).to eq("AQEBAQE=")
   end
 
   describe "base" do
@@ -38,22 +38,22 @@ describe "Base64" do
            "hahah⊙ⓧ⊙" => "aGFoYWjiipnik6fiipk=\n"}
     eqs.each do |a, b|
       it "encode #{a.inspect} to #{b.inspect}" do
-        Base64.encode64(a).should eq(b)
+        expect(Base64.encode64(a)).to eq(b)
       end
       it "decode from #{b.inspect} to #{a.inspect}" do
-        Base64.decode64(b).should eq(a)
+        expect(Base64.decode64(b)).to eq(a)
       end
     end
 
     it "decode from strict form" do
-      Base64.decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
+      expect(Base64.decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")).to eq(
        "Now is the time for all good coders\nto learn Crystal")
     end
 
     it "big message" do
       a = "a" * 100000
       b = Base64.encode64(a)
-      Crypto::MD5.hex_digest(Base64.decode64(b)).should eq(Crypto::MD5.hex_digest(a))
+      expect(Crypto::MD5.hex_digest(Base64.decode64(b))).to eq(Crypto::MD5.hex_digest(a))
     end
 
     it "works for most characters" do
@@ -61,24 +61,24 @@ describe "Base64" do
         65536.times { |i| buf << (i + 1).chr }
       end
       b = Base64.encode64(a)
-      Crypto::MD5.hex_digest(Base64.decode64(b)).should eq(Crypto::MD5.hex_digest(a))
+      expect(Crypto::MD5.hex_digest(Base64.decode64(b))).to eq(Crypto::MD5.hex_digest(a))
     end
   end
 
   describe "scrict" do
     it "encode" do
-      Base64.strict_encode64("Now is the time for all good coders\nto learn Crystal").should eq(
+      expect(Base64.strict_encode64("Now is the time for all good coders\nto learn Crystal")).to eq(
         "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")
     end
     it "decode" do
-      Base64.strict_decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
+      expect(Base64.strict_decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")).to eq(
        "Now is the time for all good coders\nto learn Crystal")
     end
     it "with spec symbols" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
-      Base64.strict_encode64(s).should eq(se)
-      Base64.strict_decode64(se).should eq(s)
+      expect(Base64.strict_encode64(s)).to eq(se)
+      expect(Base64.strict_decode64(se)).to eq(s)
     end
   end
 
@@ -86,8 +86,8 @@ describe "Base64" do
     it "work" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw"
-      Base64.urlsafe_encode64(s).should eq(se)
-      Base64.urlsafe_decode64(se).should eq(s)
+      expect(Base64.urlsafe_encode64(s)).to eq(se)
+      expect(Base64.urlsafe_decode64(se)).to eq(s)
     end
   end
 

--- a/spec/std/big_int_spec.cr
+++ b/spec/std/big_int_spec.cr
@@ -3,115 +3,115 @@ require "big_int"
 
 describe "BigInt" do
   it "creates with a value of zero" do
-    BigInt.new.to_s.should eq("0")
+    expect(BigInt.new.to_s).to eq("0")
   end
 
   it "creates from signed ints" do
-    BigInt.new(-1_i8).to_s.should eq("-1")
-    BigInt.new(-1_i16).to_s.should eq("-1")
-    BigInt.new(-1_i32).to_s.should eq("-1")
-    BigInt.new(-1_i64).to_s.should eq("-1")
+    expect(BigInt.new(-1_i8).to_s).to eq("-1")
+    expect(BigInt.new(-1_i16).to_s).to eq("-1")
+    expect(BigInt.new(-1_i32).to_s).to eq("-1")
+    expect(BigInt.new(-1_i64).to_s).to eq("-1")
   end
 
   it "creates from unsigned ints" do
-    BigInt.new(1_u8).to_s.should eq("1")
-    BigInt.new(1_u16).to_s.should eq("1")
-    BigInt.new(1_u32).to_s.should eq("1")
-    BigInt.new(1_u64).to_s.should eq("1")
+    expect(BigInt.new(1_u8).to_s).to eq("1")
+    expect(BigInt.new(1_u16).to_s).to eq("1")
+    expect(BigInt.new(1_u32).to_s).to eq("1")
+    expect(BigInt.new(1_u64).to_s).to eq("1")
   end
 
   it "creates from string" do
-    BigInt.new("12345678").to_s.should eq("12345678")
+    expect(BigInt.new("12345678").to_s).to eq("12345678")
   end
 
   it "compares" do
-    1.to_big_i.should eq(1.to_big_i)
-    1.to_big_i.should eq(1)
-    1.to_big_i.should eq(1_u8)
+    expect(1.to_big_i).to eq(1.to_big_i)
+    expect(1.to_big_i).to eq(1)
+    expect(1.to_big_i).to eq(1_u8)
 
-    [3.to_big_i, 2.to_big_i, 10.to_big_i, 4, 8_u8].sort.should eq([2, 3, 4, 8, 10])
+    expect([3.to_big_i, 2.to_big_i, 10.to_big_i, 4, 8_u8].sort).to eq([2, 3, 4, 8, 10])
   end
 
   it "adds" do
-    (1.to_big_i + 2.to_big_i).should eq(3.to_big_i)
-    (1.to_big_i + 2).should eq(3.to_big_i)
-    (1.to_big_i + 2_u8).should eq(3.to_big_i)
-    (5.to_big_i + (-2_i64)).should eq(3.to_big_i)
+    expect((1.to_big_i + 2.to_big_i)).to eq(3.to_big_i)
+    expect((1.to_big_i + 2)).to eq(3.to_big_i)
+    expect((1.to_big_i + 2_u8)).to eq(3.to_big_i)
+    expect((5.to_big_i + (-2_i64))).to eq(3.to_big_i)
 
-    (2 + 1.to_big_i).should eq(3.to_big_i)
+    expect((2 + 1.to_big_i)).to eq(3.to_big_i)
   end
 
   it "subs" do
-    (5.to_big_i - 2.to_big_i).should eq(3.to_big_i)
-    (5.to_big_i - 2).should eq(3.to_big_i)
-    (5.to_big_i - 2_u8).should eq(3.to_big_i)
-    (5.to_big_i - (-2_i64)).should eq(7.to_big_i)
+    expect((5.to_big_i - 2.to_big_i)).to eq(3.to_big_i)
+    expect((5.to_big_i - 2)).to eq(3.to_big_i)
+    expect((5.to_big_i - 2_u8)).to eq(3.to_big_i)
+    expect((5.to_big_i - (-2_i64))).to eq(7.to_big_i)
 
-    (5 - 1.to_big_i).should eq(4.to_big_i)
-    (-5 - 1.to_big_i).should eq(-6.to_big_i)
+    expect((5 - 1.to_big_i)).to eq(4.to_big_i)
+    expect((-5 - 1.to_big_i)).to eq(-6.to_big_i)
   end
 
   it "negates" do
-    (-(-123.to_big_i)).should eq(123.to_big_i)
+    expect((-(-123.to_big_i))).to eq(123.to_big_i)
   end
 
   it "multiplies" do
-    (2.to_big_i * 3.to_big_i).should eq(6.to_big_i)
-    (2.to_big_i * 3).should eq(6.to_big_i)
-    (2.to_big_i * 3_u8).should eq(6.to_big_i)
-    (3 * 2.to_big_i).should eq(6.to_big_i)
-    (3_u8 * 2.to_big_i).should eq(6.to_big_i)
+    expect((2.to_big_i * 3.to_big_i)).to eq(6.to_big_i)
+    expect((2.to_big_i * 3)).to eq(6.to_big_i)
+    expect((2.to_big_i * 3_u8)).to eq(6.to_big_i)
+    expect((3 * 2.to_big_i)).to eq(6.to_big_i)
+    expect((3_u8 * 2.to_big_i)).to eq(6.to_big_i)
   end
 
   it "gets absolute value" do
-    (-10.to_big_i.abs).should eq(10.to_big_i)
+    expect((-10.to_big_i.abs)).to eq(10.to_big_i)
   end
 
   it "divides" do
-    (10.to_big_i / 3.to_big_i).should eq(3.to_big_i)
-    (10.to_big_i / 3).should eq(3.to_big_i)
-    (10.to_big_i / -3).should eq(-3.to_big_i)
-    (10 / 3.to_big_i).should eq(3.to_big_i)
+    expect((10.to_big_i / 3.to_big_i)).to eq(3.to_big_i)
+    expect((10.to_big_i / 3)).to eq(3.to_big_i)
+    expect((10.to_big_i / -3)).to eq(-3.to_big_i)
+    expect((10 / 3.to_big_i)).to eq(3.to_big_i)
   end
 
   it "does modulo" do
-    (10.to_big_i % 3.to_big_i).should eq(1.to_big_i)
-    (10.to_big_i % 3).should eq(1.to_big_i)
-    (10.to_big_i % -3).should eq(1.to_big_i)
-    (10 % 3.to_big_i).should eq(1.to_big_i)
+    expect((10.to_big_i % 3.to_big_i)).to eq(1.to_big_i)
+    expect((10.to_big_i % 3)).to eq(1.to_big_i)
+    expect((10.to_big_i % -3)).to eq(1.to_big_i)
+    expect((10 % 3.to_big_i)).to eq(1.to_big_i)
   end
 
   it "does bitwise and" do
-    (123.to_big_i & 321).should eq(65)
-    (BigInt.new("96238761238973286532") & 86325735648).should eq(69124358272)
+    expect((123.to_big_i & 321)).to eq(65)
+    expect((BigInt.new("96238761238973286532") & 86325735648)).to eq(69124358272)
   end
 
   it "does bitwise or" do
-    (123.to_big_i | 4).should eq(127)
-    (BigInt.new("96238761238986532") | 8632573).should eq(96238761247506429)
+    expect((123.to_big_i | 4)).to eq(127)
+    expect((BigInt.new("96238761238986532") | 8632573)).to eq(96238761247506429)
   end
 
   it "does bitwise xor" do
-    (123.to_big_i ^ 50).should eq(73)
-    (BigInt.new("96238761238986532") ^ 8632573).should eq(96238761247393753)
+    expect((123.to_big_i ^ 50)).to eq(73)
+    expect((BigInt.new("96238761238986532") ^ 8632573)).to eq(96238761247393753)
   end
 
   it "does bitwise not" do
-    (~123).should eq(-124)
+    expect((~123)).to eq(-124)
 
     a = BigInt.new("192623876123689865327")
     b = BigInt.new("-192623876123689865328")
-    (~a).should eq(b)
+    expect((~a)).to eq(b)
   end
 
   it "does bitwise right shift" do
-    (123.to_big_i >> 4).should eq(7)
-    (123456.to_big_i >> 8).should eq(482)
+    expect((123.to_big_i >> 4)).to eq(7)
+    expect((123456.to_big_i >> 8)).to eq(482)
   end
 
   it "does bitwise left shift" do
-    (123.to_big_i << 4).should eq(1968)
-    (123456.to_big_i << 8).should eq(31604736)
+    expect((123.to_big_i << 4)).to eq(1968)
+    expect((123456.to_big_i << 8)).to eq(31604736)
   end
 
   it "raises if divides by zero" do
@@ -147,39 +147,39 @@ describe "BigInt" do
     b = "1000100100010000100001111010001111101111010011000000100010101"
     c = "112210f47de98115"
     d = "128gguhuuj08l"
-    a.to_s(2).should eq(b)
-    a.to_s(16).should eq(c)
-    a.to_s(32).should eq(d)
+    expect(a.to_s(2)).to eq(b)
+    expect(a.to_s(16)).to eq(c)
+    expect(a.to_s(32)).to eq(d)
   end
 
   it "casts other ints and strings" do
     a = BigInt.new(123456)
     b = BigInt.cast(123456)
-    a.should eq(b)
+    expect(a).to eq(b)
 
     a = BigInt.new("123456789012345678901234567890")
     b = BigInt.cast("123456789012345678901234567890")
-    a.should eq(b)
+    expect(a).to eq(b)
   end
 
   it "can use Number::[]" do
     a = BigInt[146, "3464", 97, "545"]
     b = [BigInt.new(146), BigInt.new(3464), BigInt.new(97), BigInt.new(545)]
-    a.should eq(b)
+    expect(a).to eq(b)
   end
 
   it "can be casted into other Number types" do
     big = BigInt.new(1234567890)
-    big.to_i.should eq(1234567890)
-    big.to_i8.should eq(-46)
-    big.to_i16.should eq(722)
-    big.to_i32.should eq(1234567890)
-    big.to_i64.should eq(1234567890)
-    big.to_u.should eq(1234567890)
-    big.to_u8.should eq(210)
-    big.to_u16.should eq(722)
-    big.to_u32.should eq(1234567890)
-    big.to_u64.should eq(1234567890)
+    expect(big.to_i).to eq(1234567890)
+    expect(big.to_i8).to eq(-46)
+    expect(big.to_i16).to eq(722)
+    expect(big.to_i32).to eq(1234567890)
+    expect(big.to_i64).to eq(1234567890)
+    expect(big.to_u).to eq(1234567890)
+    expect(big.to_u8).to eq(210)
+    expect(big.to_u16).to eq(722)
+    expect(big.to_u32).to eq(1234567890)
+    expect(big.to_u64).to eq(1234567890)
   end
 end
 

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -4,47 +4,47 @@ require "bit_array"
 describe "BitArray" do
   it "is has length" do
     ary = BitArray.new(100)
-    ary.length.should eq(100)
+    expect(ary.length).to eq(100)
   end
 
   it "is is initially empty" do
     ary = BitArray.new(100)
     100.times do |i|
-      ary[i].should be_false
+      expect(ary[i]).to be_false
     end
   end
 
   it "is sets first bit to true" do
     ary = BitArray.new(100)
     ary[0] = true
-    ary[0].should be_true
+    expect(ary[0]).to be_true
   end
 
   it "is sets second bit to true" do
     ary = BitArray.new(100)
     ary[1] = true
-    ary[1].should be_true
+    expect(ary[1]).to be_true
   end
 
   it "is sets first bit to false" do
     ary = BitArray.new(100)
     ary[0] = true
     ary[0] = false
-    ary[0].should be_false
+    expect(ary[0]).to be_false
   end
 
   it "is sets second bit to false" do
     ary = BitArray.new(100)
     ary[1] = true
     ary[1] = false
-    ary[1].should be_false
+    expect(ary[1]).to be_false
   end
 
   it "is sets last bit to true with negative index" do
     ary = BitArray.new(100)
     ary[-1] = true
-    ary[-1].should be_true
-    ary[99].should be_true
+    expect(ary[-1]).to be_true
+    expect(ary[99]).to be_true
   end
 
   it "is raises when out of bounds" do
@@ -59,6 +59,6 @@ describe "BitArray" do
     ary[0] = true
     ary[2] = true
     ary[4] = true
-    ary.to_s.should eq("BitArray[10101000]")
+    expect(ary.to_s).to eq("BitArray[10101000]")
   end
 end

--- a/spec/std/bool_spec.cr
+++ b/spec/std/bool_spec.cr
@@ -2,21 +2,21 @@ require "spec"
 
 describe "Bool" do
   describe "|" do
-    assert { (false | false).should be_false }
-    assert { (false | true).should be_true }
-    assert { (true | false).should be_true }
-    assert { (true | true).should be_true }
+    assert { expect((false | false)).to be_false }
+    assert { expect((false | true)).to be_true }
+    assert { expect((true | false)).to be_true }
+    assert { expect((true | true)).to be_true }
   end
 
   describe "&" do
-    assert { (false & false).should be_false }
-    assert { (false & true).should be_false }
-    assert { (true & false).should be_false }
-    assert { (true & true).should be_true }
+    assert { expect((false & false)).to be_false }
+    assert { expect((false & true)).to be_false }
+    assert { expect((true & false)).to be_false }
+    assert { expect((true & true)).to be_true }
   end
 
   describe "hash" do
-    true.hash.should eq(1)
-    false.hash.should eq(0)
+    expect(true.hash).to eq(1)
+    expect(false.hash).to eq(0)
   end
 end

--- a/spec/std/box_spec.cr
+++ b/spec/std/box_spec.cr
@@ -4,6 +4,6 @@ describe "Box" do
   it "boxes and unboxes" do
     a = 1
     box = Box.box(a)
-    Box(Int32).unbox(box).should eq(1)
+    expect(Box(Int32).unbox(box)).to eq(1)
   end
 end

--- a/spec/std/cgi_spec.cr
+++ b/spec/std/cgi_spec.cr
@@ -17,13 +17,13 @@ describe "CGI" do
   ].each do |tuple|
     from, to = tuple
     it "unescapes #{from}" do
-      CGI.unescape(from).should eq(to)
+      expect(CGI.unescape(from)).to eq(to)
     end
 
     it "unescapes #{from} to IO" do
-      String.build do |str|
+      expect(String.build do |str|
         CGI.unescape(from, str)
-      end.should eq(to)
+      end).to eq(to)
     end
   end
 
@@ -40,13 +40,13 @@ describe "CGI" do
   ].each do |tuple|
     from, to = tuple
     it "escapes #{to}" do
-      CGI.escape(to).should eq(from)
+      expect(CGI.escape(to)).to eq(from)
     end
 
     it "escapes #{to} to IO" do
-      String.build do |str|
+      expect(String.build do |str|
         CGI.escape(to, str)
-      end.should eq(from)
+      end).to eq(from)
     end
   end
 
@@ -61,11 +61,11 @@ describe "CGI" do
   ].each do |tuple|
     from, to = tuple
     it "parses #{from}" do
-      CGI.parse(from).should eq(to)
+      expect(CGI.parse(from)).to eq(to)
     end
   end
 
   it "escapes newline char" do
-    CGI.escape("\n").should eq("%0A")
+    expect(CGI.escape("\n")).to eq("%0A")
   end
 end

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -2,11 +2,11 @@ require "spec"
 
 describe Channel do
   it "creates unbuffered with no arguments" do
-    Channel(Int32).new.should be_a(UnbufferedChannel(Int32))
+    expect(Channel(Int32).new).to be_a(UnbufferedChannel(Int32))
   end
 
   it "creates buffered with capacity argument" do
-    Channel(Int32).new(32).should be_a(BufferedChannel(Int32))
+    expect(Channel(Int32).new(32)).to be_a(BufferedChannel(Int32))
   end
 end
 
@@ -15,7 +15,7 @@ describe UnbufferedChannel do
     ch = UnbufferedChannel(Int32).new
     spawn { ch.send(ch.receive) }
     ch.send 123
-    ch.receive.should eq(123)
+    expect(ch.receive).to eq(123)
   end
 
   it "blocks if there is no receiver" do
@@ -28,11 +28,11 @@ describe UnbufferedChannel do
     end
 
     Scheduler.yield
-    state.should eq(1)
-    ch.receive.should eq(123)
-    state.should eq(1)
+    expect(state).to eq(1)
+    expect(ch.receive).to eq(123)
+    expect(state).to eq(1)
     Scheduler.yield
-    state.should eq(2)
+    expect(state).to eq(2)
   end
 
   it "deliver many senders" do
@@ -41,23 +41,23 @@ describe UnbufferedChannel do
     spawn { ch.send 2; ch.send 5 }
     spawn { ch.send 3; ch.send 6 }
 
-    (1..6).map { ch.receive }.sort.should eq([1, 2, 3, 4, 5, 6])
+    expect((1..6).map { ch.receive }.sort).to eq([1, 2, 3, 4, 5, 6])
   end
 
   it "gets ready when there is a sender" do
     ch = UnbufferedChannel(Int32).new
-    ch.ready?.should be_false
+    expect(ch.ready?).to be_false
     spawn { ch.send 123 }
     Scheduler.yield
-    ch.ready?.should be_true
-    ch.receive.should eq(123)
+    expect(ch.ready?).to be_true
+    expect(ch.receive).to eq(123)
   end
 
   it "works with select" do
     ch1 = UnbufferedChannel(Int32).new
     ch2 = UnbufferedChannel(Int32).new
     spawn { ch1.send 123 }
-    Channel.select(ch1, ch2).should eq(ch1)
+    expect(Channel.select(ch1, ch2)).to eq(ch1)
   end
 end
 
@@ -66,7 +66,7 @@ describe BufferedChannel do
     ch = BufferedChannel(Int32).new
     spawn { ch.send(ch.receive) }
     ch.send 123
-    ch.receive.should eq(123)
+    expect(ch.receive).to eq(123)
   end
 
   it "blocks when full" do
@@ -75,38 +75,38 @@ describe BufferedChannel do
     spawn { 2.times { ch.receive }; freed = true }
 
     ch.send 1
-    ch.full?.should be_false
-    freed.should be_false
+    expect(ch.full?).to be_false
+    expect(freed).to be_false
 
     ch.send 2
-    ch.full?.should be_true
-    freed.should be_false
+    expect(ch.full?).to be_true
+    expect(freed).to be_false
 
     ch.send 3
-    ch.full?.should be_false
-    freed.should be_true
+    expect(ch.full?).to be_false
+    expect(freed).to be_true
   end
 
   it "doesn't block when not full" do
     ch = BufferedChannel(Int32).new
     done = false
     spawn { ch.send 123; done = true }
-    done.should be_false
+    expect(done).to be_false
     Scheduler.yield
-    done.should be_true
+    expect(done).to be_true
   end
 
   it "gets ready with data" do
     ch = BufferedChannel(Int32).new
-    ch.ready?.should be_false
+    expect(ch.ready?).to be_false
     ch.send 123
-    ch.ready?.should be_true
+    expect(ch.ready?).to be_true
   end
 
   it "works with select" do
     ch1 = BufferedChannel(Int32).new
     ch2 = BufferedChannel(Int32).new
     spawn { ch1.send 123 }
-    Channel.select(ch1, ch2).should eq(ch1)
+    expect(Channel.select(ch1, ch2)).to eq(ch1)
   end
 end

--- a/spec/std/char_reader_spec.cr
+++ b/spec/std/char_reader_spec.cr
@@ -4,9 +4,9 @@ require "char_reader"
 describe "CharReader" do
   it "iterates through empty string" do
     reader = CharReader.new("")
-    reader.pos.should eq(0)
-    reader.current_char.ord.should eq(0)
-    reader.has_next?.should be_false
+    expect(reader.pos).to eq(0)
+    expect(reader.current_char.ord).to eq(0)
+    expect(reader.has_next?).to be_false
 
     expect_raises IndexOutOfBounds do
       reader.next_char
@@ -15,11 +15,11 @@ describe "CharReader" do
 
   it "iterates through string of length one" do
     reader = CharReader.new("a")
-    reader.pos.should eq(0)
-    reader.current_char.should eq('a')
-    reader.has_next?.should be_true
-    reader.next_char.ord.should eq(0)
-    reader.has_next?.should be_false
+    expect(reader.pos).to eq(0)
+    expect(reader.current_char).to eq('a')
+    expect(reader.has_next?).to be_true
+    expect(reader.next_char.ord).to eq(0)
+    expect(reader.has_next?).to be_false
 
     expect_raises IndexOutOfBounds do
       reader.next_char
@@ -28,22 +28,22 @@ describe "CharReader" do
 
   it "iterates through chars" do
     reader = CharReader.new("há日本語")
-    reader.pos.should eq(0)
-    reader.current_char.ord.should eq(104)
-    reader.has_next?.should be_true
+    expect(reader.pos).to eq(0)
+    expect(reader.current_char.ord).to eq(104)
+    expect(reader.has_next?).to be_true
 
-    reader.next_char.ord.should eq(225)
+    expect(reader.next_char.ord).to eq(225)
 
-    reader.pos.should eq(1)
-    reader.current_char.ord.should eq(225)
+    expect(reader.pos).to eq(1)
+    expect(reader.current_char.ord).to eq(225)
 
-    reader.next_char.ord.should eq(26085)
-    reader.next_char.ord.should eq(26412)
-    reader.next_char.ord.should eq(35486)
-    reader.has_next?.should be_true
+    expect(reader.next_char.ord).to eq(26085)
+    expect(reader.next_char.ord).to eq(26412)
+    expect(reader.next_char.ord).to eq(35486)
+    expect(reader.has_next?).to be_true
 
-    reader.next_char.ord.should eq(0)
-    reader.has_next?.should be_false
+    expect(reader.next_char.ord).to eq(0)
+    expect(reader.has_next?).to be_false
 
     expect_raises IndexOutOfBounds do
       reader.next_char
@@ -52,14 +52,14 @@ describe "CharReader" do
 
   it "peeks next char" do
     reader = CharReader.new("há日本語")
-    reader.peek_next_char.ord.should eq(225)
+    expect(reader.peek_next_char.ord).to eq(225)
   end
 
   it "sets pos" do
     reader = CharReader.new("há日本語")
     reader.pos = 1
-    reader.pos.should eq(1)
-    reader.current_char.ord.should eq(225)
+    expect(reader.pos).to eq(1)
+    expect(reader.current_char.ord).to eq(225)
   end
 
   it "is an Enumerable(Char)" do
@@ -68,7 +68,7 @@ describe "CharReader" do
     reader.each do |char|
       sum += char.ord
     end
-    sum.should eq(294)
+    expect(sum).to eq(294)
   end
 
   it "is an Enumerable(Char) but doesn't yield if empty" do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -2,153 +2,153 @@ require "spec"
 
 describe "Char" do
   describe "upcase" do
-    assert { 'a'.upcase.should eq('A') }
-    assert { '1'.upcase.should eq('1') }
+    assert { expect('a'.upcase).to eq('A') }
+    assert { expect('1'.upcase).to eq('1') }
   end
 
   describe "downcase" do
-    assert { 'A'.downcase.should eq('a') }
-    assert { '1'.downcase.should eq('1') }
+    assert { expect('A'.downcase).to eq('a') }
+    assert { expect('1'.downcase).to eq('1') }
   end
 
   describe "whitespace?" do
     [' ', '\t', '\n', '\v', '\f', '\r'].each do |char|
-      assert { char.whitespace?.should be_true }
+      assert { expect(char.whitespace?).to be_true }
     end
   end
 
   it "dumps" do
-    'a'.dump.should eq("'a'")
-    '\\'.dump.should eq("'\\\\'")
-    '\e'.dump.should eq("'\\e'")
-    '\f'.dump.should eq("'\\f'")
-    '\n'.dump.should eq("'\\n'")
-    '\r'.dump.should eq("'\\r'")
-    '\t'.dump.should eq("'\\t'")
-    '\v'.dump.should eq("'\\v'")
-    'á'.dump.should eq("'\\u{E1}'")
-    '\u{81}'.dump.should eq("'\\u{81}'")
+    expect('a'.dump).to eq("'a'")
+    expect('\\'.dump).to eq("'\\\\'")
+    expect('\e'.dump).to eq("'\\e'")
+    expect('\f'.dump).to eq("'\\f'")
+    expect('\n'.dump).to eq("'\\n'")
+    expect('\r'.dump).to eq("'\\r'")
+    expect('\t'.dump).to eq("'\\t'")
+    expect('\v'.dump).to eq("'\\v'")
+    expect('á'.dump).to eq("'\\u{E1}'")
+    expect('\u{81}'.dump).to eq("'\\u{81}'")
   end
 
   it "inspects" do
-    'a'.inspect.should eq("'a'")
-    '\\'.inspect.should eq("'\\\\'")
-    '\e'.inspect.should eq("'\\e'")
-    '\f'.inspect.should eq("'\\f'")
-    '\n'.inspect.should eq("'\\n'")
-    '\r'.inspect.should eq("'\\r'")
-    '\t'.inspect.should eq("'\\t'")
-    '\v'.inspect.should eq("'\\v'")
-    'á'.inspect.should eq("'á'")
-    '\u{81}'.inspect.should eq("'\\u{81}'")
+    expect('a'.inspect).to eq("'a'")
+    expect('\\'.inspect).to eq("'\\\\'")
+    expect('\e'.inspect).to eq("'\\e'")
+    expect('\f'.inspect).to eq("'\\f'")
+    expect('\n'.inspect).to eq("'\\n'")
+    expect('\r'.inspect).to eq("'\\r'")
+    expect('\t'.inspect).to eq("'\\t'")
+    expect('\v'.inspect).to eq("'\\v'")
+    expect('á'.inspect).to eq("'á'")
+    expect('\u{81}'.inspect).to eq("'\\u{81}'")
   end
 
   it "escapes" do
-    '\b'.ord.should eq(8)
-    '\t'.ord.should eq(9)
-    '\n'.ord.should eq(10)
-    '\v'.ord.should eq(11)
-    '\f'.ord.should eq(12)
-    '\r'.ord.should eq(13)
-    '\e'.ord.should eq(27)
-    '\''.ord.should eq(39)
-    '\\'.ord.should eq(92)
+    expect('\b'.ord).to eq(8)
+    expect('\t'.ord).to eq(9)
+    expect('\n'.ord).to eq(10)
+    expect('\v'.ord).to eq(11)
+    expect('\f'.ord).to eq(12)
+    expect('\r'.ord).to eq(13)
+    expect('\e'.ord).to eq(27)
+    expect('\''.ord).to eq(39)
+    expect('\\'.ord).to eq(92)
   end
 
   it "escapes with octal" do
-    '\0'.ord.should eq(0)
-    '\3'.ord.should eq(3)
-    '\23'.ord.should eq((2 * 8) + 3)
-    '\123'.ord.should eq((1 * 8 * 8) + (2 * 8) + 3)
-    '\033'.ord.should eq((3 * 8) + 3)
+    expect('\0'.ord).to eq(0)
+    expect('\3'.ord).to eq(3)
+    expect('\23'.ord).to eq((2 * 8) + 3)
+    expect('\123'.ord).to eq((1 * 8 * 8) + (2 * 8) + 3)
+    expect('\033'.ord).to eq((3 * 8) + 3)
   end
 
   it "escapes with unicode" do
-    '\u{12}'.ord.should eq(1 * 16 + 2)
-    '\u{A}'.ord.should eq(10)
-    '\u{AB}'.ord.should eq(10 * 16 + 11)
+    expect('\u{12}'.ord).to eq(1 * 16 + 2)
+    expect('\u{A}'.ord).to eq(10)
+    expect('\u{AB}'.ord).to eq(10 * 16 + 11)
   end
 
   it "does to_i without a base" do
     ('0'..'9').each_with_index do |c, i|
-      c.to_i.should eq(i)
+      expect(c.to_i).to eq(i)
     end
-    'a'.to_i.should eq(0)
+    expect('a'.to_i).to eq(0)
   end
 
   it "does to_i with 16 base" do
     ('0'..'9').each_with_index do |c, i|
-      c.to_i(16).should eq(i)
+      expect(c.to_i(16)).to eq(i)
     end
     ('a'..'f').each_with_index do |c, i|
-      c.to_i(16).should eq(10 + i)
+      expect(c.to_i(16)).to eq(10 + i)
     end
     ('A'..'F').each_with_index do |c, i|
-      c.to_i(16).should eq(10 + i)
+      expect(c.to_i(16)).to eq(10 + i)
     end
-    'Z'.to_i(16).should eq(0)
-    'Z'.to_i(16, or_else: -1).should eq(-1)
+    expect('Z'.to_i(16)).to eq(0)
+    expect('Z'.to_i(16, or_else: -1)).to eq(-1)
   end
 
   it "does ord for multibyte char" do
-    '日'.ord.should eq(26085)
+    expect('日'.ord).to eq(26085)
   end
 
   it "does to_s for single-byte char" do
-    'a'.to_s.should eq("a")
+    expect('a'.to_s).to eq("a")
   end
 
   it "does to_s for multibyte char" do
-    '日'.to_s.should eq("日")
+    expect('日'.to_s).to eq("日")
   end
 
   describe "index" do
-    assert { "foo".index('o').should eq(1) }
-    assert { "foo".index('x').should be_nil }
+    assert { expect("foo".index('o')).to eq(1) }
+    assert { expect("foo".index('x')).to be_nil }
   end
 
   it "does <=>" do
-    ('a' <=> 'b').should be < 0
-    ('a' <=> 'a').should eq(0)
-    ('b' <=> 'a').should be > 0
+    expect(('a' <=> 'b')).to be < 0
+    expect(('a' <=> 'a')).to eq(0)
+    expect(('b' <=> 'a')).to be > 0
   end
 
   describe "in_set?" do
-    assert { 'a'.in_set?("a").should be_true }
-    assert { 'a'.in_set?("b").should be_false }
-    assert { 'a'.in_set?("a-c").should be_true }
-    assert { 'b'.in_set?("a-c").should be_true }
-    assert { 'c'.in_set?("a-c").should be_true }
-    assert { 'c'.in_set?("a-bc").should be_true }
-    assert { 'b'.in_set?("a-bc").should be_true }
-    assert { 'd'.in_set?("a-c").should be_false }
-    assert { 'b'.in_set?("^a-c").should be_false }
-    assert { 'd'.in_set?("^a-c").should be_true }
-    assert { 'a'.in_set?("ab-c").should be_true }
-    assert { 'a'.in_set?("\\^ab-c").should be_true }
-    assert { '^'.in_set?("\\^ab-c").should be_true }
-    assert { '^'.in_set?("a^b-c").should be_true }
-    assert { '^'.in_set?("ab-c^").should be_true }
-    assert { '^'.in_set?("a0-^").should be_true }
-    assert { '^'.in_set?("^-c").should be_true }
-    assert { '^'.in_set?("a^-c").should be_true }
-    assert { '\\'.in_set?("ab-c\\").should be_true }
-    assert { '\\'.in_set?("a\\b-c").should be_false }
-    assert { '\\'.in_set?("a0-\\c").should be_true }
-    assert { '\\'.in_set?("a\\-c").should be_false }
-    assert { '-'.in_set?("a-c").should be_false }
-    assert { '-'.in_set?("a-c").should be_false }
-    assert { '-'.in_set?("a\\-c").should be_true }
-    assert { '-'.in_set?("-c").should be_true }
-    assert { '-'.in_set?("a-").should be_true }
-    assert { '-'.in_set?("^-c").should be_false }
-    assert { '-'.in_set?("^\\-c").should be_false }
-    assert { 'b'.in_set?("^\\-c").should be_true }
-    assert { '-'.in_set?("a^-c").should be_false }
-    assert { 'a'.in_set?("a", "ab").should be_true }
-    assert { 'a'.in_set?("a", "^b").should be_true }
-    assert { 'a'.in_set?("a", "b").should be_false }
-    assert { 'a'.in_set?("ab", "ac", "ad").should be_true }
+    assert { expect('a'.in_set?("a")).to be_true }
+    assert { expect('a'.in_set?("b")).to be_false }
+    assert { expect('a'.in_set?("a-c")).to be_true }
+    assert { expect('b'.in_set?("a-c")).to be_true }
+    assert { expect('c'.in_set?("a-c")).to be_true }
+    assert { expect('c'.in_set?("a-bc")).to be_true }
+    assert { expect('b'.in_set?("a-bc")).to be_true }
+    assert { expect('d'.in_set?("a-c")).to be_false }
+    assert { expect('b'.in_set?("^a-c")).to be_false }
+    assert { expect('d'.in_set?("^a-c")).to be_true }
+    assert { expect('a'.in_set?("ab-c")).to be_true }
+    assert { expect('a'.in_set?("\\^ab-c")).to be_true }
+    assert { expect('^'.in_set?("\\^ab-c")).to be_true }
+    assert { expect('^'.in_set?("a^b-c")).to be_true }
+    assert { expect('^'.in_set?("ab-c^")).to be_true }
+    assert { expect('^'.in_set?("a0-^")).to be_true }
+    assert { expect('^'.in_set?("^-c")).to be_true }
+    assert { expect('^'.in_set?("a^-c")).to be_true }
+    assert { expect('\\'.in_set?("ab-c\\")).to be_true }
+    assert { expect('\\'.in_set?("a\\b-c")).to be_false }
+    assert { expect('\\'.in_set?("a0-\\c")).to be_true }
+    assert { expect('\\'.in_set?("a\\-c")).to be_false }
+    assert { expect('-'.in_set?("a-c")).to be_false }
+    assert { expect('-'.in_set?("a-c")).to be_false }
+    assert { expect('-'.in_set?("a\\-c")).to be_true }
+    assert { expect('-'.in_set?("-c")).to be_true }
+    assert { expect('-'.in_set?("a-")).to be_true }
+    assert { expect('-'.in_set?("^-c")).to be_false }
+    assert { expect('-'.in_set?("^\\-c")).to be_false }
+    assert { expect('b'.in_set?("^\\-c")).to be_true }
+    assert { expect('-'.in_set?("a^-c")).to be_false }
+    assert { expect('a'.in_set?("a", "ab")).to be_true }
+    assert { expect('a'.in_set?("a", "^b")).to be_true }
+    assert { expect('a'.in_set?("a", "b")).to be_false }
+    assert { expect('a'.in_set?("ab", "ac", "ad")).to be_true }
 
     it "rejects invalid ranges" do
       expect_raises do
@@ -164,6 +164,6 @@ describe "Char" do
   end
 
   it "does bytes" do
-    '\u{FF}'.bytes.should eq([195, 191])
+    expect('\u{FF}'.bytes).to eq([195, 191])
   end
 end

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -3,76 +3,76 @@ require "colorize"
 
 describe "colorize" do
   it "colorizes without change" do
-    "hello".colorize.to_s.should eq("hello")
+    expect("hello".colorize.to_s).to eq("hello")
   end
 
   it "colorizes foreground" do
-    "hello".colorize.black.to_s.should eq("\e[30mhello\e[0m")
-    "hello".colorize.red.to_s.should eq("\e[31mhello\e[0m")
-    "hello".colorize.green.to_s.should eq("\e[32mhello\e[0m")
-    "hello".colorize.yellow.to_s.should eq("\e[33mhello\e[0m")
-    "hello".colorize.blue.to_s.should eq("\e[34mhello\e[0m")
-    "hello".colorize.magenta.to_s.should eq("\e[35mhello\e[0m")
-    "hello".colorize.cyan.to_s.should eq("\e[36mhello\e[0m")
-    "hello".colorize.light_gray.to_s.should eq("\e[37mhello\e[0m")
-    "hello".colorize.dark_gray.to_s.should eq("\e[90mhello\e[0m")
-    "hello".colorize.light_red.to_s.should eq("\e[91mhello\e[0m")
-    "hello".colorize.light_green.to_s.should eq("\e[92mhello\e[0m")
-    "hello".colorize.light_yellow.to_s.should eq("\e[93mhello\e[0m")
-    "hello".colorize.light_blue.to_s.should eq("\e[94mhello\e[0m")
-    "hello".colorize.light_magenta.to_s.should eq("\e[95mhello\e[0m")
-    "hello".colorize.light_cyan.to_s.should eq("\e[96mhello\e[0m")
-    "hello".colorize.white.to_s.should eq("\e[97mhello\e[0m")
+    expect("hello".colorize.black.to_s).to eq("\e[30mhello\e[0m")
+    expect("hello".colorize.red.to_s).to eq("\e[31mhello\e[0m")
+    expect("hello".colorize.green.to_s).to eq("\e[32mhello\e[0m")
+    expect("hello".colorize.yellow.to_s).to eq("\e[33mhello\e[0m")
+    expect("hello".colorize.blue.to_s).to eq("\e[34mhello\e[0m")
+    expect("hello".colorize.magenta.to_s).to eq("\e[35mhello\e[0m")
+    expect("hello".colorize.cyan.to_s).to eq("\e[36mhello\e[0m")
+    expect("hello".colorize.light_gray.to_s).to eq("\e[37mhello\e[0m")
+    expect("hello".colorize.dark_gray.to_s).to eq("\e[90mhello\e[0m")
+    expect("hello".colorize.light_red.to_s).to eq("\e[91mhello\e[0m")
+    expect("hello".colorize.light_green.to_s).to eq("\e[92mhello\e[0m")
+    expect("hello".colorize.light_yellow.to_s).to eq("\e[93mhello\e[0m")
+    expect("hello".colorize.light_blue.to_s).to eq("\e[94mhello\e[0m")
+    expect("hello".colorize.light_magenta.to_s).to eq("\e[95mhello\e[0m")
+    expect("hello".colorize.light_cyan.to_s).to eq("\e[96mhello\e[0m")
+    expect("hello".colorize.white.to_s).to eq("\e[97mhello\e[0m")
   end
 
   it "colorizes background" do
-    "hello".colorize.on_black.to_s.should eq("\e[40mhello\e[0m")
-    "hello".colorize.on_red.to_s.should eq("\e[41mhello\e[0m")
-    "hello".colorize.on_green.to_s.should eq("\e[42mhello\e[0m")
-    "hello".colorize.on_yellow.to_s.should eq("\e[43mhello\e[0m")
-    "hello".colorize.on_blue.to_s.should eq("\e[44mhello\e[0m")
-    "hello".colorize.on_magenta.to_s.should eq("\e[45mhello\e[0m")
-    "hello".colorize.on_cyan.to_s.should eq("\e[46mhello\e[0m")
-    "hello".colorize.on_light_gray.to_s.should eq("\e[47mhello\e[0m")
-    "hello".colorize.on_dark_gray.to_s.should eq("\e[100mhello\e[0m")
-    "hello".colorize.on_light_red.to_s.should eq("\e[101mhello\e[0m")
-    "hello".colorize.on_light_green.to_s.should eq("\e[102mhello\e[0m")
-    "hello".colorize.on_light_yellow.to_s.should eq("\e[103mhello\e[0m")
-    "hello".colorize.on_light_blue.to_s.should eq("\e[104mhello\e[0m")
-    "hello".colorize.on_light_magenta.to_s.should eq("\e[105mhello\e[0m")
-    "hello".colorize.on_light_cyan.to_s.should eq("\e[106mhello\e[0m")
-    "hello".colorize.on_white.to_s.should eq("\e[107mhello\e[0m")
+    expect("hello".colorize.on_black.to_s).to eq("\e[40mhello\e[0m")
+    expect("hello".colorize.on_red.to_s).to eq("\e[41mhello\e[0m")
+    expect("hello".colorize.on_green.to_s).to eq("\e[42mhello\e[0m")
+    expect("hello".colorize.on_yellow.to_s).to eq("\e[43mhello\e[0m")
+    expect("hello".colorize.on_blue.to_s).to eq("\e[44mhello\e[0m")
+    expect("hello".colorize.on_magenta.to_s).to eq("\e[45mhello\e[0m")
+    expect("hello".colorize.on_cyan.to_s).to eq("\e[46mhello\e[0m")
+    expect("hello".colorize.on_light_gray.to_s).to eq("\e[47mhello\e[0m")
+    expect("hello".colorize.on_dark_gray.to_s).to eq("\e[100mhello\e[0m")
+    expect("hello".colorize.on_light_red.to_s).to eq("\e[101mhello\e[0m")
+    expect("hello".colorize.on_light_green.to_s).to eq("\e[102mhello\e[0m")
+    expect("hello".colorize.on_light_yellow.to_s).to eq("\e[103mhello\e[0m")
+    expect("hello".colorize.on_light_blue.to_s).to eq("\e[104mhello\e[0m")
+    expect("hello".colorize.on_light_magenta.to_s).to eq("\e[105mhello\e[0m")
+    expect("hello".colorize.on_light_cyan.to_s).to eq("\e[106mhello\e[0m")
+    expect("hello".colorize.on_white.to_s).to eq("\e[107mhello\e[0m")
   end
 
   it "colorizes mode" do
-    "hello".colorize.bold.to_s.should eq("\e[1mhello\e[0m")
-    "hello".colorize.bright.to_s.should eq("\e[1mhello\e[0m")
-    "hello".colorize.dim.to_s.should eq("\e[2mhello\e[0m")
-    "hello".colorize.underline.to_s.should eq("\e[4mhello\e[0m")
-    "hello".colorize.blink.to_s.should eq("\e[5mhello\e[0m")
-    "hello".colorize.reverse.to_s.should eq("\e[7mhello\e[0m")
-    "hello".colorize.hidden.to_s.should eq("\e[8mhello\e[0m")
+    expect("hello".colorize.bold.to_s).to eq("\e[1mhello\e[0m")
+    expect("hello".colorize.bright.to_s).to eq("\e[1mhello\e[0m")
+    expect("hello".colorize.dim.to_s).to eq("\e[2mhello\e[0m")
+    expect("hello".colorize.underline.to_s).to eq("\e[4mhello\e[0m")
+    expect("hello".colorize.blink.to_s).to eq("\e[5mhello\e[0m")
+    expect("hello".colorize.reverse.to_s).to eq("\e[7mhello\e[0m")
+    expect("hello".colorize.hidden.to_s).to eq("\e[8mhello\e[0m")
   end
 
   it "colorizes mode combination" do
-    "hello".colorize.bold.dim.underline.blink.reverse.hidden.to_s.should eq("\e[1;2;4;5;7;8mhello\e[0m")
+    expect("hello".colorize.bold.dim.underline.blink.reverse.hidden.to_s).to eq("\e[1;2;4;5;7;8mhello\e[0m")
   end
 
   it "colorizes foreground with background" do
-    "hello".colorize.blue.on_green.to_s.should eq("\e[34;42mhello\e[0m")
+    expect("hello".colorize.blue.on_green.to_s).to eq("\e[34;42mhello\e[0m")
   end
 
   it "colorizes foreground with background with mode" do
-    "hello".colorize.blue.on_green.bold.to_s.should eq("\e[34;42;1mhello\e[0m")
+    expect("hello".colorize.blue.on_green.bold.to_s).to eq("\e[34;42;1mhello\e[0m")
   end
 
   it "colorizes foreground with symbol" do
-    "hello".colorize(:red).to_s.should eq("\e[31mhello\e[0m")
-    "hello".colorize.fore(:red).to_s.should eq("\e[31mhello\e[0m")
+    expect("hello".colorize(:red).to_s).to eq("\e[31mhello\e[0m")
+    expect("hello".colorize.fore(:red).to_s).to eq("\e[31mhello\e[0m")
   end
 
   it "colorizes mode with symbol" do
-    "hello".colorize.mode(:bold).to_s.should eq("\e[1mhello\e[0m")
+    expect("hello".colorize.mode(:bold).to_s).to eq("\e[1mhello\e[0m")
   end
 
   it "raises on unknown foreground color" do
@@ -94,7 +94,7 @@ describe "colorize" do
   end
 
   it "inspects" do
-    "hello".colorize(:red).inspect.should eq("\e[31m\"hello\"\e[0m")
+    expect("hello".colorize(:red).inspect).to eq("\e[31m\"hello\"\e[0m")
   end
 
   it "colorizes io with method" do
@@ -102,7 +102,7 @@ describe "colorize" do
     with_color.red.surround(io) do
       io << "hello"
     end
-    io.to_s.should eq("\e[31mhello\e[0m")
+    expect(io.to_s).to eq("\e[31mhello\e[0m")
   end
 
   it "colorizes io with symbol" do
@@ -110,7 +110,7 @@ describe "colorize" do
     with_color(:red).surround(io) do
       io << "hello"
     end
-    io.to_s.should eq("\e[31mhello\e[0m")
+    expect(io.to_s).to eq("\e[31mhello\e[0m")
   end
 
   it "colorizes with push and pop" do
@@ -122,7 +122,7 @@ describe "colorize" do
       end
       io << "bye"
     end
-    io.to_s.should eq("\e[31mhello\e[0;32mworld\e[0;31mbye\e[0m")
+    expect(io.to_s).to eq("\e[31mhello\e[0;32mworld\e[0;31mbye\e[0m")
   end
 
   it "colorizes with push and pop resets" do
@@ -134,15 +134,15 @@ describe "colorize" do
       end
       io << "bye"
     end
-    io.to_s.should eq("\e[31mhello\e[0;32;1mworld\e[0;31mbye\e[0m")
+    expect(io.to_s).to eq("\e[31mhello\e[0;32;1mworld\e[0;31mbye\e[0m")
   end
 
   it "toggles off" do
-    "hello".colorize.black.toggle(false).to_s.should eq("hello")
-    "hello".colorize.toggle(false).black.to_s.should eq("hello")
+    expect("hello".colorize.black.toggle(false).to_s).to eq("hello")
+    expect("hello".colorize.toggle(false).black.to_s).to eq("hello")
   end
 
   it "toggles off and on" do
-    "hello".colorize.toggle(false).black.toggle(true).to_s.should eq("\e[30mhello\e[0m")
+    expect("hello".colorize.toggle(false).black.toggle(true).to_s).to eq("\e[30mhello\e[0m")
   end
 end

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -6,8 +6,8 @@ describe "Complex" do
     a = 4.5 + 6.7.i
     b = Complex.new(4.5, 6.7)
     c = Complex.new(4.5, 9.6)
-    a.should eq(b)
-    a.should_not eq(c)
+    expect(a).to eq(b)
+    expect(a).to_not eq(c)
   end
 
   describe "==" do
@@ -15,147 +15,147 @@ describe "Complex" do
       a = Complex.new(1.5, 2)
       b = Complex.new(1.5, 2)
       c = Complex.new(2.25, 3)
-      (a == b).should be_true
-      (a == c).should be_false
+      expect((a == b)).to be_true
+      expect((a == c)).to be_false
     end
 
     it "complex == number" do
       a = Complex.new(5.3, 0)
       b = 5.3
       c = 4.2
-      (a == b).should be_true
-      (a == c).should be_false
+      expect((a == b)).to be_true
+      expect((a == c)).to be_false
     end
 
     it "number == complex" do
       a = -1.75
       b = Complex.new(-1.75, 0)
       c = Complex.new(7.2, 0)
-      (a == b).should be_true
-      (a == c).should be_false
+      expect((a == b)).to be_true
+      expect((a == c)).to be_false
     end
   end
 
   it "to_s" do
-    Complex.new(1.25, 8.2).to_s.should eq("1.25 + 8.2i")
-    Complex.new(1.25, -8.2).to_s.should eq("1.25 - 8.2i")
+    expect(Complex.new(1.25, 8.2).to_s).to eq("1.25 + 8.2i")
+    expect(Complex.new(1.25, -8.2).to_s).to eq("1.25 - 8.2i")
   end
 
   it "abs" do
-    Complex.new(5.1, 9.7).abs.should eq(10.959014554237985)
+    expect(Complex.new(5.1, 9.7).abs).to eq(10.959014554237985)
   end
 
   it "abs2" do
-    Complex.new(-1.1, 9).abs2.should eq(82.21)
+    expect(Complex.new(-1.1, 9).abs2).to eq(82.21)
   end
 
   it "sign" do
-    Complex.new(-1.4, 7.7).sign.should eq(Complex.new(-0.17888543819998315, 0.9838699100999074))
+    expect(Complex.new(-1.4, 7.7).sign).to eq(Complex.new(-0.17888543819998315, 0.9838699100999074))
   end
 
   it "phase" do
-    Complex.new(11.5, -6.25).phase.should eq(-0.4978223326170012)
+    expect(Complex.new(11.5, -6.25).phase).to eq(-0.4978223326170012)
   end
 
   it "polar" do
-    Complex.new(7.25, -13.1).polar.should eq({14.972391258579906, -1.0653196179316864})
+    expect(Complex.new(7.25, -13.1).polar).to eq({14.972391258579906, -1.0653196179316864})
   end
 
   it "cis" do
-    2.4.cis.should eq(Complex.new(-0.7373937155412454, 0.675463180551151))
+    expect(2.4.cis).to eq(Complex.new(-0.7373937155412454, 0.675463180551151))
   end
 
   it "conj" do
-    Complex.new(10.1, 3.7).conj.should eq(Complex.new(10.1, -3.7))
+    expect(Complex.new(10.1, 3.7).conj).to eq(Complex.new(10.1, -3.7))
   end
 
   it "inv" do
-    Complex.new(1.5, -2.5).inv.should eq(Complex.new(0.17647058823529413, 0.29411764705882354))
+    expect(Complex.new(1.5, -2.5).inv).to eq(Complex.new(0.17647058823529413, 0.29411764705882354))
   end
 
   it "sqrt" do
-    Complex.new(1.32, 7.25).sqrt.should  be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
-    Complex.new(7.11, -0.9).sqrt.should  be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
-    Complex.new(-2.2, 6.22).sqrt.should  be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
-    Complex.new(-8.3, -1.11).sqrt.should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
+    expect(Complex.new(1.32, 7.25).sqrt).to  be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
+    expect(Complex.new(7.11, -0.9).sqrt).to  be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
+    expect(Complex.new(-2.2, 6.22).sqrt).to  be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
+    expect(Complex.new(-8.3, -1.11).sqrt).to be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
   end
 
   it "exp" do
-    Complex.new(1.15, -5.1).exp.should eq(Complex.new(1.1937266270566773, 2.923901365414129))
+    expect(Complex.new(1.15, -5.1).exp).to eq(Complex.new(1.1937266270566773, 2.923901365414129))
   end
 
   describe "logarithms" do
     it "log" do
-      Complex.new(1.25, -4.7).log.should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
+      expect(Complex.new(1.25, -4.7).log).to eq(Complex.new(1.5817344087982312, -1.3108561866063686))
     end
 
     it "log2" do
-      Complex.new(-9.1, 3.2).log2.should eq(Complex.new(3.2699671225858946, +4.044523592551345))
+      expect(Complex.new(-9.1, 3.2).log2).to eq(Complex.new(3.2699671225858946, +4.044523592551345))
     end
 
     it "log10" do
-      Complex.new(2.11, 1.21).log10.should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
+      expect(Complex.new(2.11, 1.21).log10).to eq(Complex.new(0.38602142355392594, +0.22612668967405536))
     end
   end
 
   describe "+" do
     it "complex + complex" do
-      (Complex.new(2.2, 7)+Complex.new(10.1, 1.34)).should eq(Complex.new(12.3, 8.34))
+      expect((Complex.new(2.2, 7)+Complex.new(10.1, 1.34))).to eq(Complex.new(12.3, 8.34))
     end
 
     it "complex + number" do
-      (Complex.new(0.3, 5.5)+15).should eq(Complex.new(15.3, 5.5))
+      expect((Complex.new(0.3, 5.5)+15)).to eq(Complex.new(15.3, 5.5))
     end
 
     it "number + complex" do
-      (-1.7+Complex.new(7, 4.1)).should eq(Complex.new(5.3, 4.1))
+      expect((-1.7+Complex.new(7, 4.1))).to eq(Complex.new(5.3, 4.1))
     end
   end
 
   describe "-" do
     it "- complex" do
-      (-Complex.new(5.43, 27.12)).should eq(Complex.new(-5.43, -27.12))
+      expect((-Complex.new(5.43, 27.12))).to eq(Complex.new(-5.43, -27.12))
     end
 
     it "complex - complex" do
-      (Complex.new(21.7, 2.0)-Complex.new(0.15, 3.4)).should eq(Complex.new(21.55, -1.4))
+      expect((Complex.new(21.7, 2.0)-Complex.new(0.15, 3.4))).to eq(Complex.new(21.55, -1.4))
     end
 
     it "complex - number" do
-      (Complex.new(8.1, 6.15)-15).should eq(Complex.new(-6.9, 6.15))
+      expect((Complex.new(8.1, 6.15)-15)).to eq(Complex.new(-6.9, 6.15))
     end
 
     it "number - complex" do
-      (-3.27-Complex.new(7, 5.1)).should eq(Complex.new(-10.27, -5.1))
+      expect((-3.27-Complex.new(7, 5.1))).to eq(Complex.new(-10.27, -5.1))
     end
   end
 
   describe "*" do
     it "complex * complex" do
-      (Complex.new(12.2, 9.8)*Complex.new(4.78, 2.86)).should eq(Complex.new(30.288, 81.736))
+      expect((Complex.new(12.2, 9.8)*Complex.new(4.78, 2.86))).to eq(Complex.new(30.288, 81.736))
     end
 
     it "complex * number" do
-      (Complex.new(11.3, 15.25)*1.2).should eq(Complex.new(13.56, 18.3))
+      expect((Complex.new(11.3, 15.25)*1.2)).to eq(Complex.new(13.56, 18.3))
     end
 
     it "number * complex" do
-      (-1.7*Complex.new(9.7, 3.22)).should eq(Complex.new(-16.49, -5.474))
+      expect((-1.7*Complex.new(9.7, 3.22))).to eq(Complex.new(-16.49, -5.474))
     end
   end
 
   describe "/" do
     it "complex / complex" do
-      ((Complex.new(4, 6.2))/(Complex.new(0.5, 2.7))).should eq(Complex.new(2.485411140583554, -1.0212201591511936))
-      ((Complex.new(4.1, 6.0))/(Complex.new(10, 2.2))).should eq(Complex.new(0.5169782525753529, 0.48626478443342236))
+      expect(((Complex.new(4, 6.2))/(Complex.new(0.5, 2.7)))).to eq(Complex.new(2.485411140583554, -1.0212201591511936))
+      expect(((Complex.new(4.1, 6.0))/(Complex.new(10, 2.2)))).to eq(Complex.new(0.5169782525753529, 0.48626478443342236))
     end
 
     it "complex / number" do
-      ((Complex.new(21.3, 5.8))/1.9).should eq(Complex.new(11.210526315789474, 3.0526315789473686))
+      expect(((Complex.new(21.3, 5.8))/1.9)).to eq(Complex.new(11.210526315789474, 3.0526315789473686))
     end
 
     it "number / complex" do
-      (-5.7*(Complex.new(2.27, 8.92))).should eq(Complex.new(-12.939, -50.844))
+      expect((-5.7*(Complex.new(2.27, 8.92)))).to eq(Complex.new(-12.939, -50.844))
     end
   end
 end

--- a/spec/std/concucrrent_spec.cr
+++ b/spec/std/concucrrent_spec.cr
@@ -3,8 +3,8 @@ require "spec"
 describe "concurrent" do
   it "does three things concurrently" do
     a, b, c = parallel(1 + 2, "hello".length, [1, 2, 3, 4].length)
-    a.should eq(3)
-    b.should eq(5)
-    c.should eq(4)
+    expect(a).to eq(3)
+    expect(b).to eq(5)
+    expect(c).to eq(4)
   end
 end

--- a/spec/std/crypto/blowfish_spec.cr
+++ b/spec/std/crypto/blowfish_spec.cr
@@ -7,12 +7,12 @@ describe "Blowfish" do
     orig_l, orig_r = 0xfedcba98, 0x76543210
 
     l, r = bf.encrypt_pair(orig_l, orig_r)
-    l.should eq(0xcc91732b)
-    r.should eq(0x8022f684)
+    expect(l).to eq(0xcc91732b)
+    expect(r).to eq(0x8022f684)
 
     l, r = bf.decrypt_pair(l, r)
-    l.should eq(orig_l)
-    r.should eq(orig_r)
+    expect(l).to eq(orig_l)
+    expect(r).to eq(orig_r)
   end
 
   it "raises if the key is empty" do
@@ -36,7 +36,7 @@ describe "Blowfish" do
     bf.salted_expand_key("a" * length, salt)
 
     l, r = bf.encrypt_pair(orig_l, orig_r)
-    l.should eq(0xc8f07bef)
-    r.should eq(0x57deba64)
+    expect(l).to eq(0xc8f07bef)
+    expect(r).to eq(0x57deba64)
   end
 end

--- a/spec/std/crypto/md5_spec.cr
+++ b/spec/std/crypto/md5_spec.cr
@@ -3,6 +3,6 @@ require "crypto/md5"
 
 describe "MD5" do
   it "calculates hash from string" do
-    Crypto::MD5.hex_digest("foo").should eq("acbd18db4cc2f85cedef654fccc4a4d8")
+    expect(Crypto::MD5.hex_digest("foo")).to eq("acbd18db4cc2f85cedef654fccc4a4d8")
   end
 end

--- a/spec/std/crystal/github_dependency_spec.cr
+++ b/spec/std/crystal/github_dependency_spec.cr
@@ -7,13 +7,13 @@ module Crystal
       it "uses the repository's name as the dependency name" do
         dependency = GitHubDependency.new("owner/repo")
 
-        dependency.name.should eq("repo")
+        expect(dependency.name).to eq("repo")
       end
 
       it "customizes GitHub dependency name" do
         dependency = GitHubDependency.new("owner/repo", "name")
 
-        dependency.name.should eq("name")
+        expect(dependency.name).to eq("name")
       end
 
       it "raises error with invalid GitHub project definition" do
@@ -26,19 +26,19 @@ module Crystal
         it "guesses name from project name like #{repo_name}" do
           dependency = GitHubDependency.new("owner/#{repo_name}")
 
-          dependency.name.should eq("repo")
+          expect(dependency.name).to eq("repo")
         end
 
         it "doesn't guess name from project name when specifying name" do
           dependency = GitHubDependency.new("owner/#{repo_name}", "name")
 
-          dependency.name.should eq("name")
+          expect(dependency.name).to eq("name")
         end
       end
 
       it "gets the target_dir" do
         dependency = GitHubDependency.new("owner/repo")
-        dependency.target_dir.should eq(".deps/owner-repo")
+        expect(dependency.target_dir).to eq(".deps/owner-repo")
       end
     end
   end

--- a/spec/std/crystal/path_dependency_spec.cr
+++ b/spec/std/crystal/path_dependency_spec.cr
@@ -7,26 +7,26 @@ module Crystal
       it "uses the directory's name as the dependency name" do
         dependency = PathDependency.new("../path")
 
-        dependency.name.should eq("path")
+        expect(dependency.name).to eq("path")
       end
 
       it "customizes path dependency name" do
         dependency = PathDependency.new("../path", "name")
 
-        dependency.name.should eq("name")
+        expect(dependency.name).to eq("name")
       end
 
       %w(crystal_repo crystal-repo repo.cr repo_crystal repo-crystal).each do |repo_name|
         it "guesses name from project name like #{repo_name}" do
           dependency = PathDependency.new("owner/#{repo_name}")
 
-          dependency.name.should eq("repo")
+          expect(dependency.name).to eq("repo")
         end
 
         it "doesn't guess name from project name when specifying name" do
           dependency = PathDependency.new("owner/#{repo_name}", "name")
 
-          dependency.name.should eq("name")
+          expect(dependency.name).to eq("name")
         end
       end
     end

--- a/spec/std/crystal/project_spec.cr
+++ b/spec/std/crystal/project_spec.cr
@@ -11,8 +11,8 @@ module Crystal
             github "owner/repo"
           end
         end
-        project.dependencies.length.should eq(1)
-        project.dependencies[0].should be_a(GitHubDependency)
+        expect(project.dependencies.length).to eq(1)
+        expect(project.dependencies[0]).to be_a(GitHubDependency)
       end
 
       it "adds local dependencies" do
@@ -23,8 +23,8 @@ module Crystal
           end
         end
 
-        project.dependencies.length.should eq(1)
-        project.dependencies[0].should be_a(PathDependency)
+        expect(project.dependencies.length).to eq(1)
+        expect(project.dependencies[0]).to be_a(PathDependency)
       end
     end
   end

--- a/spec/std/csv/csv_build_spec.cr
+++ b/spec/std/csv/csv_build_spec.cr
@@ -14,7 +14,7 @@ describe CSV do
           row << "four"
         end
       end
-      string.should eq("one,two\nthree,four\n")
+      expect(string).to eq("one,two\nthree,four\n")
     end
 
     it "builds with numbers" do
@@ -28,7 +28,7 @@ describe CSV do
           row << 4
         end
       end
-      string.should eq("1,2\n3,4\n")
+      expect(string).to eq("1,2\n3,4\n")
     end
 
     it "builds with commas" do
@@ -37,7 +37,7 @@ describe CSV do
           row << %(hello,world)
         end
       end
-      string.should eq(%("hello,world"\n))
+      expect(string).to eq(%("hello,world"\n))
     end
 
     it "builds with quotes" do
@@ -46,21 +46,21 @@ describe CSV do
           row << %(he said "no")
         end
       end
-      string.should eq(%("he said ""no"""\n))
+      expect(string).to eq(%("he said ""no"""\n))
     end
 
     it "builds row from enumerable" do
       string = CSV.build do |csv|
         csv.row [1, 2, 3]
       end
-      string.should eq("1,2,3\n")
+      expect(string).to eq("1,2,3\n")
     end
 
     it "builds row from splat" do
       string = CSV.build do |csv|
         csv.row 1, 2, 3
       end
-      string.should eq("1,2,3\n")
+      expect(string).to eq("1,2,3\n")
     end
 
     it "skips inside row" do
@@ -71,7 +71,7 @@ describe CSV do
           row << 2
         end
       end
-      string.should eq("1,,2\n")
+      expect(string).to eq("1,,2\n")
     end
 
     it "concats enumerable to row" do
@@ -82,7 +82,7 @@ describe CSV do
           row << 5
         end
       end
-      string.should eq("1,2,3,4,5\n")
+      expect(string).to eq("1,2,3,4,5\n")
     end
 
     it "concats splat to row" do
@@ -93,7 +93,7 @@ describe CSV do
           row << 5
         end
       end
-      string.should eq("1,2,3,4,5\n")
+      expect(string).to eq("1,2,3,4,5\n")
     end
   end
 end

--- a/spec/std/csv/csv_lex_spec.cr
+++ b/spec/std/csv/csv_lex_spec.cr
@@ -4,16 +4,16 @@ require "csv"
 class CSV::Lexer
   def expect_cell(value, file = __FILE__, line = __LINE__)
     token = next_token
-    token.kind.should eq(:cell), file, line
-    token.value.should eq(value), file, line
+    expect(token.kind).to eq(:cell), file, line
+    expect(token.value).to eq(value), file, line
   end
 
   def expect_eof(file = __FILE__, line = __LINE__)
-    next_token.kind.should eq(:eof), file, line
+    expect(next_token.kind).to eq(:eof), file, line
   end
 
   def expect_newline(file = __FILE__, line = __LINE__)
-    next_token.kind.should eq(:newline), file, line
+    expect(next_token.kind).to eq(:newline), file, line
   end
 end
 

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -4,49 +4,49 @@ require "csv"
 describe CSV do
   describe "parse" do
     it "parses empty string" do
-      CSV.parse("").should eq([] of String)
+      expect(CSV.parse("")).to eq([] of String)
     end
 
     it "parses one simple row" do
-      CSV.parse("hello,world").should eq([["hello", "world"]])
+      expect(CSV.parse("hello,world")).to eq([["hello", "world"]])
     end
 
     it "parses one row with spaces" do
-      CSV.parse("   hello   ,   world  ").should eq([["   hello   ", "   world  "]])
+      expect(CSV.parse("   hello   ,   world  ")).to eq([["   hello   ", "   world  "]])
     end
 
     it "parses two rows" do
-      CSV.parse("hello,world\ngood,bye").should eq([
+      expect(CSV.parse("hello,world\ngood,bye")).to eq([
         ["hello", "world"],
         ["good", "bye"],
         ])
     end
 
     it "parses two rows with the last one having a newline" do
-      CSV.parse("hello,world\ngood,bye\n").should eq([
+      expect(CSV.parse("hello,world\ngood,bye\n")).to eq([
         ["hello", "world"],
         ["good", "bye"],
         ])
     end
 
     it "parses with quote" do
-      CSV.parse(%("hello","world")).should eq([["hello", "world"]])
+      expect(CSV.parse(%("hello","world"))).to eq([["hello", "world"]])
     end
 
     it "parses with quote and newline" do
-      CSV.parse(%("hello","world"\nfoo)).should eq([["hello", "world"], ["foo"]])
+      expect(CSV.parse(%("hello","world"\nfoo))).to eq([["hello", "world"], ["foo"]])
     end
 
     it "parses with double quote" do
-      CSV.parse(%("hel""lo","wor""ld")).should eq([[%(hel"lo), %(wor"ld)]])
+      expect(CSV.parse(%("hel""lo","wor""ld"))).to eq([[%(hel"lo), %(wor"ld)]])
     end
 
     it "parses some commas" do
-      CSV.parse(%(,,)).should eq([["", "", ""]])
+      expect(CSV.parse(%(,,))).to eq([["", "", ""]])
     end
 
     it "parses empty quoted string" do
-      CSV.parse(%("","")).should eq([["", ""]])
+      expect(CSV.parse(%("",""))).to eq([["", ""]])
     end
 
     it "raises if single quote in the middle" do
@@ -68,14 +68,14 @@ describe CSV do
     end
 
     it "parses from IO" do
-      CSV.parse(StringIO.new(%("hel""lo",world))).should eq([[%(hel"lo), %(world)]])
+      expect(CSV.parse(StringIO.new(%("hel""lo",world)))).to eq([[%(hel"lo), %(world)]])
     end
   end
 
   it "parses row by row" do
     parser = CSV::Parser.new("hello,world\ngood,bye\n")
-    parser.next_row.should eq(%w(hello world))
-    parser.next_row.should eq(%w(good bye))
-    parser.next_row.should be_nil
+    expect(parser.next_row).to eq(%w(hello world))
+    expect(parser.next_row).to eq(%w(good bye))
+    expect(parser.next_row).to be_nil
   end
 end

--- a/spec/std/db/sql/select_spec.cr
+++ b/spec/std/db/sql/select_spec.cr
@@ -6,12 +6,12 @@ describe "DB::Sql::Select" do
   it "does to_s for simple query" do
     users = DB::Sql::Table.new(:users)
     query = DB::Sql::Select.from(users).project(users[:name])
-    query.to_sql(DB::Sql::MysqlDialect).should eq("SELECT `name` FROM `users`")
+    expect(query.to_sql(DB::Sql::MysqlDialect)).to eq("SELECT `name` FROM `users`")
   end
 
   it "does to_s with where" do
     users = DB::Sql::Table.new(:users)
     query = DB::Sql::Select.from(users).project(users[:name]).where(users[:name].eq("John"))
-    query.to_sql(DB::Sql::MysqlDialect).should eq("SELECT `name` FROM `users` WHERE `name` = 'John'")
+    expect(query.to_sql(DB::Sql::MysqlDialect)).to eq("SELECT `name` FROM `users` WHERE `name` = 'John'")
   end
 end

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -2,23 +2,23 @@ require "spec"
 
 describe "Dir" do
   it "tests exists? on existing directory" do
-    Dir.exists?(File.join([__DIR__, "../"])).should be_true
+    expect(Dir.exists?(File.join([__DIR__, "../"]))).to be_true
   end
 
   it "tests exists? on existing file" do
-    Dir.exists?(__FILE__).should be_false
+    expect(Dir.exists?(__FILE__)).to be_false
   end
 
   it "tests exists? on nonexistent directory" do
-    Dir.exists?(File.join([__DIR__, "/foo/bar/"])).should be_false
+    expect(Dir.exists?(File.join([__DIR__, "/foo/bar/"]))).to be_false
   end
 
   it "tests mkdir and rmdir with a new path" do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
-    Dir.mkdir(path, 0700).should eq(0)
-    Dir.exists?(path).should be_true
-    Dir.rmdir(path).should eq(0)
-    Dir.exists?(path).should be_false
+    expect(Dir.mkdir(path, 0700)).to eq(0)
+    expect(Dir.exists?(path)).to be_true
+    expect(Dir.rmdir(path)).to eq(0)
+    expect(Dir.exists?(path)).to be_false
   end
 
   it "tests mkdir with an existing path" do
@@ -29,15 +29,15 @@ describe "Dir" do
 
   it "tests mkdir_p with a new path" do
     path = "/tmp/crystal_mkdir_ptest_#{Process.pid}/"
-    Dir.mkdir_p(path).should eq(0)
-    Dir.exists?(path).should be_true
+    expect(Dir.mkdir_p(path)).to eq(0)
+    expect(Dir.exists?(path)).to be_true
     path = File.join({path, "a", "b", "c"})
-    Dir.mkdir_p(path).should eq(0)
-    Dir.exists?(path).should be_true
+    expect(Dir.mkdir_p(path)).to eq(0)
+    expect(Dir.exists?(path)).to be_true
   end
 
   it "tests mkdir_p with an existing path" do
-    Dir.mkdir_p(__DIR__).should eq(0)
+    expect(Dir.mkdir_p(__DIR__)).to eq(0)
     expect_raises Errno do
       Dir.mkdir_p(__FILE__)
     end
@@ -60,7 +60,7 @@ describe "Dir" do
     Dir.foreach(__DIR__) do |file|
       next unless file.ends_with?(".cr")
 
-      result.includes?(File.join(__DIR__, file)).should be_true
+      expect(result.includes?(File.join(__DIR__, file))).to be_true
     end
   end
 
@@ -70,7 +70,7 @@ describe "Dir" do
     {__DIR__, "#{__DIR__}/io", "#{__DIR__}/html"}.each do |dir|
       Dir.foreach(dir) do |file|
         next unless file.ends_with?(".cr")
-        result.includes?(File.join(dir, file)).should be_true
+        expect(result.includes?(File.join(dir, file))).to be_true
       end
     end
   end
@@ -84,7 +84,7 @@ describe "Dir" do
     Dir.foreach(__DIR__) do |file|
       next unless file.ends_with?(".cr")
 
-      result.includes?(File.join(__DIR__, file)).should be_true
+      expect(result.includes?(File.join(__DIR__, file))).to be_true
     end
   end
 
@@ -92,9 +92,9 @@ describe "Dir" do
     it "should work" do
       cwd = Dir.working_directory
       Dir.chdir("..")
-      Dir.working_directory.should_not eq(cwd)
+      expect(Dir.working_directory).to_not eq(cwd)
       Dir.cd(cwd)
-      Dir.working_directory.should eq(cwd)
+      expect(Dir.working_directory).to eq(cwd)
     end
 
     it "raises" do
@@ -107,10 +107,10 @@ describe "Dir" do
       cwd = Dir.working_directory
 
       Dir.chdir("..") do
-        Dir.working_directory.should_not eq(cwd)
+        expect(Dir.working_directory).to_not eq(cwd)
       end
 
-      Dir.working_directory.should eq(cwd)
+      expect(Dir.working_directory).to eq(cwd)
     end
   end
 
@@ -123,7 +123,7 @@ describe "Dir" do
     end
     dir.close
 
-    filenames.includes?("dir_spec.cr").should be_true
+    expect(filenames.includes?("dir_spec.cr")).to be_true
   end
 
   it "opens with open" do
@@ -135,15 +135,15 @@ describe "Dir" do
       end
     end
 
-    filenames.includes?("dir_spec.cr").should be_true
+    expect(filenames.includes?("dir_spec.cr")).to be_true
   end
 
   it "lists entries" do
     filenames = Dir.entries(__DIR__)
-    filenames.includes?("dir_spec.cr").should be_true
+    expect(filenames.includes?("dir_spec.cr")).to be_true
   end
 
   it "does to_s" do
-    Dir.new(__DIR__).to_s.should eq("#<Dir:#{__DIR__}>")
+    expect(Dir.new(__DIR__).to_s).to eq("#<Dir:#{__DIR__}>")
   end
 end

--- a/spec/std/double_spec.cr
+++ b/spec/std/double_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 describe "Double" do
   describe "**" do
-    assert { (2.5 ** 2).should eq(6.25) }
-    assert { (2.5 ** 2.5_f32).should eq(9.882117688026186) }
-    assert { (2.5 ** 2.5).should eq(9.882117688026186) }
+    assert { expect((2.5 ** 2)).to eq(6.25) }
+    assert { expect((2.5 ** 2.5_f32)).to eq(9.882117688026186) }
+    assert { expect((2.5 ** 2.5)).to eq(9.882117688026186) }
   end
 end

--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -6,81 +6,81 @@ describe "ECR::Lexer" do
     lexer = ECR::Lexer.new("hello")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq("hello")
-    token.line_number.should eq(1)
-    token.column_number.should eq(1)
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("hello")
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "lexes with <% %>" do
     lexer = ECR::Lexer.new("hello <% foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq("hello ")
-    token.column_number.should eq(1)
-    token.line_number.should eq(1)
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("hello ")
+    expect(token.column_number).to eq(1)
+    expect(token.line_number).to eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
-    token.value.should eq(" foo ")
-    token.line_number.should eq(1)
-    token.column_number.should eq(9)
+    expect(token.type).to eq(:CONTROL)
+    expect(token.value).to eq(" foo ")
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(9)
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq(" bar")
-    token.line_number.should eq(1)
-    token.column_number.should eq(16)
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq(" bar")
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(16)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "lexes with <%= %>" do
     lexer = ECR::Lexer.new("hello <%= foo %> bar")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq("hello ")
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("hello ")
 
     token = lexer.next_token
-    token.type.should eq(:OUTPUT)
-    token.value.should eq(" foo ")
+    expect(token.type).to eq(:OUTPUT)
+    expect(token.value).to eq(" foo ")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq(" bar")
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq(" bar")
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 
   it "lexes with <% %> and correct location info" do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq("hi\nthere ")
-    token.line_number.should eq(1)
-    token.column_number.should eq(1)
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq("hi\nthere ")
+    expect(token.line_number).to eq(1)
+    expect(token.column_number).to eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:CONTROL)
-    token.value.should eq(" foo\nbar ")
-    token.line_number.should eq(2)
-    token.column_number.should eq(9)
+    expect(token.type).to eq(:CONTROL)
+    expect(token.value).to eq(" foo\nbar ")
+    expect(token.line_number).to eq(2)
+    expect(token.column_number).to eq(9)
 
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.value.should eq(" baz")
-    token.line_number.should eq(3)
-    token.column_number.should eq(7)
+    expect(token.type).to eq(:STRING)
+    expect(token.value).to eq(" baz")
+    expect(token.line_number).to eq(3)
+    expect(token.column_number).to eq(7)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    expect(token.type).to eq(:EOF)
   end
 end

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -21,11 +21,11 @@ describe "ECR" do
         %(__str__ << " 2 "),
       %(#<loc:"foo.cr",2,25> end ),
     ]
-    program.should eq(pieces.join("\n") + "\n")
+    expect(program).to eq(pieces.join("\n") + "\n")
   end
 
   it "does ecr_file" do
     view = ECRSpecHelloView.new("world!")
-    view.to_s.strip.should eq("Hello world! 012")
+    expect(view.to_s.strip).to eq("Hello world! 012")
   end
 end

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -16,66 +16,66 @@ end
 describe Enum do
   describe "to_s" do
     it "for simple enum" do
-      SpecEnum::One.to_s.should eq("One")
-      SpecEnum::Two.to_s.should eq("Two")
-      SpecEnum::Three.to_s.should eq("Three")
+      expect(SpecEnum::One.to_s).to eq("One")
+      expect(SpecEnum::Two.to_s).to eq("Two")
+      expect(SpecEnum::Three.to_s).to eq("Three")
     end
 
     it "for flags enum" do
-      SpecEnumFlags::None.to_s.should eq("None")
-      SpecEnumFlags::All.to_s.should eq("One, Two, Three")
-      (SpecEnumFlags::One | SpecEnumFlags::Two).to_s.should eq("One, Two")
+      expect(SpecEnumFlags::None.to_s).to eq("None")
+      expect(SpecEnumFlags::All.to_s).to eq("One, Two, Three")
+      expect((SpecEnumFlags::One | SpecEnumFlags::Two).to_s).to eq("One, Two")
     end
   end
 
   it "does +" do
-    (SpecEnum::One + 1).should eq(SpecEnum::Two)
+    expect((SpecEnum::One + 1)).to eq(SpecEnum::Two)
   end
 
   it "does -" do
-    (SpecEnum::Two - 1).should eq(SpecEnum::One)
+    expect((SpecEnum::Two - 1)).to eq(SpecEnum::One)
   end
 
   it "sorts" do
-    [SpecEnum::Three, SpecEnum::One, SpecEnum::Two].sort.should eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
+    expect([SpecEnum::Three, SpecEnum::One, SpecEnum::Two].sort).to eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
   end
 
   it "does includes?" do
-    (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::One).should be_true
-    (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::Three).should be_false
+    expect((SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::One)).to be_true
+    expect((SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::Three)).to be_false
   end
 
   describe "names" do
     it "for simple enum" do
-      SpecEnum.names.should eq(%w(One Two Three))
+      expect(SpecEnum.names).to eq(%w(One Two Three))
     end
 
     it "for flags enum" do
-      SpecEnumFlags.names.should eq(%w(One Two Three))
+      expect(SpecEnumFlags.names).to eq(%w(One Two Three))
     end
   end
 
   describe "values" do
     it "for simple enum" do
-      SpecEnum.values.should eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
+      expect(SpecEnum.values).to eq([SpecEnum::One, SpecEnum::Two, SpecEnum::Three])
     end
 
     it "for flags enum" do
-      SpecEnumFlags.values.should eq([SpecEnumFlags::One, SpecEnumFlags::Two, SpecEnumFlags::Three])
+      expect(SpecEnumFlags.values).to eq([SpecEnumFlags::One, SpecEnumFlags::Two, SpecEnumFlags::Three])
     end
   end
 
   it "has hash" do
-    SpecEnum::Two.hash.should eq(1.hash)
+    expect(SpecEnum::Two.hash).to eq(1.hash)
   end
 
   it "parses" do
-    SpecEnum.parse("Two").should eq(SpecEnum::Two)
+    expect(SpecEnum.parse("Two")).to eq(SpecEnum::Two)
     expect_raises(Exception, "Unknown enum SpecEnum value: Four") { SpecEnum.parse("Four") }
   end
 
   it "parses?" do
-    SpecEnum.parse?("Two").should eq(SpecEnum::Two)
-    SpecEnum.parse?("Four").should be_nil
+    expect(SpecEnum.parse?("Two")).to eq(SpecEnum::Two)
+    expect(SpecEnum.parse?("Four")).to be_nil
   end
 end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -3,21 +3,21 @@ require "spec"
 describe "Enumerable" do
   describe "find" do
     it "finds" do
-      [1, 2, 3].find { |x| x > 2 }.should eq(3)
+      expect([1, 2, 3].find { |x| x > 2 }).to eq(3)
     end
 
     it "doesn't find" do
-      [1, 2, 3].find { |x| x > 3 }.should be_nil
+      expect([1, 2, 3].find { |x| x > 3 }).to be_nil
     end
 
     it "doesn't find with default value" do
-      [1, 2, 3].find(-1) { |x| x > 3 }.should eq(-1)
+      expect([1, 2, 3].find(-1) { |x| x > 3 }).to eq(-1)
     end
   end
 
   describe "inject" do
-    assert { [1, 2, 3].inject { |memo, i| memo + i }.should eq(6) }
-    assert { [1, 2, 3].inject(10) { |memo, i| memo + i }.should eq(16) }
+    assert { expect([1, 2, 3].inject { |memo, i| memo + i }).to eq(6) }
+    assert { expect([1, 2, 3].inject(10) { |memo, i| memo + i }).to eq(16) }
 
     it "raises if empty" do
       expect_raises EmptyEnumerable do
@@ -27,7 +27,7 @@ describe "Enumerable" do
   end
 
   describe "min" do
-    assert { [1, 2, 3].min.should eq(1) }
+    assert { expect([1, 2, 3].min).to eq(1) }
 
     it "raises if empty" do
       expect_raises EmptyEnumerable do
@@ -37,7 +37,7 @@ describe "Enumerable" do
   end
 
   describe "max" do
-    assert { [1, 2, 3].max.should eq(3) }
+    assert { expect([1, 2, 3].max).to eq(3) }
 
     it "raises if empty" do
       expect_raises EmptyEnumerable do
@@ -47,7 +47,7 @@ describe "Enumerable" do
   end
 
   describe "minmax" do
-    assert { [1, 2, 3].minmax.should eq({1, 3}) }
+    assert { expect([1, 2, 3].minmax).to eq({1, 3}) }
 
     it "raises if empty" do
       expect_raises EmptyEnumerable do
@@ -57,75 +57,75 @@ describe "Enumerable" do
   end
 
   describe "min_by" do
-    assert { [1, 2, 3].min_by { |x| -x }.should eq(3) }
+    assert { expect([1, 2, 3].min_by { |x| -x }).to eq(3) }
   end
 
   describe "min_of" do
-    assert { [1, 2, 3].min_of { |x| -x }.should eq(-3) }
+    assert { expect([1, 2, 3].min_of { |x| -x }).to eq(-3) }
   end
 
   describe "max_by" do
-    assert { [-1, -2, -3].max_by { |x| -x }.should eq(-3) }
+    assert { expect([-1, -2, -3].max_by { |x| -x }).to eq(-3) }
   end
 
   describe "max_of" do
-    assert { [-1, -2, -3].max_of { |x| -x }.should eq(3) }
+    assert { expect([-1, -2, -3].max_of { |x| -x }).to eq(3) }
   end
 
   describe "minmax_by" do
-    assert { [-1, -2, -3].minmax_by { |x| -x }.should eq({-1, -3}) }
+    assert { expect([-1, -2, -3].minmax_by { |x| -x }).to eq({-1, -3}) }
   end
 
   describe "minmax_of" do
-    assert { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
+    assert { expect([-1, -2, -3].minmax_of { |x| -x }).to eq({1, 3}) }
   end
 
   describe "take" do
-    assert { [-1, -2, -3].take(1).should eq([-1]) }
-    assert { [-1, -2, -3].take(4).should eq([-1, -2, -3]) }
+    assert { expect([-1, -2, -3].take(1)).to eq([-1]) }
+    assert { expect([-1, -2, -3].take(4)).to eq([-1, -2, -3]) }
   end
 
   describe "first" do
-    assert { [-1, -2, -3].first.should eq(-1) }
-    assert { [-1, -2, -3].first(1).should eq([-1]) }
-    assert { [-1, -2, -3].first(4).should eq([-1, -2, -3]) }
+    assert { expect([-1, -2, -3].first).to eq(-1) }
+    assert { expect([-1, -2, -3].first(1)).to eq([-1]) }
+    assert { expect([-1, -2, -3].first(4)).to eq([-1, -2, -3]) }
   end
 
   describe "one?" do
-    assert { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
-    assert { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
-    assert { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
+    assert { expect([1, 2, 2, 3].one? { |x| x == 1 }).to eq(true) }
+    assert { expect([1, 2, 2, 3].one? { |x| x == 2 }).to eq(false) }
+    assert { expect([1, 2, 2, 3].one? { |x| x == 0 }).to eq(false) }
   end
 
   describe "none?" do
-    assert { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
-    assert { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
+    assert { expect([1, 2, 2, 3].none? { |x| x == 1 }).to eq(false) }
+    assert { expect([1, 2, 2, 3].none? { |x| x == 0 }).to eq(true) }
   end
 
   describe "group_by" do
-    assert { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
+    assert { expect([1, 2, 2, 3].group_by { |x| x == 2 }).to eq({true => [2, 2], false => [1, 3]}) }
   end
 
   describe "partition" do
-    assert { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
+    assert { expect([1, 2, 2, 3].partition { |x| x == 2 }).to eq({[2, 2], [1, 3]}) }
   end
 
   describe "sum" do
-    assert { ([] of Int32).sum.should eq(0) }
-    assert { [1, 2, 3].sum.should eq(6) }
-    assert { [1, 2, 3].sum(4).should eq(10) }
-    assert { [1, 2, 3].sum(4.5).should eq(10.5) }
-    assert { (1..3).sum { |x| x * 2 }.should eq(12) }
-    assert { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
+    assert { expect(([] of Int32).sum).to eq(0) }
+    assert { expect([1, 2, 3].sum).to eq(6) }
+    assert { expect([1, 2, 3].sum(4)).to eq(10) }
+    assert { expect([1, 2, 3].sum(4.5)).to eq(10.5) }
+    assert { expect((1..3).sum { |x| x * 2 }).to eq(12) }
+    assert { expect((1..3).sum(1.5) { |x| x * 2 }).to eq(13.5) }
   end
 
   describe "compact map" do
-    assert { Set { 1, nil, 2, nil, 3 }.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
+    assert { expect(Set { 1, nil, 2, nil, 3 }.compact_map { |x| x.try &.+(1) }).to eq([2, 3, 4]) }
   end
 
   describe "first" do
     it "gets first" do
-      (1..3).first.should eq(1)
+      expect((1..3).first).to eq(1)
     end
 
     it "raises if enumerable empty" do
@@ -137,28 +137,28 @@ describe "Enumerable" do
 
   describe "first?" do
     it "gets first?" do
-      (1..3).first?.should eq(1)
+      expect((1..3).first?).to eq(1)
     end
 
     it "returns nil if enumerable empty" do
-      (1...1).first?.should be_nil
+      expect((1...1).first?).to be_nil
     end
   end
 
   describe "to_h" do
     it "for tuples" do
       hash = Tuple.new({:a, 1}, {:c, 2}).to_h
-      hash.should be_a(Hash(Symbol, Int32))
-      hash.should eq({a: 1, c: 2})
+      expect(hash).to be_a(Hash(Symbol, Int32))
+      expect(hash).to eq({a: 1, c: 2})
     end
 
     it "for array" do
-      [[:a, :b], [:c, :d]].to_h.should eq({a: :b, c: :d})
+      expect([[:a, :b], [:c, :d]].to_h).to eq({a: :b, c: :d})
     end
   end
 
   it "indexes by" do
-    ["foo", "hello", "goodbye", "something"].index_by(&.length).should eq({
+    expect(["foo", "hello", "goodbye", "something"].index_by(&.length)).to eq({
         3 => "foo",
         5 => "hello",
         7 => "goodbye",
@@ -167,40 +167,40 @@ describe "Enumerable" do
   end
 
   it "selects" do
-    [1, 2, 3, 4].select(&.even?).should eq([2, 4])
+    expect([1, 2, 3, 4].select(&.even?)).to eq([2, 4])
   end
 
   it "rejects" do
-    [1, 2, 3, 4].reject(&.even?).should eq([1, 3])
+    expect([1, 2, 3, 4].reject(&.even?)).to eq([1, 3])
   end
 
   it "joins with separator and block" do
     str = [1, 2, 3].join(", ") { |x| x + 1 }
-    str.should eq("2, 3, 4")
+    expect(str).to eq("2, 3, 4")
   end
 
   it "joins without separator and block" do
     str = [1, 2, 3].join { |x| x + 1 }
-    str.should eq("234")
+    expect(str).to eq("234")
   end
 
   it "joins with io and block" do
     str = StringIO.new
     [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
-    str.to_s.should eq("2, 3, 4")
+    expect(str.to_s).to eq("2, 3, 4")
   end
 
   describe "each_slice" do
     it "returns partial slices" do
       array = [] of Array(Int32)
       [1, 2, 3].each_slice(2) { |slice| array << slice }
-      array.should eq([[1, 2], [3]])
+      expect(array).to eq([[1, 2], [3]])
     end
 
     it "returns full slices" do
       array = [] of Array(Int32)
       [1, 2, 3, 4].each_slice(2) { |slice| array << slice }
-      array.should eq([[1, 2], [3, 4]])
+      expect(array).to eq([[1, 2], [3, 4]])
     end
   end
 end

--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -8,25 +8,25 @@ describe "ENV" do
   end
 
   it "gets non existent key as nilable" do
-    ENV["NON-EXISTENT"]?.should be_nil
+    expect(ENV["NON-EXISTENT"]?).to be_nil
   end
 
   it "set and gets" do
     ENV["FOO"] = "1"
-    ENV["FOO"].should eq("1")
-    ENV["FOO"]?.should eq("1")
+    expect(ENV["FOO"]).to eq("1")
+    expect(ENV["FOO"]?).to eq("1")
   end
 
   it "does has_key?" do
     ENV["FOO"] = "1"
-    ENV.has_key?("BAR").should be_false
-    ENV.has_key?("FOO").should be_true
+    expect(ENV.has_key?("BAR")).to be_false
+    expect(ENV.has_key?("FOO")).to be_true
   end
 
   it "deletes a key" do
     ENV["FOO"] = "1"
-    ENV.delete("FOO").should eq("1")
-    ENV.delete("FOO").should be_nil
-    ENV.has_key?("FOO").should be_false
+    expect(ENV.delete("FOO")).to eq("1")
+    expect(ENV.delete("FOO")).to be_nil
+    expect(ENV.has_key?("FOO")).to be_false
   end
 end

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -14,13 +14,13 @@ describe "Exception" do
       ex.backtrace.each do |bt|
         puts bt
       end
-      ex.backtrace.any? {|x| x.includes? "ModuleWithLooooooooooooooooooooooooooooooooooooooooooooooongName" }.should be_true
+      expect(ex.backtrace.any? {|x| x.includes? "ModuleWithLooooooooooooooooooooooooooooooooooooooooooooooongName" }).to be_true
     end
   end
 
   it "unescapes linux backtrace" do
     frame = "_2A_Crystal_3A__3A_Compiler_23_compile_3C_Crystal_3A__3A_Compiler_3E__3A_Nil"
     fixed = "\u{2A}Crystal\u{3A}\u{3A}Compiler\u{23}compile\u{3C}Crystal\u{3A}\u{3A}Compiler\u{3E}\u{3A}Nil"
-    Exception.unescape_linux_backtrace_frame(frame).should eq(fixed)
+    expect(Exception.unescape_linux_backtrace_frame(frame)).to eq(fixed)
   end
 end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -21,127 +21,127 @@ describe "File" do
   it "gets path" do
     path = "#{__DIR__}/data/test_file.txt"
     file = File.new path
-    file.path.should eq(path)
+    expect(file.path).to eq(path)
   end
 
   it "reads entire file" do
     str = File.read "#{__DIR__}/data/test_file.txt"
-    str.should eq("Hello World\n" * 20)
+    expect(str).to eq("Hello World\n" * 20)
   end
 
   it "reads lines from file" do
     lines = File.read_lines "#{__DIR__}/data/test_file.txt"
-    lines.length.should eq(20)
-    lines.first.should eq("Hello World\n")
+    expect(lines.length).to eq(20)
+    expect(lines.first).to eq("Hello World\n")
   end
 
   it "reads lines from file with each" do
     idx = 0
     File.each_line("#{__DIR__}/data/test_file.txt") do |line|
       if idx == 0
-        line.should eq("Hello World\n")
+        expect(line).to eq("Hello World\n")
       end
       idx += 1
     end
-    idx.should eq(20)
+    expect(idx).to eq(20)
   end
 
   describe "exists?" do
     it "gives true" do
-      File.exists?("#{__DIR__}/data/test_file.txt").should be_true
+      expect(File.exists?("#{__DIR__}/data/test_file.txt")).to be_true
     end
 
     it "gives false" do
-      File.exists?("#{__DIR__}/data/non_existing_file.txt").should be_false
+      expect(File.exists?("#{__DIR__}/data/non_existing_file.txt")).to be_false
     end
   end
 
   describe "file?" do
     it "gives true" do
-      File.file?("#{__DIR__}/data/test_file.txt").should be_true
+      expect(File.file?("#{__DIR__}/data/test_file.txt")).to be_true
     end
 
     it "gives false" do
-      File.file?("#{__DIR__}/data").should be_false
+      expect(File.file?("#{__DIR__}/data")).to be_false
     end
   end
 
   describe "directory?" do
     it "gives true" do
-      File.directory?("#{__DIR__}/data").should be_true
+      expect(File.directory?("#{__DIR__}/data")).to be_true
     end
 
     it "gives false" do
-      File.directory?("#{__DIR__}/data/test_file.txt").should be_false
+      expect(File.directory?("#{__DIR__}/data/test_file.txt")).to be_false
     end
   end
 
   it "gets dirname" do
-    File.dirname("/Users/foo/bar.cr").should eq("/Users/foo")
-    File.dirname("foo").should eq(".")
-    File.dirname("").should eq(".")
+    expect(File.dirname("/Users/foo/bar.cr")).to eq("/Users/foo")
+    expect(File.dirname("foo")).to eq(".")
+    expect(File.dirname("")).to eq(".")
   end
 
   it "gets basename" do
-    File.basename("/foo/bar/baz.cr").should eq("baz.cr")
-    File.basename("/foo/").should eq("foo")
-    File.basename("foo").should eq("foo")
-    File.basename("").should eq("")
+    expect(File.basename("/foo/bar/baz.cr")).to eq("baz.cr")
+    expect(File.basename("/foo/")).to eq("foo")
+    expect(File.basename("foo")).to eq("foo")
+    expect(File.basename("")).to eq("")
   end
 
   it "gets basename removing suffix" do
-    File.basename("/foo/bar/baz.cr", ".cr").should eq("baz")
+    expect(File.basename("/foo/bar/baz.cr", ".cr")).to eq("baz")
   end
 
   it "gets extname" do
-    File.extname("/foo/bar/baz.cr").should eq(".cr")
-    File.extname("/foo/bar/baz.cr.cz").should eq(".cz")
-    File.extname("/foo/bar/.profile").should eq("")
-    File.extname("/foo/bar/.profile.sh").should eq(".sh")
-    File.extname("/foo/bar/foo.").should eq("")
-    File.extname("test").should eq("")
+    expect(File.extname("/foo/bar/baz.cr")).to eq(".cr")
+    expect(File.extname("/foo/bar/baz.cr.cz")).to eq(".cz")
+    expect(File.extname("/foo/bar/.profile")).to eq("")
+    expect(File.extname("/foo/bar/.profile.sh")).to eq(".sh")
+    expect(File.extname("/foo/bar/foo.")).to eq("")
+    expect(File.extname("test")).to eq("")
   end
 
   it "constructs a path from parts" do
-    File.join(["///foo", "bar"]).should eq("///foo/bar")
-    File.join(["///foo", "//bar"]).should eq("///foo//bar")
-    File.join(["/foo/", "/bar"]).should eq("/foo/bar")
-    File.join(["foo", "bar", "baz"]).should eq("foo/bar/baz")
-    File.join(["foo", "//bar//", "baz///"]).should eq("foo//bar//baz///")
-    File.join(["/foo/", "/bar/", "/baz/"]).should eq("/foo/bar/baz/")
+    expect(File.join(["///foo", "bar"])).to eq("///foo/bar")
+    expect(File.join(["///foo", "//bar"])).to eq("///foo//bar")
+    expect(File.join(["/foo/", "/bar"])).to eq("/foo/bar")
+    expect(File.join(["foo", "bar", "baz"])).to eq("foo/bar/baz")
+    expect(File.join(["foo", "//bar//", "baz///"])).to eq("foo//bar//baz///")
+    expect(File.join(["/foo/", "/bar/", "/baz/"])).to eq("/foo/bar/baz/")
   end
 
   it "gets stat for this file" do
     stat = File.stat(__FILE__)
-    stat.blockdev?.should be_false
-    stat.chardev?.should be_false
-    stat.directory?.should be_false
-    stat.file?.should be_true
+    expect(stat.blockdev?).to be_false
+    expect(stat.chardev?).to be_false
+    expect(stat.directory?).to be_false
+    expect(stat.file?).to be_true
   end
 
   it "gets stat for this directory" do
     stat = File.stat(__DIR__)
-    stat.blockdev?.should be_false
-    stat.chardev?.should be_false
-    stat.directory?.should be_true
-    stat.file?.should be_false
+    expect(stat.blockdev?).to be_false
+    expect(stat.chardev?).to be_false
+    expect(stat.directory?).to be_true
+    expect(stat.file?).to be_false
   end
 
   it "gets stat for a character device" do
     stat = File.stat("/dev/null")
-    stat.blockdev?.should be_false
-    stat.chardev?.should be_true
-    stat.directory?.should be_false
-    stat.file?.should be_false
+    expect(stat.blockdev?).to be_false
+    expect(stat.chardev?).to be_true
+    expect(stat.directory?).to be_false
+    expect(stat.file?).to be_false
   end
 
   it "gets stat for open file" do
     File.open(__FILE__, "r") do |file|
       stat = file.stat
-      stat.blockdev?.should be_false
-      stat.chardev?.should be_false
-      stat.directory?.should be_false
-      stat.file?.should be_true
+      expect(stat.blockdev?).to be_false
+      expect(stat.chardev?).to be_false
+      expect(stat.directory?).to be_false
+      expect(stat.file?).to be_true
     end
   end
 
@@ -154,19 +154,19 @@ describe "File" do
   it "gets stat mtime for new file" do
     tmp = Tempfile.new "tmp"
     begin
-      (tmp.stat.atime - Time.utc_now).total_seconds.should be < 5
-      (tmp.stat.ctime - Time.utc_now).total_seconds.should be < 5
-      (tmp.stat.mtime - Time.utc_now).total_seconds.should be < 5
+      expect((tmp.stat.atime - Time.utc_now).total_seconds).to be < 5
+      expect((tmp.stat.ctime - Time.utc_now).total_seconds).to be < 5
+      expect((tmp.stat.mtime - Time.utc_now).total_seconds).to be < 5
     ensure
       tmp.delete
     end
   end
 
   describe "size" do
-    assert { File.size("#{__DIR__}/data/test_file.txt").should eq(240) }
+    assert { expect(File.size("#{__DIR__}/data/test_file.txt")).to eq(240) }
     assert do
       File.open("#{__DIR__}/data/test_file.txt", "r") do |file|
-        file.size.should eq(240)
+        expect(file.size).to eq(240)
       end
     end
   end
@@ -175,9 +175,9 @@ describe "File" do
     it "deletes a file" do
       filename = "#{__DIR__}/data/temp1.txt"
       File.open(filename, "w") {}
-      File.exists?(filename).should be_true
+      expect(File.exists?(filename)).to be_true
       File.delete(filename)
-      File.exists?(filename).should be_false
+      expect(File.exists?(filename)).to be_false
     end
 
     it "raises errno when file doesn't exist" do
@@ -194,9 +194,9 @@ describe "File" do
       filename2 = "#{__DIR__}/data/temp2.txt"
       File.open(filename, "w") { |f| f.puts "hello" }
       File.rename(filename, filename2)
-      File.exists?(filename).should be_false
-      File.exists?(filename2).should be_true
-      File.read(filename2).strip.should eq("hello")
+      expect(File.exists?(filename)).to be_false
+      expect(File.exists?(filename2)).to be_true
+      expect(File.read(filename2).strip).to eq("hello")
       File.delete(filename2)
     end
 
@@ -210,91 +210,91 @@ describe "File" do
 
   describe "expand_path" do
     it "converts a pathname to an absolute pathname" do
-      File.expand_path("").should eq(base)
-      File.expand_path("a").should eq(File.join([base, "a"]))
-      File.expand_path("a", nil).should eq(File.join([base, "a"]))
+      expect(File.expand_path("")).to eq(base)
+      expect(File.expand_path("a")).to eq(File.join([base, "a"]))
+      expect(File.expand_path("a", nil)).to eq(File.join([base, "a"]))
     end
 
     it "converts a pathname to an absolute pathname, Ruby-Talk:18512" do
-      File.expand_path(".a").should eq(File.join([base, ".a"]))
-      File.expand_path("..a").should eq(File.join([base, "..a"]))
-      File.expand_path("a../b").should eq(File.join([base, "a../b"]))
+      expect(File.expand_path(".a")).to eq(File.join([base, ".a"]))
+      expect(File.expand_path("..a")).to eq(File.join([base, "..a"]))
+      expect(File.expand_path("a../b")).to eq(File.join([base, "a../b"]))
     end
 
     it "keeps trailing dots on absolute pathname" do
-      File.expand_path("a.").should eq(File.join([base, "a."]))
-      File.expand_path("a..").should eq(File.join([base, "a.."]))
+      expect(File.expand_path("a.")).to eq(File.join([base, "a."]))
+      expect(File.expand_path("a..")).to eq(File.join([base, "a.."]))
     end
 
     it "converts a pathname to an absolute pathname, using a complete path" do
-      File.expand_path("", "#{tmpdir}").should eq("#{tmpdir}")
-      File.expand_path("a", "#{tmpdir}").should eq("#{tmpdir}/a")
-      File.expand_path("../a", "#{tmpdir}/xxx").should eq("#{tmpdir}/a")
-      File.expand_path(".", "#{rootdir}").should eq("#{rootdir}")
+      expect(File.expand_path("", "#{tmpdir}")).to eq("#{tmpdir}")
+      expect(File.expand_path("a", "#{tmpdir}")).to eq("#{tmpdir}/a")
+      expect(File.expand_path("../a", "#{tmpdir}/xxx")).to eq("#{tmpdir}/a")
+      expect(File.expand_path(".", "#{rootdir}")).to eq("#{rootdir}")
     end
 
     it "expands a path with multi-byte characters" do
-      File.expand_path("Ångström").should eq("#{base}/Ångström")
+      expect(File.expand_path("Ångström")).to eq("#{base}/Ångström")
     end
 
     it "expands /./dir to /dir" do
-      File.expand_path("/./dir").should eq("/dir")
+      expect(File.expand_path("/./dir")).to eq("/dir")
     end
 
     it "replaces multiple / with a single /" do
-      File.expand_path("////some/path").should eq("/some/path")
-      File.expand_path("/some////path").should eq( "/some/path")
+      expect(File.expand_path("////some/path")).to eq("/some/path")
+      expect(File.expand_path("/some////path")).to eq( "/some/path")
     end
 
     it "expand path with" do
-      File.expand_path("../../bin", "/tmp/x").should eq("/bin")
-      File.expand_path("../../bin", "/tmp").should eq("/bin")
-      File.expand_path("../../bin", "/").should eq("/bin")
-      File.expand_path("../bin", "tmp/x").should eq(File.join([base, "tmp", "bin"]))
-      File.expand_path("../bin", "x/../tmp").should eq(File.join([base, "bin"]))
+      expect(File.expand_path("../../bin", "/tmp/x")).to eq("/bin")
+      expect(File.expand_path("../../bin", "/tmp")).to eq("/bin")
+      expect(File.expand_path("../../bin", "/")).to eq("/bin")
+      expect(File.expand_path("../bin", "tmp/x")).to eq(File.join([base, "tmp", "bin"]))
+      expect(File.expand_path("../bin", "x/../tmp")).to eq(File.join([base, "bin"]))
     end
 
     it "expand_path for commoms unix path  give a full path" do
-      File.expand_path("/tmp/").should eq("/tmp")
-      File.expand_path("/tmp/../../../tmp").should eq("/tmp")
-      File.expand_path("").should eq(base)
-      File.expand_path("./////").should eq(base)
-      File.expand_path(".").should eq(base)
-      File.expand_path(base).should eq(base)
+      expect(File.expand_path("/tmp/")).to eq("/tmp")
+      expect(File.expand_path("/tmp/../../../tmp")).to eq("/tmp")
+      expect(File.expand_path("")).to eq(base)
+      expect(File.expand_path("./////")).to eq(base)
+      expect(File.expand_path(".")).to eq(base)
+      expect(File.expand_path(base)).to eq(base)
     end
 
     it "converts a pathname to an absolute pathname, using ~ (home) as base" do
-      File.expand_path("~/").should eq(home)
-      File.expand_path("~/..badfilename").should eq("#{home}/..badfilename")
-      File.expand_path("..").should eq(base.split("/")[0...-1].join("/"))
-      File.expand_path("~/a","~/b").should eq("#{home}/a")
-      File.expand_path("~").should eq(home)
-      File.expand_path("~", "/tmp/gumby/ddd").should eq(home)
-      File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))
+      expect(File.expand_path("~/")).to eq(home)
+      expect(File.expand_path("~/..badfilename")).to eq("#{home}/..badfilename")
+      expect(File.expand_path("..")).to eq(base.split("/")[0...-1].join("/"))
+      expect(File.expand_path("~/a","~/b")).to eq("#{home}/a")
+      expect(File.expand_path("~")).to eq(home)
+      expect(File.expand_path("~", "/tmp/gumby/ddd")).to eq(home)
+      expect(File.expand_path("~/a", "/tmp/gumby/ddd")).to eq(File.join([home, "a"]))
     end
   end
 
   it "writes" do
     filename = "#{__DIR__}/data/temp_write.txt"
     File.write(filename, "hello")
-    File.read(filename).strip.should eq("hello")
+    expect(File.read(filename).strip).to eq("hello")
     File.delete(filename)
   end
 
   it "does to_s" do
-    File.new(__FILE__).to_s.should eq("#<File:#{__FILE__}>")
+    expect(File.new(__FILE__).to_s).to eq("#<File:#{__FILE__}>")
   end
 
   describe "close" do
     it "is not closed when opening" do
       file = File.new(__FILE__)
-      file.closed?.should be_false
+      expect(file.closed?).to be_false
     end
 
     it "is closed when closed" do
       file = File.new(__FILE__)
       file.close
-      file.closed?.should be_true
+      expect(file.closed?).to be_true
     end
 
     it "raises when closing twice" do
@@ -309,7 +309,7 @@ describe "File" do
     it "does to_s when closed" do
       file = File.new(__FILE__)
       file.close
-      file.to_s.should eq("#<File:#{__FILE__} (closed)>")
+      expect(file.to_s).to eq("#<File:#{__FILE__} (closed)>")
     end
   end
 end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -4,11 +4,11 @@ require "file_utils"
 describe "FileUtils" do
   describe "cmp" do
     it "compares two equal files" do
-      FileUtils.cmp("#{__DIR__}/data/test_file.txt", "#{__DIR__}/data/test_file.txt").should be_true
+      expect(FileUtils.cmp("#{__DIR__}/data/test_file.txt", "#{__DIR__}/data/test_file.txt")).to be_true
     end
 
     it "compares two different files" do
-      FileUtils.cmp("#{__DIR__}/data/test_file.txt", "#{__DIR__}/data/test_file.ini").should be_false
+      expect(FileUtils.cmp("#{__DIR__}/data/test_file.txt", "#{__DIR__}/data/test_file.ini")).to be_false
     end
   end
 end

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -2,90 +2,90 @@ require "spec"
 
 describe "Float" do
   describe "**" do
-    assert { (2.5_f32 ** 2_i32).should eq(6.25_f32) }
-    assert { (2.5_f32 ** 2).should eq(6.25_f32) }
-    assert { (2.5_f32 ** 2.5_f32).should eq(9.882117688026186_f32) }
-    assert { (2.5_f32 ** 2.5).should eq(9.882117688026186_f32) }
-    assert { (2.5_f64 ** 2_i32).should eq(6.25_f64) }
-    assert { (2.5_f64 ** 2).should eq(6.25_f64) }
-    assert { (2.5_f64 ** 2.5_f64).should eq(9.882117688026186_f64) }
-    assert { (2.5_f64 ** 2.5).should eq(9.882117688026186_f64) }
+    assert { expect((2.5_f32 ** 2_i32)).to eq(6.25_f32) }
+    assert { expect((2.5_f32 ** 2)).to eq(6.25_f32) }
+    assert { expect((2.5_f32 ** 2.5_f32)).to eq(9.882117688026186_f32) }
+    assert { expect((2.5_f32 ** 2.5)).to eq(9.882117688026186_f32) }
+    assert { expect((2.5_f64 ** 2_i32)).to eq(6.25_f64) }
+    assert { expect((2.5_f64 ** 2)).to eq(6.25_f64) }
+    assert { expect((2.5_f64 ** 2.5_f64)).to eq(9.882117688026186_f64) }
+    assert { expect((2.5_f64 ** 2.5)).to eq(9.882117688026186_f64) }
   end
 
   describe "round" do
-    assert { 2.5.round.should eq(3) }
-    assert { 2.4.round.should eq(2) }
+    assert { expect(2.5.round).to eq(3) }
+    assert { expect(2.4.round).to eq(2) }
   end
 
   describe "floor" do
-    assert { 2.1.floor.should eq(2) }
-    assert { 2.9.floor.should eq(2) }
+    assert { expect(2.1.floor).to eq(2) }
+    assert { expect(2.9.floor).to eq(2) }
   end
 
   describe "ceil" do
-    assert { 2.0_f32.ceil.should eq(2) }
-    assert { 2.0.ceil.should eq(2) }
+    assert { expect(2.0_f32.ceil).to eq(2) }
+    assert { expect(2.0.ceil).to eq(2) }
 
-    assert { 2.1_f32.ceil.should eq(3_f32) }
-    assert { 2.1.ceil.should eq(3) }
+    assert { expect(2.1_f32.ceil).to eq(3_f32) }
+    assert { expect(2.1.ceil).to eq(3) }
 
-    assert { 2.9_f32.ceil.should eq(3) }
-    assert { 2.9.ceil.should eq(3) }
+    assert { expect(2.9_f32.ceil).to eq(3) }
+    assert { expect(2.9.ceil).to eq(3) }
   end
 
   describe "fdiv" do
-    assert { 1.0.fdiv(1).should eq 1.0 }
-    assert { 1.0.fdiv(2).should eq 0.5 }
-    assert { 1.0.fdiv(0.5).should eq 2.0 }
-    assert { 0.0.fdiv(1).should eq 0.0 }
-    assert { 1.0.fdiv(0).should eq 1.0/0.0 }
+    assert { expect(1.0.fdiv(1)).to eq 1.0 }
+    assert { expect(1.0.fdiv(2)).to eq 0.5 }
+    assert { expect(1.0.fdiv(0.5)).to eq 2.0 }
+    assert { expect(0.0.fdiv(1)).to eq 0.0 }
+    assert { expect(1.0.fdiv(0)).to eq 1.0/0.0 }
   end
 
   describe "to_s" do
     it "does to_s for f32 and f64" do
-      12.34.to_s.should eq("12.34")
-      12.34_f64.to_s.should eq("12.34")
+      expect(12.34.to_s).to eq("12.34")
+      expect(12.34_f64.to_s).to eq("12.34")
     end
   end
 
   describe "hash" do
     it "does for Float32" do
-      1.2_f32.hash.should_not eq(0)
+      expect(1.2_f32.hash).to_not eq(0)
     end
 
     it "does for Float64" do
-      1.2.hash.should_not eq(0)
+      expect(1.2.hash).to_not eq(0)
     end
   end
 
   it "casts" do
-    Float32.cast(1_f64).should be_a(Float32)
-    Float32.cast(1_f64).should eq(1)
+    expect(Float32.cast(1_f64)).to be_a(Float32)
+    expect(Float32.cast(1_f64)).to eq(1)
 
-    Float64.cast(1_f32).should be_a(Float64)
-    Float64.cast(1_f32).should eq(1)
+    expect(Float64.cast(1_f32)).to be_a(Float64)
+    expect(Float64.cast(1_f32)).to eq(1)
   end
 
   it "does nan?" do
-    1.5.nan?.should be_false
-    (0.0 / 0.0).nan?.should be_true
+    expect(1.5.nan?).to be_false
+    expect((0.0 / 0.0).nan?).to be_true
   end
 
   it "does infinite?" do
-    (0.0).infinite?.should be_nil
-    (-1.0/0.0).infinite?.should eq(-1)
-    (1.0/0.0).infinite?.should eq(1)
+    expect((0.0).infinite?).to be_nil
+    expect((-1.0/0.0).infinite?).to eq(-1)
+    expect((1.0/0.0).infinite?).to eq(1)
 
-    (0.0_f32).infinite?.should be_nil
-    (-1.0_f32/0.0_f32).infinite?.should eq(-1)
-    (1.0_f32/0.0_f32).infinite?.should eq(1)
+    expect((0.0_f32).infinite?).to be_nil
+    expect((-1.0_f32/0.0_f32).infinite?).to eq(-1)
+    expect((1.0_f32/0.0_f32).infinite?).to eq(1)
   end
 
   it "does finite?" do
-    0.0.finite?.should be_true
-    1.5.finite?.should be_true
-    (1.0/0.0).finite?.should be_false
-    (-1.0/0.0).finite?.should be_false
-    (-0.0/0.0).finite?.should be_false
+    expect(0.0.finite?).to be_true
+    expect(1.5.finite?).to be_true
+    expect((1.0/0.0).finite?).to be_false
+    expect((-1.0/0.0).finite?).to be_false
+    expect((-0.0/0.0).finite?).to be_false
   end
 end

--- a/spec/std/fs/fs_spec.cr
+++ b/spec/std/fs/fs_spec.cr
@@ -3,75 +3,75 @@ require "fs"
 
 macro filesystem_spec(fs)
   it "should combine path using both parts or first" do
-    {{fs.id}}.combine("foo", "bar").should eq("foo/bar")
-    {{fs.id}}.combine("foo", "").should eq("foo")
-    {{fs.id}}.combine("", "bar").should eq("bar")
+    expect({{fs.id}}.combine("foo", "bar")).to eq("foo/bar")
+    expect({{fs.id}}.combine("foo", "")).to eq("foo")
+    expect({{fs.id}}.combine("", "bar")).to eq("bar")
   end
 
   it "should list top level folders" do
-    {{fs.id}}.dirs.map(&.name).sort.should eq(["folder1","folder2"])
+    expect({{fs.id}}.dirs.map(&.name).sort).to eq(["folder1","folder2"])
   end
 
   it "should list top level files" do
-    {{fs.id}}.files.map(&.name).should eq(["top-level.txt"])
+    expect({{fs.id}}.files.map(&.name)).to eq(["top-level.txt"])
   end
 
   it "should list top level entries" do
-    {{fs.id}}.entries.map(&.name).sort.should eq(["folder1","folder2","top-level.txt"])
+    expect({{fs.id}}.entries.map(&.name).sort).to eq(["folder1","folder2","top-level.txt"])
   end
 
   it "should have path from filesystem root" do
-    {{fs.id}}.entry("folder1").path.should eq("folder1")
-    {{fs.id}}.entry("top-level.txt").path.should eq("top-level.txt")
-    {{fs.id}}.entry("folder1/subfolder1").path.should eq("folder1/subfolder1")
-    {{fs.id}}.dir("folder1").entry("subfolder1").path.should eq("folder1/subfolder1")
+    expect({{fs.id}}.entry("folder1").path).to eq("folder1")
+    expect({{fs.id}}.entry("top-level.txt").path).to eq("top-level.txt")
+    expect({{fs.id}}.entry("folder1/subfolder1").path).to eq("folder1/subfolder1")
+    expect({{fs.id}}.dir("folder1").entry("subfolder1").path).to eq("folder1/subfolder1")
   end
 
   it "should list entries inside directory from path" do
-    {{fs.id}}.find_entries("folder1").map(&.name).should eq(["subfolder1"])
+    expect({{fs.id}}.find_entries("folder1").map(&.name)).to eq(["subfolder1"])
   end
 
   it "should tell if existing entry is dir or file" do
-    {{fs.id}}.entry("folder1").dir?.should be_true
-    {{fs.id}}.entry("folder1").file?.should be_false
+    expect({{fs.id}}.entry("folder1").dir?).to be_true
+    expect({{fs.id}}.entry("folder1").file?).to be_false
 
-    {{fs.id}}.entry("top-level.txt").file?.should be_true
-    {{fs.id}}.entry("top-level.txt").dir?.should be_false
+    expect({{fs.id}}.entry("top-level.txt").file?).to be_true
+    expect({{fs.id}}.entry("top-level.txt").dir?).to be_false
   end
 
   it "should read all file" do
-    {{fs.id}}.file("top-level.txt").read.should eq("Now is the time for all good coders\nto learn Crystal\n")
+    expect({{fs.id}}.file("top-level.txt").read).to eq("Now is the time for all good coders\nto learn Crystal\n")
   end
 
   it "should check non existing entry" do
-    {{fs.id}}.exists?("no-existing").should be_false
-    {{fs.id}}.exists?("folder1/no-existing.txt").should be_false
-    {{fs.id}}.exists?("folder1/no-existing/").should be_false
+    expect({{fs.id}}.exists?("no-existing")).to be_false
+    expect({{fs.id}}.exists?("folder1/no-existing.txt")).to be_false
+    expect({{fs.id}}.exists?("folder1/no-existing/")).to be_false
 
-    {{fs.id}}.exists?("folder1").should be_true
-    {{fs.id}}.exists?("folder1/subfolder1").should be_true
+    expect({{fs.id}}.exists?("folder1")).to be_true
+    expect({{fs.id}}.exists?("folder1/subfolder1")).to be_true
   end
 
   it "should get if dir exists using dir?" do
-    {{fs.id}}.dir?("no-existing").should be_false
-    {{fs.id}}.dir?("folder1/no-existing.txt").should be_false
-    {{fs.id}}.dir?("folder1/no-existing/").should be_false
+    expect({{fs.id}}.dir?("no-existing")).to be_false
+    expect({{fs.id}}.dir?("folder1/no-existing.txt")).to be_false
+    expect({{fs.id}}.dir?("folder1/no-existing/")).to be_false
 
-    {{fs.id}}.dir?("folder1").should be_true
-    {{fs.id}}.dir?("folder1/subfolder1").should be_true
-    {{fs.id}}.dir?("top-level.txt").should be_false
+    expect({{fs.id}}.dir?("folder1")).to be_true
+    expect({{fs.id}}.dir?("folder1/subfolder1")).to be_true
+    expect({{fs.id}}.dir?("top-level.txt")).to be_false
   end
 
 
   it "should get if file exists using file?" do
-    {{fs.id}}.file?("no-existing").should be_false
-    {{fs.id}}.file?("folder1/no-existing.txt").should be_false
-    {{fs.id}}.file?("folder1/no-existing/").should be_false
+    expect({{fs.id}}.file?("no-existing")).to be_false
+    expect({{fs.id}}.file?("folder1/no-existing.txt")).to be_false
+    expect({{fs.id}}.file?("folder1/no-existing/")).to be_false
 
-    {{fs.id}}.file?("folder1").should be_false
-    {{fs.id}}.file?("folder1/subfolder1").should be_false
-    {{fs.id}}.file?("folder2/second-level.txt").should be_true
-    {{fs.id}}.file?("top-level.txt").should be_true
+    expect({{fs.id}}.file?("folder1")).to be_false
+    expect({{fs.id}}.file?("folder1/subfolder1")).to be_false
+    expect({{fs.id}}.file?("folder2/second-level.txt")).to be_true
+    expect({{fs.id}}.file?("top-level.txt")).to be_true
   end
 end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -89,7 +89,8 @@ describe "Hash" do
     it "gets" do
       a = {1 => 2}
       expect(a[1]).to eq(2)
-      expect(# a[2]).to raise_exception
+      # TODO: use expect_raises here
+      # expect(a[2]).to raise_exception
       expect(a).to eq({1 => 2})
     end
   end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -15,47 +15,47 @@ describe "Hash" do
   describe "empty" do
     it "length should be zero" do
       h = {} of Int32 => Int32
-      h.length.should eq(0)
-      h.empty?.should be_true
+      expect(h.length).to eq(0)
+      expect(h.empty?).to be_true
     end
   end
 
   it "sets and gets" do
     a = {} of Int32 => Int32
     a[1] = 2
-    a[1].should eq(2)
+    expect(a[1]).to eq(2)
   end
 
   it "gets from literal" do
     a = {1 => 2}
-    a[1].should eq(2)
+    expect(a[1]).to eq(2)
   end
 
   it "gets from union" do
     a = {1 => 2, :foo => 1.1}
-    a[1].should eq(2)
+    expect(a[1]).to eq(2)
   end
 
   it "gets nilable" do
     a = {1 => 2}
-    a[1]?.should eq(2)
-    a[2]?.should be_nil
+    expect(a[1]?).to eq(2)
+    expect(a[2]?).to be_nil
   end
 
   it "gets array of keys" do
     a = {} of Symbol => Int32
-    a.keys.should eq([] of Symbol)
+    expect(a.keys).to eq([] of Symbol)
     a[:foo] = 1
     a[:bar] = 2
-    a.keys.should eq([:foo, :bar])
+    expect(a.keys).to eq([:foo, :bar])
   end
 
   it "gets array of values" do
     a = {} of Symbol => Int32
-    a.values.should eq([] of Int32)
+    expect(a.values).to eq([] of Int32)
     a[:foo] = 1
     a[:bar] = 2
-    a.values.should eq([1, 2])
+    expect(a.values).to eq([1, 2])
   end
 
   describe "==" do
@@ -64,33 +64,33 @@ describe "Hash" do
       b = {3 => 4, 1 => 2}
       c = {2 => 3}
       d = {5 => 6, 7 => 8}
-      a.should eq(a)
-      a.should eq(b)
-      b.should eq(a)
-      a.should_not eq(c)
-      c.should_not eq(a)
-      d.should_not eq(a)
+      expect(a).to eq(a)
+      expect(a).to eq(b)
+      expect(b).to eq(a)
+      expect(a).to_not eq(c)
+      expect(c).to_not eq(a)
+      expect(d).to_not eq(a)
     end
 
     assert do
       a = {1 => nil}
       b = {3 => 4}
-      a.should_not eq(b)
+      expect(a).to_not eq(b)
     end
 
     it "compares hash of nested hash" do
       a = { {1 => 2} => 3}
       b = { {1 => 2} => 3}
-      a.should eq(b)
+      expect(a).to eq(b)
     end
   end
 
   describe "[]" do
     it "gets" do
       a = {1 => 2}
-      a[1].should eq(2)
-      # a[2].should raise_exception
-      a.should eq({1 => 2})
+      expect(a[1]).to eq(2)
+      expect(# a[2]).to raise_exception
+      expect(a).to eq({1 => 2})
     end
   end
 
@@ -98,29 +98,29 @@ describe "Hash" do
     it "overrides value" do
       a = {1 => 2}
       a[1] = 3
-      a[1].should eq(3)
+      expect(a[1]).to eq(3)
     end
   end
 
   describe "fetch" do
     it "fetches with one argument" do
       a = {1 => 2}
-      a.fetch(1).should eq(2)
-      a.should eq({1 => 2})
+      expect(a.fetch(1)).to eq(2)
+      expect(a).to eq({1 => 2})
     end
 
     it "fetches with default value" do
       a = {1 => 2}
-      a.fetch(1, 3).should eq(2)
-      a.fetch(2, 3).should eq(3)
-      a.should eq({1 => 2})
+      expect(a.fetch(1, 3)).to eq(2)
+      expect(a.fetch(2, 3)).to eq(3)
+      expect(a).to eq({1 => 2})
     end
 
     it "fetches with block" do
       a = {1 => 2}
-      a.fetch(1) { |k| k * 3 }.should eq(2)
-      a.fetch(2) { |k| k * 3 }.should eq(6)
-      a.should eq({1 => 2})
+      expect(a.fetch(1) { |k| k * 3 }).to eq(2)
+      expect(a.fetch(2) { |k| k * 3 }).to eq(6)
+      expect(a).to eq({1 => 2})
     end
 
     it "fetches and raises" do
@@ -134,190 +134,190 @@ describe "Hash" do
   describe "has_key?" do
     it "doesn't have key" do
       a = {1 => 2}
-      a.has_key?(2).should be_false
+      expect(a.has_key?(2)).to be_false
     end
 
     it "has key" do
       a = {1 => 2}
-      a.has_key?(1).should be_true
+      expect(a.has_key?(1)).to be_true
     end
   end
 
   describe "delete" do
     it "deletes key in the beginning" do
       a = {1 => 2, 3 => 4, 5 => 6}
-      a.delete(1).should eq(2)
-      a.has_key?(1).should be_false
-      a.has_key?(3).should be_true
-      a.has_key?(5).should be_true
-      a.length.should eq(2)
-      a.should eq({3 => 4, 5 => 6})
+      expect(a.delete(1)).to eq(2)
+      expect(a.has_key?(1)).to be_false
+      expect(a.has_key?(3)).to be_true
+      expect(a.has_key?(5)).to be_true
+      expect(a.length).to eq(2)
+      expect(a).to eq({3 => 4, 5 => 6})
     end
 
     it "deletes key in the middle" do
       a = {1 => 2, 3 => 4, 5 => 6}
-      a.delete(3).should eq(4)
-      a.has_key?(1).should be_true
-      a.has_key?(3).should be_false
-      a.has_key?(5).should be_true
-      a.length.should eq(2)
-      a.should eq({1 => 2, 5 => 6})
+      expect(a.delete(3)).to eq(4)
+      expect(a.has_key?(1)).to be_true
+      expect(a.has_key?(3)).to be_false
+      expect(a.has_key?(5)).to be_true
+      expect(a.length).to eq(2)
+      expect(a).to eq({1 => 2, 5 => 6})
     end
 
     it "deletes key in the end" do
       a = {1 => 2, 3 => 4, 5 => 6}
-      a.delete(5).should eq(6)
-      a.has_key?(1).should be_true
-      a.has_key?(3).should be_true
-      a.has_key?(5).should be_false
-      a.length.should eq(2)
-      a.should eq({1 => 2, 3 =>4})
+      expect(a.delete(5)).to eq(6)
+      expect(a.has_key?(1)).to be_true
+      expect(a.has_key?(3)).to be_true
+      expect(a.has_key?(5)).to be_false
+      expect(a.length).to eq(2)
+      expect(a).to eq({1 => 2, 3 =>4})
     end
 
     it "deletes only remaining entry" do
       a = {1 => 2}
-      a.delete(1).should eq(2)
-      a.has_key?(1).should be_false
-      a.length.should eq(0)
-      a.should eq({} of Int32 => Int32)
+      expect(a.delete(1)).to eq(2)
+      expect(a.has_key?(1)).to be_false
+      expect(a.length).to eq(0)
+      expect(a).to eq({} of Int32 => Int32)
     end
 
     it "deletes not found" do
       a = {1 => 2}
-      a.delete(2).should be_nil
+      expect(a.delete(2)).to be_nil
     end
   end
 
   it "maps" do
     hash = {1 => 2, 3 => 4}
     array = hash.map { |k, v| k + v }
-    array.should eq([3, 7])
+    expect(array).to eq([3, 7])
   end
 
   describe "to_s" do
-    assert { {1 => 2, 3 => 4}.to_s.should eq("{1 => 2, 3 => 4}") }
+    assert { expect({1 => 2, 3 => 4}.to_s).to eq("{1 => 2, 3 => 4}") }
 
     assert do
       h = {} of RecursiveHash => RecursiveHash
       h[h] = h
-      h.to_s.should eq("{{...} => {...}}")
+      expect(h.to_s).to eq("{{...} => {...}}")
     end
   end
 
   it "does to_h" do
     h = {a: 1}
-    h.to_h.should be(h)
+    expect(h.to_h).to be(h)
   end
 
   it "clones" do
     h1 = {1 => 2, 3 => 4}
     h2 = h1.clone
-    h1.object_id.should_not eq(h2.object_id)
-    h1.should eq(h2)
+    expect(h1.object_id).to_not eq(h2.object_id)
+    expect(h1).to eq(h2)
   end
 
   it "initializes with block" do
     h1 = Hash(String, Array(Int32)).new { |h, k| h[k] = [] of Int32 }
-    h1["foo"].should eq([] of Int32)
+    expect(h1["foo"]).to eq([] of Int32)
     h1["bar"].push 2
-    h1["bar"].should eq([2])
+    expect(h1["bar"]).to eq([2])
   end
 
   it "initializes with default value" do
     h = Hash(Int32, Int32).new(10)
-    h[0].should eq(10)
-    h.has_key?(0).should be_false
+    expect(h[0]).to eq(10)
+    expect(h.has_key?(0)).to be_false
     h[1] += 2
-    h[1].should eq(12)
-    h.has_key?(1).should be_true
+    expect(h[1]).to eq(12)
+    expect(h.has_key?(1)).to be_true
   end
 
   it "initializes with comparator" do
     h = Hash(String, Int32).new(Hash::CaseInsensitiveComparator)
     h["foo"] = 1
-    h["foo"].should eq(1)
-    h["FoO"].should eq(1)
+    expect(h["foo"]).to eq(1)
+    expect(h["FoO"]).to eq(1)
   end
 
   it "initializes with block and comparator" do
     h1 = Hash(String, Array(Int32)).new(Hash::CaseInsensitiveComparator) { |h, k| h[k] = [] of Int32 }
-    h1["foo"].should eq([] of Int32)
+    expect(h1["foo"]).to eq([] of Int32)
     h1["bar"] = [2]
-    h1["BAR"].should eq([2])
+    expect(h1["BAR"]).to eq([2])
   end
 
   it "initializes with default value and comparator" do
     h = Hash(String, Int32).new(10, Hash::CaseInsensitiveComparator)
-    h["x"].should eq(10)
-    h.has_key?("x").should be_false
+    expect(h["x"]).to eq(10)
+    expect(h.has_key?("x")).to be_false
     h["foo"] = 5
-    h["FoO"].should eq(5)
+    expect(h["FoO"]).to eq(5)
   end
 
   it "merges" do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}
     h3 = h1.merge(h2)
-    h3.object_id.should_not eq(h1.object_id)
-    h3.should eq({1 => 5, 3 => 4, 2 => 3})
+    expect(h3.object_id).to_not eq(h1.object_id)
+    expect(h3).to eq({1 => 5, 3 => 4, 2 => 3})
   end
 
   it "merges!" do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}
     h3 = h1.merge!(h2)
-    h3.object_id.should eq(h1.object_id)
-    h3.should eq({1 => 5, 3 => 4, 2 => 3})
+    expect(h3.object_id).to eq(h1.object_id)
+    expect(h3).to eq({1 => 5, 3 => 4, 2 => 3})
   end
 
   it "zips" do
     ary1 = [1, 2, 3]
     ary2 = ['a', 'b', 'c']
     hash = Hash.zip(ary1, ary2)
-    hash.should eq({1 => 'a', 2 => 'b', 3 => 'c'})
+    expect(hash).to eq({1 => 'a', 2 => 'b', 3 => 'c'})
   end
 
   it "gets first" do
     h = {1 => 2, 3 => 4}
-    h.first.should eq({1, 2})
+    expect(h.first).to eq({1, 2})
   end
 
   it "gets first key" do
     h = {1 => 2, 3 => 4}
-    h.first_key.should eq(1)
+    expect(h.first_key).to eq(1)
   end
 
   it "gets first value" do
     h = {1 => 2, 3 => 4}
-    h.first_value.should eq(2)
+    expect(h.first_value).to eq(2)
   end
 
   it "shifts" do
     h = {1 => 2, 3 => 4}
-    h.shift.should eq({1, 2})
-    h.should eq({3 => 4})
-    h.shift.should eq({3, 4})
-    h.empty?.should be_true
+    expect(h.shift).to eq({1, 2})
+    expect(h).to eq({3 => 4})
+    expect(h.shift).to eq({3, 4})
+    expect(h.empty?).to be_true
   end
 
   it "shifts?" do
     h = {1 => 2}
-    h.shift?.should eq({1, 2})
-    h.empty?.should be_true
-    h.shift?.should be_nil
+    expect(h.shift?).to eq({1, 2})
+    expect(h.empty?).to be_true
+    expect(h.shift?).to be_nil
   end
 
   it "works with custom comparator" do
     h = Hash(String, Int32).new(Hash::CaseInsensitiveComparator)
     h["FOO"] = 1
-    h["foo"].should eq(1)
-    h["Foo"].should eq(1)
+    expect(h["foo"]).to eq(1)
+    expect(h["Foo"]).to eq(1)
   end
 
   it "gets key index" do
     h = {1 => 2, 3 => 4}
-    h.key_index(3).should eq(1)
-    h.key_index(2).should be_nil
+    expect(h.key_index(3)).to eq(1)
+    expect(h.key_index(2)).to be_nil
   end
 
   it "inserts many" do
@@ -325,61 +325,61 @@ describe "Hash" do
     h = {} of Int32 => Int32
     times.times do |i|
       h[i] = i
-      h.length.should eq(i + 1)
+      expect(h.length).to eq(i + 1)
     end
     times.times do |i|
-      h[i].should eq(i)
+      expect(h[i]).to eq(i)
     end
-    h.first_key.should eq(0)
-    h.first_value.should eq(0)
+    expect(h.first_key).to eq(0)
+    expect(h.first_value).to eq(0)
     times.times do |i|
-      h.delete(i).should eq(i)
-      h.has_key?(i).should be_false
-      h.length.should eq(times - i - 1)
+      expect(h.delete(i)).to eq(i)
+      expect(h.has_key?(i)).to be_false
+      expect(h.length).to eq(times - i - 1)
     end
   end
 
   it "inserts in one bucket and deletes from the same one" do
     h = {11 => 1}
-    h.delete(0).should be_nil
-    h.has_key?(11).should be_true
-    h.length.should eq(1)
+    expect(h.delete(0)).to be_nil
+    expect(h.has_key?(11)).to be_true
+    expect(h.length).to eq(1)
   end
 
   it "does to_a" do
     h = {1 => "hello", 2 => "bye"}
-    h.to_a.should eq([{1, "hello"}, {2, "bye"}])
+    expect(h.to_a).to eq([{1, "hello"}, {2, "bye"}])
   end
 
   it "clears" do
     h = {1 => 2, 3 => 4}
     h.clear
-    h.empty?.should be_true
-    h.to_a.length.should eq(0)
+    expect(h.empty?).to be_true
+    expect(h.to_a.length).to eq(0)
   end
 
   it "computes hash" do
     h = { {1 => 2} => {3 => 4} }
-    h.hash.should_not eq(h.object_id)
+    expect(h.hash).to_not eq(h.object_id)
 
     h2 = { {1 => 2} => {3 => 4} }
-    h.hash.should eq(h2.hash)
+    expect(h.hash).to eq(h2.hash)
   end
 
   it "fetches from empty hash with default value" do
     x = {} of Int32 => HashBreaker
     breaker = x.fetch(10) { HashBreaker.new(1) }
-    breaker.x.should eq(1)
+    expect(breaker.x).to eq(1)
   end
 
   it "does to to_s with instance that was never instantiated" do
     x = {} of Int32 => NeverInstantiated
-    x.to_s.should eq("{}")
+    expect(x.to_s).to eq("{}")
   end
 
   it "deletes if" do
     x = {a: 1, b: 2, c: 3, d: 4}
     x.delete_if { |k, v| v % 2 == 0 }
-    x.should eq({a: 1, c: 3})
+    expect(x).to eq({a: 1, c: 3})
   end
 end

--- a/spec/std/html/builder_spec.cr
+++ b/spec/std/html/builder_spec.cr
@@ -17,21 +17,21 @@ describe "HTML" do
           end
         end
       end
-      str.should eq %(<html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks!</a><form method="POST"><input name="name"></input></form></body></html>)
+      expect(str).to eq %(<html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks!</a><form method="POST"><input name="name"></input></form></body></html>)
     end
 
     it "escapes attribute values" do
       str = HTML::Builder.new.build do
         a({href: "<>"}) {}
       end
-      str.should eq %(<a href="&lt;&gt;"></a>)
+      expect(str).to eq %(<a href="&lt;&gt;"></a>)
     end
 
     it "escapes text" do
       str = HTML::Builder.new.build do
         a { text "<>" }
       end
-      str.should eq %(<a>&lt;&gt;</a>)
+      expect(str).to eq %(<a>&lt;&gt;</a>)
     end
   end
 end

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -6,13 +6,13 @@ describe "HTML" do
     it "does not change a safe string" do
       str = HTML.escape("safe_string")
 
-      str.should eq("safe_string")
+      expect(str).to eq("safe_string")
     end
 
     it "escapes dangerous characters from a string" do
       str = HTML.escape("< & >")
 
-      str.should eq("&lt; &amp; &gt;")
+      expect(str).to eq("&lt; &amp; &gt;")
     end
   end
 end

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -4,77 +4,77 @@ require "http/headers"
 describe HTTP::Headers do
   it "is empty" do
     headers = HTTP::Headers.new
-    headers.empty?.should be_true
+    expect(headers.empty?).to be_true
   end
 
   it "is case insensitive" do
     headers = HTTP::Headers{"Foo": "bar"}
-    headers["foo"].should eq("bar")
+    expect(headers["foo"]).to eq("bar")
   end
 
   it "is gets with []?" do
     headers = HTTP::Headers.new
-    headers["foo"]?.should be_nil
+    expect(headers["foo"]?).to be_nil
 
     headers["Foo"] = "bar"
-    headers["foo"]?.should eq("bar")
+    expect(headers["foo"]?).to eq("bar")
   end
 
   it "fetches" do
     headers = HTTP::Headers{"Foo": "bar"}
-    headers.fetch("foo").should eq("bar")
+    expect(headers.fetch("foo")).to eq("bar")
   end
 
   it "fetches with default value" do
     headers = HTTP::Headers.new
-    headers.fetch("foo", "baz").should eq("baz")
+    expect(headers.fetch("foo", "baz")).to eq("baz")
 
     headers["Foo"] = "bar"
-    headers.fetch("foo", "baz").should eq("bar")
+    expect(headers.fetch("foo", "baz")).to eq("bar")
   end
 
   it "fetches with block" do
     headers = HTTP::Headers.new
-    headers.fetch("foo") { |k| "#{k}baz" }.should eq("Foobaz")
+    expect(headers.fetch("foo") { |k| "#{k}baz" }).to eq("Foobaz")
 
     headers["Foo"] = "bar"
-    headers.fetch("foo") { "baz" }.should eq("bar")
+    expect(headers.fetch("foo") { "baz" }).to eq("bar")
   end
 
   it "has key" do
     headers = HTTP::Headers{"Foo": "bar"}
-    headers.has_key?("foo").should be_true
-    headers.has_key?("bar").should be_false
+    expect(headers.has_key?("foo")).to be_true
+    expect(headers.has_key?("bar")).to be_false
   end
 
   it "deletes" do
     headers = HTTP::Headers{"Foo": "bar"}
-    headers.delete("foo").should eq("bar")
-    headers.empty?.should be_true
+    expect(headers.delete("foo")).to eq("bar")
+    expect(headers.empty?).to be_true
   end
 
   it "equals another hash" do
     headers = HTTP::Headers{"Foo": "bar"}
-    headers.should eq({"foo": "bar"})
+    expect(headers).to eq({"foo": "bar"})
   end
 
   it "dups" do
     headers = HTTP::Headers{"Foo": "bar"}
     other = headers.dup
-    other.should be_a(HTTP::Headers)
-    other["foo"].should eq("bar")
+    expect(other).to be_a(HTTP::Headers)
+    expect(other["foo"]).to eq("bar")
 
     other["Baz"] = "Qux"
-    headers["baz"]?.should be_nil
+    expect(headers["baz"]?).to be_nil
   end
 
   it "clones" do
     headers = HTTP::Headers{"Foo": "bar"}
     other = headers.clone
-    other.should be_a(HTTP::Headers)
-    other["foo"].should eq("bar")
+    expect(other).to be_a(HTTP::Headers)
+    expect(other["foo"]).to eq("bar")
 
     other["Baz"] = "Qux"
-    headers["baz"]?.should be_nil
+    expect(headers["baz"]?).to be_nil
   end
 end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -10,69 +10,69 @@ module HTTP
 
       io = StringIO.new
       request.to_io(io)
-      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")
+      expect(io.to_s).to eq("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")
     end
 
     it "serialize POST (with body)" do
       request = Request.new "POST", "/", body: "thisisthebody"
       io = StringIO.new
       request.to_io(io)
-      io.to_s.should eq("POST / HTTP/1.1\r\nContent-length: 13\r\n\r\nthisisthebody")
+      expect(io.to_s).to eq("POST / HTTP/1.1\r\nContent-length: 13\r\n\r\nthisisthebody")
     end
 
     it "parses GET" do
       request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")).not_nil!
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.domain.com"})
+      expect(request.method).to eq("GET")
+      expect(request.path).to eq("/")
+      expect(request.headers).to eq({"Host" => "host.domain.com"})
     end
 
     it "parses GET without \\r" do
       request = Request.from_io(StringIO.new("GET / HTTP/1.1\nHost: host.domain.com\n\n")).not_nil!
-      request.method.should eq("GET")
-      request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.domain.com"})
+      expect(request.method).to eq("GET")
+      expect(request.path).to eq("/")
+      expect(request.headers).to eq({"Host" => "host.domain.com"})
     end
 
     it "headers are case insensitive" do
       request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")).not_nil!
       headers = request.headers.not_nil!
-      headers["HOST"].should eq("host.domain.com")
-      headers["host"].should eq("host.domain.com")
-      headers["Host"].should eq("host.domain.com")
+      expect(headers["HOST"]).to eq("host.domain.com")
+      expect(headers["host"]).to eq("host.domain.com")
+      expect(headers["Host"]).to eq("host.domain.com")
     end
 
     it "parses POST (with body)" do
       request = Request.from_io(StringIO.new("POST /foo HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")).not_nil!
-      request.method.should eq("POST")
-      request.path.should eq("/foo")
-      request.headers.should eq({"Content-Length" => "13"})
-      request.body.should eq("thisisthebody")
+      expect(request.method).to eq("POST")
+      expect(request.path).to eq("/foo")
+      expect(request.headers).to eq({"Content-Length" => "13"})
+      expect(request.body).to eq("thisisthebody")
     end
 
     describe "keep-alive" do
       it "is false by default in HTTP/1.0" do
         request = Request.new "GET", "/", version: "HTTP/1.0"
-        request.keep_alive?.should be_false
+        expect(request.keep_alive?).to be_false
       end
 
       it "is true in HTTP/1.0 if `Connection: keep-alive` header is present" do
         headers = HTTP::Headers.new
         headers["Connection"] = "keep-alive"
         request = Request.new "GET", "/", headers: headers, version: "HTTP/1.0"
-        request.keep_alive?.should be_true
+        expect(request.keep_alive?).to be_true
       end
 
       it "is true by default in HTTP/1.1" do
         request = Request.new "GET", "/", version: "HTTP/1.1"
-        request.keep_alive?.should be_true
+        expect(request.keep_alive?).to be_true
       end
 
       it "is false in HTTP/1.1 if `Connection: close` header is present" do
         headers = HTTP::Headers.new
         headers["Connection"] = "close"
         request = Request.new "GET", "/", headers: headers, version: "HTTP/1.1"
-        request.keep_alive?.should be_false
+        expect(request.keep_alive?).to be_false
       end
     end
   end

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -5,37 +5,37 @@ module HTTP
   describe Response do
     it "parses response with body" do
       response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"))
-      response.version.should eq("HTTP/1.1")
-      response.status_code.should eq(200)
-      response.status_message.should eq("OK")
-      response.headers["content-type"].should eq("text/plain")
-      response.headers["content-length"].should eq("5")
-      response.body.should eq("hello")
+      expect(response.version).to eq("HTTP/1.1")
+      expect(response.status_code).to eq(200)
+      expect(response.status_message).to eq("OK")
+      expect(response.headers["content-type"]).to eq("text/plain")
+      expect(response.headers["content-length"]).to eq("5")
+      expect(response.body).to eq("hello")
     end
 
     it "parses response with body without \\r" do
       response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 5\n\nhelloworld"))
-      response.version.should eq("HTTP/1.1")
-      response.status_code.should eq(200)
-      response.status_message.should eq("OK")
-      response.headers["content-type"].should eq("text/plain")
-      response.headers["content-length"].should eq("5")
-      response.body.should eq("hello")
+      expect(response.version).to eq("HTTP/1.1")
+      expect(response.status_code).to eq(200)
+      expect(response.status_message).to eq("OK")
+      expect(response.headers["content-type"]).to eq("text/plain")
+      expect(response.headers["content-length"]).to eq("5")
+      expect(response.body).to eq("hello")
     end
 
     it "parses response without body" do
       response = Response.from_io(StringIO.new("HTTP/1.1 404 Not Found\r\n\r\n"))
-      response.status_code.should eq(404)
-      response.status_message.should eq("Not Found")
-      response.headers.length.should eq(0)
-      response.body.should eq("")
-      response.body?.should be_nil
+      expect(response.status_code).to eq(404)
+      expect(response.status_message).to eq("Not Found")
+      expect(response.headers.length).to eq(0)
+      expect(response.body).to eq("")
+      expect(response.body?).to be_nil
     end
 
     it "parses response with chunked body" do
       response = Response.from_io(io = StringIO.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n"))
-      response.body.should eq("abcde0123456789")
-      io.gets.should be_nil
+      expect(response.body).to eq("abcde0123456789")
+      expect(io.gets).to be_nil
     end
 
     it "serialize with body" do
@@ -46,33 +46,33 @@ module HTTP
       response = Response.new(200, "hello", headers)
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nhello")
+      expect(io.to_s).to eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nhello")
     end
 
     it "sets content length from body" do
       response = Response.new(200, "hello")
-      response.headers["Content-Length"].should eq("5")
+      expect(response.headers["Content-Length"]).to eq("5")
     end
 
     it "builds default not found" do
       response = Response.not_found
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 404 Not Found\r\nContent-type: text/plain\r\nContent-length: 9\r\n\r\nNot Found")
+      expect(io.to_s).to eq("HTTP/1.1 404 Not Found\r\nContent-type: text/plain\r\nContent-length: 9\r\n\r\nNot Found")
     end
 
     it "builds default ok response" do
       response = Response.ok("text/plain", "Hello")
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nHello")
+      expect(io.to_s).to eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nHello")
     end
 
     it "builds default error response" do
       response = Response.error("text/plain", "Error!")
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-type: text/plain\r\nContent-length: 6\r\n\r\nError!")
+      expect(io.to_s).to eq("HTTP/1.1 500 Internal Server Error\r\nContent-type: text/plain\r\nContent-length: 6\r\n\r\nError!")
     end
   end
 end

--- a/spec/std/http/server/handlers/websocket_handler_spec.cr
+++ b/spec/std/http/server/handlers/websocket_handler_spec.cr
@@ -5,8 +5,8 @@ describe HTTP::WebSocketHandler do
   it "returns not found if the request is not an websocket upgrade" do
     handler = HTTP::WebSocketHandler.new {}
     response = handler.call HTTP::Request.new("GET", "/")
-    response.status_code.should eq(404)
-    response.upgrade_handler.should be_nil
+    expect(response.status_code).to eq(404)
+    expect(response.upgrade_handler).to be_nil
   end
 
   it "gives upgrade response for websocket upgrade request" do
@@ -18,10 +18,10 @@ describe HTTP::WebSocketHandler do
     }
     request = HTTP::Request.new("GET", "/", headers)
     response = handler.call request
-    response.status_code.should eq(101)
-    response.headers["Upgrade"].should eq("websocket")
-    response.headers["Connection"].should eq("Upgrade")
-    response.headers["Sec-WebSocket-Accept"].should eq("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
-    response.upgrade_handler.should_not be_nil
+    expect(response.status_code).to eq(101)
+    expect(response.headers["Upgrade"]).to eq("websocket")
+    expect(response.headers["Connection"]).to eq("Upgrade")
+    expect(response.headers["Sec-WebSocket-Accept"]).to eq("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+    expect(response.upgrade_handler).to_not be_nil
   end
 end

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -15,10 +15,10 @@ describe HTTP::WebSocket do
 
       buffer = Slice(UInt8).new(64)
       result = ws.receive(buffer)
-      result.type.should eq(:text)
-      result.length.should eq(5)
-      result.final?.should be_true
-      String.new(buffer[0, result.length]).should eq("Hello")
+      expect(result.type).to eq(:text)
+      expect(result.length).to eq(5)
+      expect(result.final?).to be_true
+      expect(String.new(buffer[0, result.length])).to eq("Hello")
     end
 
     it "can read partial packets" do
@@ -31,16 +31,16 @@ describe HTTP::WebSocket do
 
       2.times do
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(3)
-        result.final?.should be_false
-        String.new(buffer).should eq("Hel")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(3)
+        expect(result.final?).to be_false
+        expect(String.new(buffer)).to eq("Hel")
 
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(2)
-        result.final?.should be_true
-        String.new(buffer[0, 2]).should eq("lo")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(2)
+        expect(result.final?).to be_true
+        expect(String.new(buffer[0, 2])).to eq("lo")
       end
     end
 
@@ -54,16 +54,16 @@ describe HTTP::WebSocket do
 
       2.times do
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(3)
-        result.final?.should be_false
-        String.new(buffer).should eq("Hel")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(3)
+        expect(result.final?).to be_false
+        expect(String.new(buffer)).to eq("Hel")
 
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(2)
-        result.final?.should be_true
-        String.new(buffer[0, 2]).should eq("lo")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(2)
+        expect(result.final?).to be_true
+        expect(String.new(buffer[0, 2])).to eq("lo")
       end
     end
 
@@ -78,16 +78,16 @@ describe HTTP::WebSocket do
 
       2.times do
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(3)
-        result.final?.should be_false
-        String.new(buffer[0, 3]).should eq("Hel")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(3)
+        expect(result.final?).to be_false
+        expect(String.new(buffer[0, 3])).to eq("Hel")
 
         result = ws.receive(buffer)
-        result.type.should eq(:text)
-        result.length.should eq(2)
-        result.final?.should be_true
-        String.new(buffer[0, 2]).should eq("lo")
+        expect(result.type).to eq(:text)
+        expect(result.length).to eq(2)
+        expect(result.final?).to be_true
+        expect(String.new(buffer[0, 2])).to eq("lo")
       end
     end
 
@@ -98,10 +98,10 @@ describe HTTP::WebSocket do
 
       buffer = Slice(UInt8).new(64)
       result = ws.receive(buffer)
-      result.type.should eq(:ping)
-      result.length.should eq(5)
-      result.final?.should be_true
-      String.new(buffer[0, result.length]).should eq("Hello")
+      expect(result.type).to eq(:ping)
+      expect(result.length).to eq(5)
+      expect(result.final?).to be_true
+      expect(String.new(buffer[0, result.length])).to eq("Hello")
     end
 
     it "read ping packet in between fragmented packet" do
@@ -114,22 +114,22 @@ describe HTTP::WebSocket do
       buffer = Slice(UInt8).new(64)
 
       result = ws.receive(buffer)
-      result.type.should eq(:text)
-      result.length.should eq(3)
-      result.final?.should be_false
-      String.new(buffer[0, 3]).should eq("Hel")
+      expect(result.type).to eq(:text)
+      expect(result.length).to eq(3)
+      expect(result.final?).to be_false
+      expect(String.new(buffer[0, 3])).to eq("Hel")
 
       result = ws.receive(buffer)
-      result.type.should eq(:ping)
-      result.length.should eq(5)
-      result.final?.should be_true
-      String.new(buffer[0, result.length]).should eq("Hello")
+      expect(result.type).to eq(:ping)
+      expect(result.length).to eq(5)
+      expect(result.final?).to be_true
+      expect(String.new(buffer[0, result.length])).to eq("Hello")
 
       result = ws.receive(buffer)
-      result.type.should eq(:text)
-      result.length.should eq(2)
-      result.final?.should be_true
-      String.new(buffer[0, 2]).should eq("lo")
+      expect(result.type).to eq(:text)
+      expect(result.length).to eq(2)
+      expect(result.final?).to be_true
+      expect(String.new(buffer[0, 2])).to eq("lo")
     end
 
     it "read long packet" do
@@ -140,10 +140,10 @@ describe HTTP::WebSocket do
       buffer = Slice(UInt8).new(2048)
 
       result = ws.receive(buffer)
-      result.type.should eq(:text)
-      result.length.should eq(1023)
-      result.final?.should be_true
-      String.new(buffer[0, 1023]).should eq("x" * 1023)
+      expect(result.type).to eq(:text)
+      expect(result.length).to eq(1023)
+      expect(result.final?).to be_true
+      expect(String.new(buffer[0, 1023])).to eq("x" * 1023)
     end
   end
 end

--- a/spec/std/inifile_spec.cr
+++ b/spec/std/inifile_spec.cr
@@ -4,23 +4,23 @@ require "inifile"
 describe "IniFile" do
   describe "parse from string" do
     it "parses key = value" do
-      IniFile.load("key = value").should eq({"" => {"key" => "value"}})
+      expect(IniFile.load("key = value")).to eq({"" => {"key" => "value"}})
     end
 
     it "ignores whitespaces" do
-      IniFile.load("   key   =   value  ").should eq({"" => {"key" => "value"}})
+      expect(IniFile.load("   key   =   value  ")).to eq({"" => {"key" => "value"}})
     end
 
     it "parses sections" do
-      IniFile.load("[section]\na = 1").should eq({"section" => {"a" => "1"}})
+      expect(IniFile.load("[section]\na = 1")).to eq({"section" => {"a" => "1"}})
     end
 
     it "empty section" do
-      IniFile.load("[section]").should eq({"section" => {} of String => String})
+      expect(IniFile.load("[section]")).to eq({"section" => {} of String => String})
     end
 
     it "parse file" do
-      IniFile.load(File.read "#{__DIR__}/data/test_file.ini").should eq({
+      expect(IniFile.load(File.read "#{__DIR__}/data/test_file.ini")).to eq({
         "general" => {
           "log_level" => "DEBUG"
         },

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -2,63 +2,63 @@ require "spec"
 
 describe "Int" do
   describe "**" do
-    assert { (2 ** 2).should eq(4) }
-    assert { (2 ** 2.5_f32).should eq(5.656854249492381) }
-    assert { (2 ** 2.5).should eq(5.656854249492381) }
+    assert { expect((2 ** 2)).to eq(4) }
+    assert { expect((2 ** 2.5_f32)).to eq(5.656854249492381) }
+    assert { expect((2 ** 2.5)).to eq(5.656854249492381) }
   end
 
   describe "divisible_by?" do
-    assert { 10.divisible_by?(5).should be_true }
-    assert { 10.divisible_by?(3).should be_false }
+    assert { expect(10.divisible_by?(5)).to be_true }
+    assert { expect(10.divisible_by?(3)).to be_false }
   end
 
   describe "even?" do
-    assert { 2.even?.should be_true }
-    assert { 3.even?.should be_false }
+    assert { expect(2.even?).to be_true }
+    assert { expect(3.even?).to be_false }
   end
 
   describe "odd?" do
-    assert { 2.odd?.should be_false }
-    assert { 3.odd?.should be_true }
+    assert { expect(2.odd?).to be_false }
+    assert { expect(3.odd?).to be_true }
   end
 
   describe "abs" do
     it "does for signed" do
-      1_i8.abs.should eq(1_i8)
-      -1_i8.abs.should eq(1_i8)
-      1_i16.abs.should eq(1_i16)
-      -1_i16.abs.should eq(1_i16)
-      1_i32.abs.should eq(1_i32)
-      -1_i32.abs.should eq(1_i32)
-      1_i64.abs.should eq(1_i64)
-      -1_i64.abs.should eq(1_i64)
+      expect(1_i8.abs).to eq(1_i8)
+      expect(-1_i8.abs).to eq(1_i8)
+      expect(1_i16.abs).to eq(1_i16)
+      expect(-1_i16.abs).to eq(1_i16)
+      expect(1_i32.abs).to eq(1_i32)
+      expect(-1_i32.abs).to eq(1_i32)
+      expect(1_i64.abs).to eq(1_i64)
+      expect(-1_i64.abs).to eq(1_i64)
     end
 
     it "does for unsigned" do
-      1_u8.abs.should eq(1_u8)
-      1_u16.abs.should eq(1_u16)
-      1_u32.abs.should eq(1_u32)
-      1_u64.abs.should eq(1_u64)
+      expect(1_u8.abs).to eq(1_u8)
+      expect(1_u16.abs).to eq(1_u16)
+      expect(1_u32.abs).to eq(1_u32)
+      expect(1_u64.abs).to eq(1_u64)
     end
   end
 
   describe "lcm" do
-    assert { 2.lcm(2).should eq(2) }
-    assert { 3.lcm(-7).should eq(21) }
-    assert { 4.lcm(6).should eq(12) }
-    assert { 0.lcm(2).should eq(0) }
-    assert { 2.lcm(0).should eq(0) }
+    assert { expect(2.lcm(2)).to eq(2) }
+    assert { expect(3.lcm(-7)).to eq(21) }
+    assert { expect(4.lcm(6)).to eq(12) }
+    assert { expect(0.lcm(2)).to eq(0) }
+    assert { expect(2.lcm(0)).to eq(0) }
   end
 
   describe "to_s in base" do
-    assert { 12.to_s(2).should eq("1100") }
-    assert { -12.to_s(2).should eq("-1100") }
-    assert { -123456.to_s(2).should eq("-11110001001000000") }
-    assert { 1234.to_s(16).should eq("4D2") }
-    assert { -1234.to_s(16).should eq("-4D2") }
-    assert { 1234.to_s(36).should eq("YA") }
-    assert { -1234.to_s(36).should eq("-YA") }
-    assert { 0.to_s(16).should eq("0") }
+    assert { expect(12.to_s(2)).to eq("1100") }
+    assert { expect(-12.to_s(2)).to eq("-1100") }
+    assert { expect(-123456.to_s(2)).to eq("-11110001001000000") }
+    assert { expect(1234.to_s(16)).to eq("4D2") }
+    assert { expect(-1234.to_s(16)).to eq("-4D2") }
+    assert { expect(1234.to_s(36)).to eq("YA") }
+    assert { expect(-1234.to_s(36)).to eq("-YA") }
+    assert { expect(0.to_s(16)).to eq("0") }
 
     it "raises on base 1" do
       expect_raises { 123.to_s(1) }
@@ -70,68 +70,68 @@ describe "Int" do
   end
 
   describe "bit" do
-    assert { 5.bit(0).should eq(1) }
-    assert { 5.bit(1).should eq(0) }
-    assert { 5.bit(2).should eq(1) }
-    assert { 5.bit(3).should eq(0) }
+    assert { expect(5.bit(0)).to eq(1) }
+    assert { expect(5.bit(1)).to eq(0) }
+    assert { expect(5.bit(2)).to eq(1) }
+    assert { expect(5.bit(3)).to eq(0) }
   end
 
   describe "divmod" do
-    assert { 5.divmod(3).should eq({1, 2}) }
+    assert { expect(5.divmod(3)).to eq({1, 2}) }
   end
 
   describe "fdiv" do
-    assert { 1.fdiv(1).should eq 1.0 }
-    assert { 1.fdiv(2).should eq 0.5 }
-    assert { 1.fdiv(0.5).should eq 2.0 }
-    assert { 0.fdiv(1).should eq 0.0 }
-    assert { 1.fdiv(0).should eq 1.0/0.0 }
+    assert { expect(1.fdiv(1)).to eq 1.0 }
+    assert { expect(1.fdiv(2)).to eq 0.5 }
+    assert { expect(1.fdiv(0.5)).to eq 2.0 }
+    assert { expect(0.fdiv(1)).to eq 0.0 }
+    assert { expect(1.fdiv(0)).to eq 1.0/0.0 }
   end
 
   describe "~" do
-    assert { (~1).should eq(-2) }
-    assert { (~1_u32).should eq(4294967294) }
+    assert { expect((~1)).to eq(-2) }
+    assert { expect((~1_u32)).to eq(4294967294) }
   end
 
   describe "to" do
     it "does upwards" do
       a = 0
       1.to(3) { |i| a += i }
-      a.should eq(6)
+      expect(a).to eq(6)
     end
 
     it "does downards" do
       a = 0
       4.to(2) { |i| a += i }
-      a.should eq(9)
+      expect(a).to eq(9)
     end
 
     it "does when same" do
       a = 0
       2.to(2) { |i| a += i }
-      a.should eq(2)
+      expect(a).to eq(2)
     end
   end
 
   describe "to_s" do
     it "does to_s for various int sizes" do
-      127_i8.to_s.should eq("127")
-      -128_i8.to_s.should eq("-128")
+      expect(127_i8.to_s).to eq("127")
+      expect(-128_i8.to_s).to eq("-128")
 
-      32767_i16.to_s.should eq("32767")
-      -32768_i16.to_s.should eq("-32768")
+      expect(32767_i16.to_s).to eq("32767")
+      expect(-32768_i16.to_s).to eq("-32768")
 
-      2147483647.to_s.should eq("2147483647")
-      -2147483648.to_s.should eq("-2147483648")
+      expect(2147483647.to_s).to eq("2147483647")
+      expect(-2147483648.to_s).to eq("-2147483648")
 
-      9223372036854775807_i64.to_s.should eq("9223372036854775807")
-      -9223372036854775808_i64.to_s.should eq("-9223372036854775808")
+      expect(9223372036854775807_i64.to_s).to eq("9223372036854775807")
+      expect(-9223372036854775808_i64.to_s).to eq("-9223372036854775808")
 
-      255_u8.to_s.should eq("255")
-      65535_u16.to_s.should eq("65535")
-      4294967295_u32.to_s.should eq("4294967295")
+      expect(255_u8.to_s).to eq("255")
+      expect(65535_u16.to_s).to eq("65535")
+      expect(4294967295_u32.to_s).to eq("4294967295")
 
-      18446744073709551615_u64.to_s.should eq("18446744073709551615")
+      expect(18446744073709551615_u64.to_s).to eq("18446744073709551615")
     end
   end
 
@@ -144,38 +144,38 @@ describe "Int" do
   end
 
   it "casts" do
-    Int8.cast(1).should be_a(Int8)
-    Int8.cast(1).should eq(1)
+    expect(Int8.cast(1)).to be_a(Int8)
+    expect(Int8.cast(1)).to eq(1)
 
-    Int16.cast(1).should be_a(Int16)
-    Int16.cast(1).should eq(1)
+    expect(Int16.cast(1)).to be_a(Int16)
+    expect(Int16.cast(1)).to eq(1)
 
-    Int32.cast(1).should be_a(Int32)
-    Int32.cast(1).should eq(1)
+    expect(Int32.cast(1)).to be_a(Int32)
+    expect(Int32.cast(1)).to eq(1)
 
-    Int64.cast(1).should be_a(Int64)
-    Int64.cast(1).should eq(1)
+    expect(Int64.cast(1)).to be_a(Int64)
+    expect(Int64.cast(1)).to eq(1)
 
-    UInt8.cast(1).should be_a(UInt8)
-    UInt8.cast(1).should eq(1)
+    expect(UInt8.cast(1)).to be_a(UInt8)
+    expect(UInt8.cast(1)).to eq(1)
 
-    UInt16.cast(1).should be_a(UInt16)
-    UInt16.cast(1).should eq(1)
+    expect(UInt16.cast(1)).to be_a(UInt16)
+    expect(UInt16.cast(1)).to eq(1)
 
-    UInt32.cast(1).should be_a(UInt32)
-    UInt32.cast(1).should eq(1)
+    expect(UInt32.cast(1)).to be_a(UInt32)
+    expect(UInt32.cast(1)).to eq(1)
 
-    UInt64.cast(1).should be_a(UInt64)
-    UInt64.cast(1).should eq(1)
+    expect(UInt64.cast(1)).to be_a(UInt64)
+    expect(UInt64.cast(1)).to eq(1)
   end
 
   it "raises when divides by zero" do
     expect_raises(DivisionByZero) { 1 / 0 }
-    (4 / 2).should eq(2)
+    expect((4 / 2)).to eq(2)
   end
 
   it "raises when mods by zero" do
     expect_raises(DivisionByZero) { 1 % 0 }
-    (4 % 2).should eq(0)
+    expect((4 % 2)).to eq(0)
   end
 end

--- a/spec/std/io/buffered_io_spec.cr
+++ b/spec/std/io/buffered_io_spec.cr
@@ -3,72 +3,72 @@ require "spec"
 describe "BufferedIO" do
   it "does gets" do
     io = BufferedIO.new(StringIO.new("hello\nworld\n"))
-    io.gets.should eq("hello\n")
-    io.gets.should eq("world\n")
-    io.gets.should be_nil
+    expect(io.gets).to eq("hello\n")
+    expect(io.gets).to eq("world\n")
+    expect(io.gets).to be_nil
   end
 
   it "does gets with big line" do
     big_line = "a" * 20_000
     io = BufferedIO.new(StringIO.new("#{big_line}\nworld\n"))
-    io.gets.should eq("#{big_line}\n")
+    expect(io.gets).to eq("#{big_line}\n")
   end
 
   it "does gets with char delimiter" do
     io = BufferedIO.new(StringIO.new("hello world"))
-    io.gets('w').should eq("hello w")
-    io.gets('r').should eq("or")
-    io.gets('r').should eq("ld")
-    io.gets('r').should be_nil
+    expect(io.gets('w')).to eq("hello w")
+    expect(io.gets('r')).to eq("or")
+    expect(io.gets('r')).to eq("ld")
+    expect(io.gets('r')).to be_nil
   end
 
   it "does gets with unicode char delimiter" do
     io = BufferedIO.new(StringIO.new("こんにちは"))
-    io.gets('ち').should eq("こんにち")
-    io.gets('ち').should eq("は")
-    io.gets('ち').should be_nil
+    expect(io.gets('ち')).to eq("こんにち")
+    expect(io.gets('ち')).to eq("は")
+    expect(io.gets('ち')).to be_nil
   end
 
   it "does puts" do
     str = StringIO.new
     io = BufferedIO.new(str)
     io.puts "Hello"
-    str.to_s.should eq("")
+    expect(str.to_s).to eq("")
     io.flush
-    str.to_s.should eq("Hello\n")
+    expect(str.to_s).to eq("Hello\n")
   end
 
   it "does read" do
     io = BufferedIO.new(StringIO.new("hello world"))
-    io.read(5).should eq("hello")
-    io.read(10).should eq(" world")
-    io.read(5).should eq("")
+    expect(io.read(5)).to eq("hello")
+    expect(io.read(10)).to eq(" world")
+    expect(io.read(5)).to eq("")
   end
 
   it "reads char" do
     io = BufferedIO.new(StringIO.new("hi 世界"))
-    io.read_char.should eq('h')
-    io.read_char.should eq('i')
-    io.read_char.should eq(' ')
-    io.read_char.should eq('世')
-    io.read_char.should eq('界')
-    io.read_char.should be_nil
+    expect(io.read_char).to eq('h')
+    expect(io.read_char).to eq('i')
+    expect(io.read_char).to eq(' ')
+    expect(io.read_char).to eq('世')
+    expect(io.read_char).to eq('界')
+    expect(io.read_char).to be_nil
   end
 
   it "reads byte" do
     io = BufferedIO.new(StringIO.new("hello"))
-    io.read_byte.should eq('h'.ord)
-    io.read_byte.should eq('e'.ord)
-    io.read_byte.should eq('l'.ord)
-    io.read_byte.should eq('l'.ord)
-    io.read_byte.should eq('o'.ord)
-    io.read_char.should be_nil
+    expect(io.read_byte).to eq('h'.ord)
+    expect(io.read_byte).to eq('e'.ord)
+    expect(io.read_byte).to eq('l'.ord)
+    expect(io.read_byte).to eq('l'.ord)
+    expect(io.read_byte).to eq('o'.ord)
+    expect(io.read_char).to be_nil
   end
 
   it "does new with block" do
     str = StringIO.new
     res = BufferedIO.new str, &.print "Hello"
-    res.should be(str)
-    str.to_s.should eq("Hello")
+    expect(res).to be(str)
+    expect(str.to_s).to eq("Hello")
   end
 end

--- a/spec/std/io/string_io_spec.cr
+++ b/spec/std/io/string_io_spec.cr
@@ -5,28 +5,28 @@ describe "StringIO" do
     str = String.build do |io|
       io << 'a'
     end
-    str.should eq("a")
+    expect(str).to eq("a")
   end
 
   it "appends a string" do
     str = String.build do |io|
       io << "hello"
     end
-    str.should eq("hello")
+    expect(str).to eq("hello")
   end
 
   it "writes to a buffer with count" do
     str = String.build do |io|
       io.write Slice.new("hello".cstr, 3)
     end
-    str.should eq("hel")
+    expect(str).to eq("hel")
   end
 
   it "appends a byte" do
     str = String.build do |io|
       io.write_byte 'a'.ord.to_u8
     end
-    str.should eq("a")
+    expect(str).to eq("a")
   end
 
   it "appends to another buffer" do
@@ -35,90 +35,90 @@ describe "StringIO" do
 
     s2 = StringIO.new
     s1.to_s(s2)
-    s2.to_s.should eq("hello")
+    expect(s2.to_s).to eq("hello")
   end
 
   it "writes" do
     io = StringIO.new
     io << "foo" << "bar"
-    io.to_s.should eq("foobar")
+    expect(io.to_s).to eq("foobar")
   end
 
   it "puts" do
     io = StringIO.new
     io.puts "foo"
-    io.to_s.should eq("foo\n")
+    expect(io.to_s).to eq("foo\n")
   end
 
   it "print" do
     io = StringIO.new
     io.print "foo"
-    io.to_s.should eq("foo")
+    expect(io.to_s).to eq("foo")
   end
 
   it "reads single line content" do
     io = StringIO.new("foo")
-    io.gets.should eq("foo")
+    expect(io.gets).to eq("foo")
   end
 
   it "reads each line" do
     io = StringIO.new("foo\r\nbar\r\n")
-    io.gets.should eq("foo\r\n")
-    io.gets.should eq("bar\r\n")
-    io.gets.should eq(nil)
+    expect(io.gets).to eq("foo\r\n")
+    expect(io.gets).to eq("bar\r\n")
+    expect(io.gets).to eq(nil)
   end
 
   it "gets with char as delimiter" do
     io = StringIO.new("hello world")
-    io.gets('w').should eq("hello w")
-    io.gets('r').should eq("or")
-    io.gets('r').should eq("ld")
-    io.gets('r').should eq(nil)
+    expect(io.gets('w')).to eq("hello w")
+    expect(io.gets('r')).to eq("or")
+    expect(io.gets('r')).to eq("ld")
+    expect(io.gets('r')).to eq(nil)
   end
 
   it "reads all remaining content" do
     io = StringIO.new("foo\nbar\nbaz\n")
-    io.gets.should eq("foo\n")
-    io.read.should eq("bar\nbaz\n")
+    expect(io.gets).to eq("foo\n")
+    expect(io.read).to eq("bar\nbaz\n")
   end
 
   it "reads utf-8 string" do
     io = StringIO.new("há日本語")
-    io.gets.should eq("há日本語")
+    expect(io.gets).to eq("há日本語")
   end
 
   it "reads N chars" do
     io = StringIO.new("foobarbaz")
-    io.read(3).should eq("foo")
-    io.read(50).should eq("barbaz")
+    expect(io.read(3)).to eq("foo")
+    expect(io.read(50)).to eq("barbaz")
   end
 
   it "write single byte" do
     io = StringIO.new
     io.write_byte 97_u8
-    io.to_s.should eq("a")
+    expect(io.to_s).to eq("a")
   end
 
   it "writes and reads" do
     io = StringIO.new
     io << "foo" << "bar"
-    io.gets.should eq("foobar")
+    expect(io.gets).to eq("foobar")
   end
 
   it "does puts" do
     io = StringIO.new
     io.puts
-    io.to_s.should eq("\n")
+    expect(io.to_s).to eq("\n")
   end
 
   it "read chars from UTF-8 string" do
     io = StringIO.new("há日本語")
-    io.read_char.should eq('h')
-    io.read_char.should eq('á')
-    io.read_char.should eq('日')
-    io.read_char.should eq('本')
-    io.read_char.should eq('語')
-    io.read_char.should eq(nil)
+    expect(io.read_char).to eq('h')
+    expect(io.read_char).to eq('á')
+    expect(io.read_char).to eq('日')
+    expect(io.read_char).to eq('本')
+    expect(io.read_char).to eq('語')
+    expect(io.read_char).to eq(nil)
   end
 
   it "does each_line" do
@@ -127,15 +127,15 @@ describe "StringIO" do
     io.each_line do |line|
       case counter
       when 0
-        line.should eq("a\n")
+        expect(line).to eq("a\n")
       when 1
-        line.should eq("bb\n")
+        expect(line).to eq("bb\n")
       when 2
-        line.should eq("cc")
+        expect(line).to eq("cc")
       end
       counter += 1
     end
-    counter.should eq(3)
+    expect(counter).to eq(3)
   end
 
   it "writes an array of btyes" do
@@ -143,12 +143,12 @@ describe "StringIO" do
       bytes = ['a'.ord.to_u8, 'b'.ord.to_u8]
       io.write bytes
     end
-    str.should eq("ab")
+    expect(str).to eq("ab")
   end
 
   it "raises on EOF with read_line" do
     str = StringIO.new("hello")
-    str.read_line.should eq("hello")
+    expect(str.read_line).to eq("hello")
 
     expect_raises IO::EOFError, "end of file reached" do
       str.read_line
@@ -157,8 +157,8 @@ describe "StringIO" do
 
   it "raises on EOF with readline and delimiter" do
     str = StringIO.new("hello")
-    str.read_line('e').should eq("he")
-    str.read_line('e').should eq("llo")
+    expect(str.read_line('e')).to eq("he")
+    expect(str.read_line('e')).to eq("llo")
 
     expect_raises IO::EOFError, "end of file reached" do
       str.read_line
@@ -168,12 +168,12 @@ describe "StringIO" do
   it "writes with printf" do
     str = StringIO.new
     str.printf "Hello %d", 123
-    str.to_s.should eq("Hello 123")
+    expect(str.to_s).to eq("Hello 123")
   end
 
   it "writes with printf as an array" do
     str = StringIO.new
     str.printf "Hello %d", [123]
-    str.to_s.should eq("Hello 123")
+    expect(str.to_s).to eq("Hello 123")
   end
 end

--- a/spec/std/io_spec.cr
+++ b/spec/std/io_spec.cr
@@ -14,19 +14,19 @@ describe "IO" do
       with_pipe do |read, write|
         write.puts "hey"
         write.close
-        IO.select({read}).includes?(read).should be_true
+        expect(IO.select({read}).includes?(read)).to be_true
       end
     end
 
     it "returns the available writable ios" do
       with_pipe do |read, write|
-        IO.select(nil, {write}).includes?(write).should be_true
+        expect(IO.select(nil, {write}).includes?(write)).to be_true
       end
     end
 
     it "times out" do
       with_pipe do |read, write|
-        IO.select({read}, nil, nil, 0.00001).should be_nil
+        expect(IO.select({read}, nil, nil, 0.00001)).to be_nil
       end
     end
   end

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -6,10 +6,10 @@ describe Iterator do
     it "does next" do
       a = [1, 2, 3]
       iterator = a.iterator
-      iterator.next.should eq(1)
-      iterator.next.should eq(2)
-      iterator.next.should eq(3)
-      iterator.next.should eq(Iterator::Stop::INSTANCE)
+      expect(iterator.next).to eq(1)
+      expect(iterator.next).to eq(2)
+      expect(iterator.next).to eq(3)
+      expect(iterator.next).to eq(Iterator::Stop::INSTANCE)
     end
   end
 
@@ -17,52 +17,52 @@ describe Iterator do
     it "does next with inclusive range" do
       a = 1..3
       iterator = a.iterator
-      iterator.next.should eq(1)
-      iterator.next.should eq(2)
-      iterator.next.should eq(3)
-      iterator.next.should eq(Iterator::Stop::INSTANCE)
+      expect(iterator.next).to eq(1)
+      expect(iterator.next).to eq(2)
+      expect(iterator.next).to eq(3)
+      expect(iterator.next).to eq(Iterator::Stop::INSTANCE)
     end
 
     it "does next with exclusive range" do
       r = 1...3
       iterator = r.iterator
-      iterator.next.should eq(1)
-      iterator.next.should eq(2)
-      iterator.next.should eq(Iterator::Stop::INSTANCE)
+      expect(iterator.next).to eq(1)
+      expect(iterator.next).to eq(2)
+      expect(iterator.next).to eq(Iterator::Stop::INSTANCE)
     end
   end
 
   describe "map" do
     it "does map with Range iterator" do
-      (1..3).iterator.map { |x| x * 2 }.to_a.should eq([2, 4, 6])
+      expect((1..3).iterator.map { |x| x * 2 }.to_a).to eq([2, 4, 6])
     end
   end
 
   describe "select" do
     it "does select with Range iterator" do
-      (1..3).iterator.select { |x| x >= 2 }.to_a.should eq([2, 3])
+      expect((1..3).iterator.select { |x| x >= 2 }.to_a).to eq([2, 3])
     end
   end
 
   describe "reject" do
     it "does reject with Range iterator" do
-      (1..3).iterator.reject { |x| x >= 2 }.to_a.should eq([1])
+      expect((1..3).iterator.reject { |x| x >= 2 }.to_a).to eq([1])
     end
   end
 
   describe "take" do
     it "does take with Range iterator" do
-      (1..3).iterator.take(2).to_a.should eq([1, 2])
+      expect((1..3).iterator.take(2).to_a).to eq([1, 2])
     end
 
     it "does take with more than available" do
-      (1..3).iterator.take(10).to_a.should eq([1, 2, 3])
+      expect((1..3).iterator.take(10).to_a).to eq([1, 2, 3])
     end
   end
 
   describe "skip" do
     it "does skip with Range iterator" do
-      (1..3).iterator.skip(2).to_a.should eq([3])
+      expect((1..3).iterator.skip(2).to_a).to eq([3])
     end
   end
 
@@ -70,34 +70,34 @@ describe Iterator do
     it "does skip with Range iterator" do
       r1 = (1..3).iterator
       r2 = (4..6).iterator
-      r1.zip(r2).to_a.should eq([{1, 4}, {2, 5}, {3, 6}])
+      expect(r1.zip(r2).to_a).to eq([{1, 4}, {2, 5}, {3, 6}])
     end
   end
 
   describe "cycle" do
     it "does cycle from range" do
-      (1..3).iterator.cycle.take(10).to_a.should eq([1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
+      expect((1..3).iterator.cycle.take(10).to_a).to eq([1, 2, 3, 1, 2, 3, 1, 2, 3, 1])
     end
 
     it "cycles an empty array" do
       ary = [] of Int32
       values = ary.iterator.cycle.to_a
-      values.empty?.should be_true
+      expect(values.empty?).to be_true
     end
   end
 
   describe "with_index" do
     it "does with_index from range" do
-      (1..3).iterator.with_index.to_a.should eq([{1, 0}, {2, 1}, {3, 2}])
+      expect((1..3).iterator.with_index.to_a).to eq([{1, 0}, {2, 1}, {3, 2}])
     end
   end
 
   it "combines many iterators" do
-    (1..100).iterator
-            .select { |x| 50 <= x < 60 }
-            .map { |x| x * 2 }
-            .take(3)
-            .to_a
-            .should eq([100, 102, 104])
+    expect((1..100).iterator
+                   .select { |x| 50 <= x < 60 }
+                   .map { |x| x * 2 }
+                   .take(3)
+                   .to_a
+                   ).to eq([100, 102, 104])
   end
 end

--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -5,13 +5,13 @@ private def it_lexes(string, expected_type, file = __FILE__, line = __LINE__)
   it "lexes #{string} from string", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(expected_type)
+    expect(token.type).to eq(expected_type)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new StringIO.new(string)
     token = lexer.next_token
-    token.type.should eq(expected_type)
+    expect(token.type).to eq(expected_type)
   end
 end
 
@@ -19,15 +19,15 @@ private def it_lexes_string(string, string_value, file = __FILE__, line = __LINE
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.string_value.should eq(string_value)
+    expect(token.type).to eq(:STRING)
+    expect(token.string_value).to eq(string_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new StringIO.new(string)
     token = lexer.next_token
-    token.type.should eq(:STRING)
-    token.string_value.should eq(string_value)
+    expect(token.type).to eq(:STRING)
+    expect(token.string_value).to eq(string_value)
   end
 end
 
@@ -35,15 +35,15 @@ private def it_lexes_int(string, int_value, file = __FILE__, line = __LINE__)
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:INT)
-    token.int_value.should eq(int_value)
+    expect(token.type).to eq(:INT)
+    expect(token.int_value).to eq(int_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new StringIO.new(string)
     token = lexer.next_token
-    token.type.should eq(:INT)
-    token.int_value.should eq(int_value)
+    expect(token.type).to eq(:INT)
+    expect(token.int_value).to eq(int_value)
   end
 end
 
@@ -51,15 +51,15 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
   it "lexes #{string} from String", file, line do
     lexer = JSON::Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:FLOAT)
-    token.float_value.should eq(float_value)
+    expect(token.type).to eq(:FLOAT)
+    expect(token.float_value).to eq(float_value)
   end
 
   it "lexes #{string} from IO", file, line do
     lexer = JSON::Lexer.new StringIO.new(string)
     token = lexer.next_token
-    token.type.should eq(:FLOAT)
-    token.float_value.should eq(float_value)
+    expect(token.type).to eq(:FLOAT)
+    expect(token.float_value).to eq(float_value)
   end
 end
 

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -72,35 +72,35 @@ end
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
-    person.should be_a(JSONPerson)
-    person.name.should eq("John")
-    person.age.should eq(30)
+    expect(person).to be_a(JSONPerson)
+    expect(person.name).to eq("John")
+    expect(person.age).to eq(30)
   end
 
   it "parses person without age" do
     person = JSONPerson.from_json(%({"name": "John"}))
-    person.should be_a(JSONPerson)
-    person.name.should eq("John")
-    person.name.length.should eq(4) # This verifies that name is not nilable
-    person.age.should be_nil
+    expect(person).to be_a(JSONPerson)
+    expect(person.name).to eq("John")
+    expect(person.name.length).to eq(4) # This verifies that name is not nilable
+    expect(person.age).to be_nil
   end
 
   it "parses array of people" do
     people = Array(JSONPerson).from_json(%([{"name": "John"}, {"name": "Doe"}]))
-    people.length.should eq(2)
+    expect(people.length).to eq(2)
   end
 
   it "does to_json" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
     person2 = JSONPerson.from_json(person.to_json)
-    person2.should eq(person)
+    expect(person2).to eq(person)
   end
 
   it "parses person with unknown attributes" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30, "foo": "bar"}))
-    person.should be_a(JSONPerson)
-    person.name.should eq("John")
-    person.age.should eq(30)
+    expect(person).to be_a(JSONPerson)
+    expect(person.name).to eq("John")
+    expect(person.age).to eq(30)
   end
 
   it "parses strict person with unknown attributes" do
@@ -111,24 +111,24 @@ describe "JSON mapping" do
 
   it "doesn't emit null by default when doing to_json" do
     person = JSONPerson.from_json(%({"name": "John"}))
-    (person.to_json =~ /age/).should be_falsey
+    expect((person.to_json =~ /age/)).to be_falsey
   end
 
   it "emits null on request when doing to_json" do
     person = JSONPersonEmittingNull.from_json(%({"name": "John"}))
-    (person.to_json =~ /age/).should be_truthy
+    expect((person.to_json =~ /age/)).to be_truthy
   end
 
   it "doesn't raises on false value when not-nil" do
     json = JSONWithBool.from_json(%({"value": false}))
-    json.value.should be_false
+    expect(json.value).to be_false
   end
 
   it "parses json with TimeFormat converter" do
     json = JSONWithTime.from_json(%({"value": "2014-10-31 23:37:16"}))
-    json.value.should be_a(Time)
-    json.value.to_s.should eq("2014-10-31 23:37:16")
-    json.to_json.should eq(%({"value":"2014-10-31 23:37:16"}))
+    expect(json.value).to be_a(Time)
+    expect(json.value.to_s).to eq("2014-10-31 23:37:16")
+    expect(json.to_json).to eq(%({"value":"2014-10-31 23:37:16"}))
   end
 
   it "allows setting a nilable property to nil" do
@@ -139,31 +139,31 @@ describe "JSON mapping" do
 
   it "parses simple mapping" do
     person = JSONWithSimpleMapping.from_json(%({"name": "John", "age": 30}))
-    person.should be_a(JSONWithSimpleMapping)
-    person.name.should eq("John")
-    person.age.should eq(30)
+    expect(person).to be_a(JSONWithSimpleMapping)
+    expect(person.name).to eq("John")
+    expect(person.age).to eq(30)
   end
 
   it "outputs with converter when nilable" do
     json = JSONWithNilableTime.new
-    json.to_json.should eq("{}")
+    expect(json.to_json).to eq("{}")
   end
 
   it "outputs with converter when nilable when emit_null is true" do
     json = JSONWithNilableTimeEmittingNull.new
-    json.to_json.should eq(%({"value":null}))
+    expect(json.to_json).to eq(%({"value":null}))
   end
 
   it "parses json with keywords" do
     json = JSONWithKeywordsMapping.from_json(%({"end": 1, "abstract": 2}))
-    json.end.should eq(1)
-    json.abstract.should eq(2)
+    expect(json.end).to eq(1)
+    expect(json.abstract).to eq(2)
   end
 
   it "parses json with any" do
     json = JSONWithAny.from_json(%({"name": "Hi", "any": [{"x": 1}, 2, "hey", true, false, 1.5, null]}))
-    json.name.should eq("Hi")
-    json.any.should eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
-    json.to_json.should eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
+    expect(json.name).to eq("Hi")
+    expect(json.any).to eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
+    expect(json.to_json).to eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
   end
 end

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -3,7 +3,7 @@ require "json"
 
 private def it_parses(string, expected_value, file = __FILE__, line = __LINE__)
   it "parses #{string}", file, line do
-    JSON.parse(string).should eq(expected_value)
+    expect(JSON.parse(string)).to eq(expected_value)
   end
 end
 

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -3,42 +3,42 @@ require "json"
 
 class JSON::PullParser
   def assert(event_kind : Symbol)
-    kind.should eq(event_kind)
+    expect(kind).to eq(event_kind)
     read_next
   end
 
   def assert(value : Nil)
-    kind.should eq(:null)
+    expect(kind).to eq(:null)
     read_next
   end
 
   def assert(value : Int)
-    kind.should eq(:int)
-    int_value.should eq(value)
+    expect(kind).to eq(:int)
+    expect(int_value).to eq(value)
     read_next
   end
 
   def assert(value : Float)
-    kind.should eq(:float)
-    float_value.should eq(value)
+    expect(kind).to eq(:float)
+    expect(float_value).to eq(value)
     read_next
   end
 
   def assert(value : Bool)
-    kind.should eq(:bool)
-    bool_value.should eq(value)
+    expect(kind).to eq(:bool)
+    expect(bool_value).to eq(value)
     read_next
   end
 
   def assert(value : String)
-    kind.should eq(:string)
-    string_value.should eq(value)
+    expect(kind).to eq(:string)
+    expect(string_value).to eq(value)
     read_next
   end
 
   def assert(value : String)
-    kind.should eq(:object_key)
-    string_value.should eq(value)
+    expect(kind).to eq(:object_key)
+    expect(string_value).to eq(value)
     read_next
     yield
   end
@@ -62,10 +62,10 @@ class JSON::PullParser
   end
 
   def assert_array
-    kind.should eq(:begin_array)
+    expect(kind).to eq(:begin_array)
     read_next
     yield
-    kind.should eq(:end_array)
+    expect(kind).to eq(:end_array)
     read_next
   end
 
@@ -74,10 +74,10 @@ class JSON::PullParser
   end
 
   def assert_object
-    kind.should eq(:begin_object)
+    expect(kind).to eq(:begin_object)
     read_next
     yield
-    kind.should eq(:end_object)
+    expect(kind).to eq(:end_object)
     read_next
   end
 
@@ -96,7 +96,7 @@ private def assert_pull_parse(string)
   it "parses #{string}" do
     parser = JSON::PullParser.new string
     parser.assert JSON.parse(string)
-    parser.kind.should eq(:EOF)
+    expect(parser.kind).to eq(:EOF)
   end
 end
 
@@ -168,32 +168,32 @@ describe "JSON::PullParser" do
       it "skips #{tuple[0]}" do
         pull = JSON::PullParser.new("[1, #{tuple[1]}, 2]")
         pull.read_array do
-          pull.read_int.should eq(1)
+          expect(pull.read_int).to eq(1)
           pull.skip
-          pull.read_int.should eq(2)
+          expect(pull.read_int).to eq(2)
         end
       end
     end
   end
 
   it "reads bool or null" do
-    JSON::PullParser.new("null").read_bool_or_null.should be_nil
-    JSON::PullParser.new("false").read_bool_or_null.should be_false
+    expect(JSON::PullParser.new("null").read_bool_or_null).to be_nil
+    expect(JSON::PullParser.new("false").read_bool_or_null).to be_false
   end
 
   it "reads int or null" do
-    JSON::PullParser.new("null").read_int_or_null.should be_nil
-    JSON::PullParser.new("1").read_int_or_null.should eq(1)
+    expect(JSON::PullParser.new("null").read_int_or_null).to be_nil
+    expect(JSON::PullParser.new("1").read_int_or_null).to eq(1)
   end
 
   it "reads float or null" do
-    JSON::PullParser.new("null").read_float_or_null.should be_nil
-    JSON::PullParser.new("1.5").read_float_or_null.should eq(1.5)
+    expect(JSON::PullParser.new("null").read_float_or_null).to be_nil
+    expect(JSON::PullParser.new("1.5").read_float_or_null).to eq(1.5)
   end
 
   it "reads string or null" do
-    JSON::PullParser.new("null").read_string_or_null.should be_nil
-    JSON::PullParser.new(%("hello")).read_string_or_null.should eq("hello")
+    expect(JSON::PullParser.new("null").read_string_or_null).to be_nil
+    expect(JSON::PullParser.new(%("hello")).read_string_or_null).to eq("hello")
   end
 
   it "reads array or null" do
@@ -201,7 +201,7 @@ describe "JSON::PullParser" do
 
     pull = JSON::PullParser.new(%([1]))
     pull.read_array_or_null do
-      pull.read_int.should eq(1)
+      expect(pull.read_int).to eq(1)
     end
   end
 
@@ -210,8 +210,8 @@ describe "JSON::PullParser" do
 
     pull = JSON::PullParser.new(%({"foo": 1}))
     pull.read_object_or_null do |key|
-      key.should eq("foo")
-      pull.read_int.should eq(1)
+      expect(key).to eq("foo")
+      expect(pull.read_int).to eq(1)
     end
   end
 
@@ -224,7 +224,7 @@ describe "JSON::PullParser" do
         bar = pull.read_int
       end
 
-      bar.should eq(2)
+      expect(bar).to eq(2)
     end
 
     it "finds key" do
@@ -235,7 +235,7 @@ describe "JSON::PullParser" do
         bar = pull.read_int
       end
 
-      bar.should eq(2)
+      expect(bar).to eq(2)
     end
 
     it "doesn't find key" do
@@ -246,7 +246,7 @@ describe "JSON::PullParser" do
         bar = pull.read_int
       end
 
-      bar.should be_nil
+      expect(bar).to be_nil
     end
 
     it "finds key with bang" do
@@ -257,7 +257,7 @@ describe "JSON::PullParser" do
         bar = pull.read_int
       end
 
-      bar.should eq(2)
+      expect(bar).to eq(2)
     end
 
     it "doesn't find key with bang" do
@@ -272,15 +272,15 @@ describe "JSON::PullParser" do
     it "reads float when it is an int" do
       pull = JSON::PullParser.new(%(1))
       f = pull.read_float
-      f.should be_a(Float64)
-      f.should eq(1.0)
+      expect(f).to be_a(Float64)
+      expect(f).to eq(1.0)
     end
 
     ["1", "[1]", %({"x": [1]})].each do |value|
       it "yields all keys when skipping #{value}" do
         pull = JSON::PullParser.new(%({"foo": #{value}, "bar": 2}))
         pull.read_object do |key|
-          key.should_not eq("")
+          expect(key).to_not eq("")
           pull.skip
         end
       end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -4,44 +4,44 @@ require "json"
 describe "JSON serialization" do
   describe "from_json" do
     it "does Array(Nil)#from_json" do
-      Array(Nil).from_json("[null, null]").should eq([nil, nil])
+      expect(Array(Nil).from_json("[null, null]")).to eq([nil, nil])
     end
 
     it "does Array(Bool)#from_json" do
-      Array(Bool).from_json("[true, false]").should eq([true, false])
+      expect(Array(Bool).from_json("[true, false]")).to eq([true, false])
     end
 
     it "does Array(Int32)#from_json" do
-      Array(Int32).from_json("[1, 2, 3]").should eq([1, 2, 3])
+      expect(Array(Int32).from_json("[1, 2, 3]")).to eq([1, 2, 3])
     end
 
     it "does Array(Int64)#from_json" do
-      Array(Int64).from_json("[1, 2, 3]").should eq([1, 2, 3])
+      expect(Array(Int64).from_json("[1, 2, 3]")).to eq([1, 2, 3])
     end
 
     it "does Array(Float32)#from_json" do
-      Array(Float32).from_json("[1.5, 2, 3.5]").should eq([1.5, 2.0, 3.5])
+      expect(Array(Float32).from_json("[1.5, 2, 3.5]")).to eq([1.5, 2.0, 3.5])
     end
 
     it "does Array(Float64)#from_json" do
-      Array(Float64).from_json("[1.5, 2, 3.5]").should eq([1.5, 2, 3.5])
+      expect(Array(Float64).from_json("[1.5, 2, 3.5]")).to eq([1.5, 2, 3.5])
     end
 
     it "does Hash(String, String)#from_json" do
-      Hash(String, String).from_json(%({"foo": "x", "bar": "y"})).should eq({"foo" => "x", "bar" => "y"})
+      expect(Hash(String, String).from_json(%({"foo": "x", "bar": "y"}))).to eq({"foo" => "x", "bar" => "y"})
     end
 
     it "does Hash(String, Int32)#from_json" do
-      Hash(String, Int32).from_json(%({"foo": 1, "bar": 2})).should eq({"foo" => 1, "bar" => 2})
+      expect(Hash(String, Int32).from_json(%({"foo": 1, "bar": 2}))).to eq({"foo" => 1, "bar" => 2})
     end
 
     it "does Hash(String, Int32)#from_json and skips null" do
-      Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null})).should eq({"foo" => 1, "bar" => 2})
+      expect(Hash(String, Int32).from_json(%({"foo": 1, "bar": 2, "baz": null}))).to eq({"foo" => 1, "bar" => 2})
     end
 
     it "does for Array(Int32) from IO" do
       io = StringIO.new "[1, 2, 3]"
-      Array(Int32).from_json(io).should eq([1, 2, 3])
+      expect(Array(Int32).from_json(io)).to eq([1, 2, 3])
     end
 
     it "does for Array(Int32) with block" do
@@ -49,104 +49,104 @@ describe "JSON serialization" do
       Array(Int32).from_json("[1, 2, 3]") do |element|
         elements << element
       end
-      elements.should eq([1, 2, 3])
+      expect(elements).to eq([1, 2, 3])
     end
   end
 
   describe "to_json" do
     it "does for Nil" do
-      nil.to_json.should eq("null")
+      expect(nil.to_json).to eq("null")
     end
 
     it "does for Bool" do
-      true.to_json.should eq("true")
+      expect(true.to_json).to eq("true")
     end
 
     it "does for Int32" do
-      1.to_json.should eq("1")
+      expect(1.to_json).to eq("1")
     end
 
     it "does for Float64" do
-      1.5.to_json.should eq("1.5")
+      expect(1.5.to_json).to eq("1.5")
     end
 
     it "does for String" do
-      "hello".to_json.should eq("\"hello\"")
+      expect("hello".to_json).to eq("\"hello\"")
     end
 
     it "does for String with quote" do
-      "hel\"lo".to_json.should eq("\"hel\\\"lo\"")
+      expect("hel\"lo".to_json).to eq("\"hel\\\"lo\"")
     end
 
     it "does for String with slash" do
-      "hel\\lo".to_json.should eq("\"hel\\\\lo\"")
+      expect("hel\\lo".to_json).to eq("\"hel\\\\lo\"")
     end
 
     it "does for String with control codes" do
-      "\b".to_json.should eq("\"\\b\"")
-      "\f".to_json.should eq("\"\\f\"")
-      "\n".to_json.should eq("\"\\n\"")
-      "\r".to_json.should eq("\"\\r\"")
-      "\t".to_json.should eq("\"\\t\"")
-      "\u{19}".to_json.should eq("\"\\u0019\"")
+      expect("\b".to_json).to eq("\"\\b\"")
+      expect("\f".to_json).to eq("\"\\f\"")
+      expect("\n".to_json).to eq("\"\\n\"")
+      expect("\r".to_json).to eq("\"\\r\"")
+      expect("\t".to_json).to eq("\"\\t\"")
+      expect("\u{19}".to_json).to eq("\"\\u0019\"")
     end
 
     it "does for Array" do
-      [1, 2, 3].to_json.should eq("[1,2,3]")
+      expect([1, 2, 3].to_json).to eq("[1,2,3]")
     end
 
     it "does for Hash" do
-      {"foo" => 1, "bar" => 2}.to_json.should eq(%({"foo":1,"bar":2}))
+      expect({"foo" => 1, "bar" => 2}.to_json).to eq(%({"foo":1,"bar":2}))
     end
 
     it "does for Hash with non-string keys" do
-      {foo: 1, bar: 2}.to_json.should eq(%({"foo":1,"bar":2}))
+      expect({foo: 1, bar: 2}.to_json).to eq(%({"foo":1,"bar":2}))
     end
   end
 
   describe "to_pretty_json" do
     it "does for Nil" do
-      nil.to_pretty_json.should eq("null")
+      expect(nil.to_pretty_json).to eq("null")
     end
 
     it "does for Bool" do
-      true.to_pretty_json.should eq("true")
+      expect(true.to_pretty_json).to eq("true")
     end
 
     it "does for Int32" do
-      1.to_pretty_json.should eq("1")
+      expect(1.to_pretty_json).to eq("1")
     end
 
     it "does for Float64" do
-      1.5.to_pretty_json.should eq("1.5")
+      expect(1.5.to_pretty_json).to eq("1.5")
     end
 
     it "does for String" do
-      "hello".to_pretty_json.should eq("\"hello\"")
+      expect("hello".to_pretty_json).to eq("\"hello\"")
     end
 
     it "does for Array" do
-      [1, 2, 3].to_pretty_json.should eq("[\n  1,\n  2,\n  3\n]")
+      expect([1, 2, 3].to_pretty_json).to eq("[\n  1,\n  2,\n  3\n]")
     end
 
     it "does for nested Array" do
-      [[1, 2, 3]].to_pretty_json.should eq("[\n  [\n    1,\n    2,\n    3\n  ]\n]")
+      expect([[1, 2, 3]].to_pretty_json).to eq("[\n  [\n    1,\n    2,\n    3\n  ]\n]")
     end
 
     it "does for empty Array" do
-      ([] of Nil).to_pretty_json.should eq("[]")
+      expect(([] of Nil).to_pretty_json).to eq("[]")
     end
 
     it "does for Hash" do
-      {"foo" => 1, "bar" => 2}.to_pretty_json.should eq(%({\n  "foo": 1,\n  "bar": 2\n}))
+      expect({"foo" => 1, "bar" => 2}.to_pretty_json).to eq(%({\n  "foo": 1,\n  "bar": 2\n}))
     end
 
     it "does for nested Hash" do
-      {"foo" => {"bar" => 1} }.to_pretty_json.should eq(%({\n  "foo": {\n    "bar": 1\n  }\n}))
+      expect({"foo" => {"bar" => 1} }.to_pretty_json).to eq(%({\n  "foo": {\n    "bar": 1\n  }\n}))
     end
 
     it "does for empty Hash" do
-      ({} of Nil => Nil).to_pretty_json.should eq(%({}))
+      expect(({} of Nil => Nil).to_pretty_json).to eq(%({}))
     end
   end
 end

--- a/spec/std/levenshtein_spec.cr
+++ b/spec/std/levenshtein_spec.cr
@@ -2,16 +2,16 @@ require "spec"
 require "levenshtein"
 
 describe "levenshtein" do
-  assert { levenshtein("algorithm", "altruistic").should eq(6) }
-  assert { levenshtein("1638452297", "444488444").should eq(9) }
-  assert { levenshtein("", "").should eq(0) }
-  assert { levenshtein("", "a").should eq(1) }
-  assert { levenshtein("aaapppp", "").should eq(7) }
-  assert { levenshtein("frog", "fog").should eq(1) }
-  assert { levenshtein("fly", "ant").should eq(3) }
-  assert { levenshtein("elephant", "hippo").should eq(7) }
-  assert { levenshtein("hippo", "elephant").should eq(7) }
-  assert { levenshtein("hippo", "zzzzzzzz").should eq(8) }
-  assert { levenshtein("hello", "hallo").should eq(1) }
-  assert { levenshtein("こんにちは", "こんちは").should eq(1) }
+  assert { expect(levenshtein("algorithm", "altruistic")).to eq(6) }
+  assert { expect(levenshtein("1638452297", "444488444")).to eq(9) }
+  assert { expect(levenshtein("", "")).to eq(0) }
+  assert { expect(levenshtein("", "a")).to eq(1) }
+  assert { expect(levenshtein("aaapppp", "")).to eq(7) }
+  assert { expect(levenshtein("frog", "fog")).to eq(1) }
+  assert { expect(levenshtein("fly", "ant")).to eq(3) }
+  assert { expect(levenshtein("elephant", "hippo")).to eq(7) }
+  assert { expect(levenshtein("hippo", "elephant")).to eq(7) }
+  assert { expect(levenshtein("hippo", "zzzzzzzz")).to eq(8) }
+  assert { expect(levenshtein("hello", "hallo")).to eq(1) }
+  assert { expect(levenshtein("こんにちは", "こんちは")).to eq(1) }
 end

--- a/spec/std/llvm/x86_64_abi_spec.cr
+++ b/spec/std/llvm/x86_64_abi_spec.cr
@@ -14,74 +14,74 @@ class LLVM::ABI
   describe X86_64 do
     describe "align" do
       it "for integer" do
-        abi.align(LLVM::Int1).should be_a(::Int32)
-        abi.align(LLVM::Int1).should eq(1)
-        abi.align(LLVM::Int8).should eq(1)
-        abi.align(LLVM::Int16).should eq(2)
-        abi.align(LLVM::Int32).should eq(4)
-        abi.align(LLVM::Int64).should eq(8)
+        expect(abi.align(LLVM::Int1)).to be_a(::Int32)
+        expect(abi.align(LLVM::Int1)).to eq(1)
+        expect(abi.align(LLVM::Int8)).to eq(1)
+        expect(abi.align(LLVM::Int16)).to eq(2)
+        expect(abi.align(LLVM::Int32)).to eq(4)
+        expect(abi.align(LLVM::Int64)).to eq(8)
       end
 
       it "for pointer" do
-        abi.align(LLVM::Int8.pointer).should eq(8)
+        expect(abi.align(LLVM::Int8.pointer)).to eq(8)
       end
 
       it "for float" do
-        abi.align(LLVM::Float).should eq(4)
+        expect(abi.align(LLVM::Float)).to eq(4)
       end
 
       it "for double" do
-        abi.align(LLVM::Double).should eq(8)
+        expect(abi.align(LLVM::Double)).to eq(8)
       end
 
       it "for struct" do
-        abi.align(LLVM::Type.struct([LLVM::Int32, LLVM::Int64])).should eq(8)
-        abi.align(LLVM::Type.struct([LLVM::Int8, LLVM::Int16])).should eq(2)
+        expect(abi.align(LLVM::Type.struct([LLVM::Int32, LLVM::Int64]))).to eq(8)
+        expect(abi.align(LLVM::Type.struct([LLVM::Int8, LLVM::Int16]))).to eq(2)
       end
 
       it "for packed struct" do
-        abi.align(LLVM::Type.struct([LLVM::Int32, LLVM::Int64], packed: true)).should eq(1)
+        expect(abi.align(LLVM::Type.struct([LLVM::Int32, LLVM::Int64], packed: true))).to eq(1)
       end
 
       it "for array" do
-        abi.align(LLVM::Int16.array(10)).should eq(2)
+        expect(abi.align(LLVM::Int16.array(10))).to eq(2)
       end
     end
 
     describe "size" do
       it "for integer" do
-        abi.size(LLVM::Int1).should be_a(::Int32)
-        abi.size(LLVM::Int1).should eq(1)
-        abi.size(LLVM::Int8).should eq(1)
-        abi.size(LLVM::Int16).should eq(2)
-        abi.size(LLVM::Int32).should eq(4)
-        abi.size(LLVM::Int64).should eq(8)
+        expect(abi.size(LLVM::Int1)).to be_a(::Int32)
+        expect(abi.size(LLVM::Int1)).to eq(1)
+        expect(abi.size(LLVM::Int8)).to eq(1)
+        expect(abi.size(LLVM::Int16)).to eq(2)
+        expect(abi.size(LLVM::Int32)).to eq(4)
+        expect(abi.size(LLVM::Int64)).to eq(8)
       end
 
       it "for pointer" do
-        abi.size(LLVM::Int8.pointer).should eq(8)
+        expect(abi.size(LLVM::Int8.pointer)).to eq(8)
       end
 
       it "for float" do
-        abi.size(LLVM::Float).should eq(4)
+        expect(abi.size(LLVM::Float)).to eq(4)
       end
 
       it "for double" do
-        abi.size(LLVM::Double).should eq(8)
+        expect(abi.size(LLVM::Double)).to eq(8)
       end
 
       it "for struct" do
-        abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int64])).should eq(16)
-        abi.size(LLVM::Type.struct([LLVM::Int16, LLVM::Int8])).should eq(4)
-        abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int8, LLVM::Int8])).should eq(8)
+        expect(abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int64]))).to eq(16)
+        expect(abi.size(LLVM::Type.struct([LLVM::Int16, LLVM::Int8]))).to eq(4)
+        expect(abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int8, LLVM::Int8]))).to eq(8)
       end
 
       it "for packed struct" do
-        abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int64], packed: true)).should eq(12)
+        expect(abi.size(LLVM::Type.struct([LLVM::Int32, LLVM::Int64], packed: true))).to eq(12)
       end
 
       it "for array" do
-        abi.size(LLVM::Int16.array(10)).should eq(20)
+        expect(abi.size(LLVM::Int16.array(10))).to eq(20)
       end
     end
 
@@ -90,11 +90,11 @@ class LLVM::ABI
         arg_types = [LLVM::Int32, LLVM::Int64]
         return_type = LLVM::Int8
         info = abi.abi_info(arg_types, return_type, true)
-        info.arg_types.length.should eq(2)
+        expect(info.arg_types.length).to eq(2)
 
-        info.arg_types[0].should eq(ArgType.direct(LLVM::Int32))
-        info.arg_types[1].should eq(ArgType.direct(LLVM::Int64))
-        info.return_type.should eq(ArgType.direct(LLVM::Int8))
+        expect(info.arg_types[0]).to eq(ArgType.direct(LLVM::Int32))
+        expect(info.arg_types[1]).to eq(ArgType.direct(LLVM::Int64))
+        expect(info.return_type).to eq(ArgType.direct(LLVM::Int8))
       end
 
       it "does with structs less than 64 bits" do
@@ -103,10 +103,10 @@ class LLVM::ABI
         return_type = str
 
         info = abi.abi_info(arg_types, return_type, true)
-        info.arg_types.length.should eq(1)
+        expect(info.arg_types.length).to eq(1)
 
-        info.arg_types[0].should eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64])))
-        info.return_type.should eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64])))
+        expect(info.arg_types[0]).to eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64])))
+        expect(info.return_type).to eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64])))
       end
 
       it "does with structs between 64 and 128 bits" do
@@ -115,10 +115,10 @@ class LLVM::ABI
         return_type = str
 
         info = abi.abi_info(arg_types, return_type, true)
-        info.arg_types.length.should eq(1)
+        expect(info.arg_types.length).to eq(1)
 
-        info.arg_types[0].should eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64, LLVM::Int64])))
-        info.return_type.should eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64, LLVM::Int64])))
+        expect(info.arg_types[0]).to eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64, LLVM::Int64])))
+        expect(info.return_type).to eq(ArgType.direct(str, cast: LLVM::Type.struct([LLVM::Int64, LLVM::Int64])))
       end
 
       it "does with structs between 64 and 128 bits" do
@@ -127,10 +127,10 @@ class LLVM::ABI
         return_type = str
 
         info = abi.abi_info(arg_types, return_type, true)
-        info.arg_types.length.should eq(1)
+        expect(info.arg_types.length).to eq(1)
 
-        info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
-        info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
+        expect(info.arg_types[0]).to eq(ArgType.indirect(str, Attribute::ByVal))
+        expect(info.return_type).to eq(ArgType.indirect(str, Attribute::StructRet))
       end
     end
   end

--- a/spec/std/llvm/x86_abi_spec.cr
+++ b/spec/std/llvm/x86_abi_spec.cr
@@ -13,11 +13,11 @@ end
 class LLVM::ABI
   describe X86 do
     it "does size" do
-      abi.size(LLVM::Int32).should eq(4)
+      expect(abi.size(LLVM::Int32)).to eq(4)
     end
 
     it "does align" do
-      abi.align(LLVM::Int32).should eq(4)
+      expect(abi.align(LLVM::Int32)).to eq(4)
     end
 
     describe "abi_info" do
@@ -25,11 +25,11 @@ class LLVM::ABI
         arg_types = [LLVM::Int32, LLVM::Int64]
         return_type = LLVM::Int8
         info = abi.abi_info(arg_types, return_type, true)
-        info.arg_types.length.should eq(2)
+        expect(info.arg_types.length).to eq(2)
 
-        info.arg_types[0].should eq(ArgType.direct(LLVM::Int32))
-        info.arg_types[1].should eq(ArgType.direct(LLVM::Int64))
-        info.return_type.should eq(ArgType.direct(LLVM::Int8))
+        expect(info.arg_types[0]).to eq(ArgType.direct(LLVM::Int32))
+        expect(info.arg_types[1]).to eq(ArgType.direct(LLVM::Int64))
+        expect(info.return_type).to eq(ArgType.direct(LLVM::Int8))
       end
     end
   end

--- a/spec/std/logger_spec.cr
+++ b/spec/std/logger_spec.cr
@@ -16,9 +16,9 @@ describe "Logger" do
       logger.info "info:skip"
       logger.error "error:show"
 
-      r.gets.should match(/info:show/)
-      r.gets.should match(/debug:show/)
-      r.gets.should match(/error:show/)
+      expect(r.gets).to match(/info:show/)
+      expect(r.gets).to match(/debug:show/)
+      expect(r.gets).to match(/error:show/)
     end
   end
 
@@ -27,7 +27,7 @@ describe "Logger" do
       logger = Logger.new(w)
       logger.info 12345
 
-      r.gets.should match(/12345/)
+      expect(r.gets).to match(/12345/)
     end
   end
 
@@ -37,7 +37,7 @@ describe "Logger" do
       logger.progname = "crystal"
       logger.warn "message"
 
-      r.gets.should match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
+      expect(r.gets).to match(/W, \[.+? #\d+\]  WARN -- crystal: message\n/)
     end
   end
 
@@ -49,7 +49,7 @@ describe "Logger" do
       end
       logger.warn "message", "prog"
 
-      r.gets.should eq("W prog: message\n")
+      expect(r.gets).to eq("W prog: message\n")
     end
   end
 
@@ -59,8 +59,8 @@ describe "Logger" do
       logger.error { "message" }
       logger.unknown { "another message" }
 
-      r.gets.should match(/ERROR -- : message\n/)
-      r.gets.should match(/  ANY -- : another message\n/)
+      expect(r.gets).to match(/ERROR -- : message\n/)
+      expect(r.gets).to match(/  ANY -- : another message\n/)
     end
   end
 
@@ -70,8 +70,8 @@ describe "Logger" do
       logger.error("crystal") { "message" }
       logger.unknown("shard") { "another message" }
 
-      r.gets.should match(/ERROR -- crystal: message\n/)
-      r.gets.should match(/  ANY -- shard: another message\n/)
+      expect(r.gets).to match(/ERROR -- crystal: message\n/)
+      expect(r.gets).to match(/  ANY -- shard: another message\n/)
     end
   end
 end

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -3,7 +3,7 @@ require "markdown"
 
 private def assert_render(input, output, file = __FILE__, line = __LINE__)
   it "renders #{input.inspect}", file, line do
-    Markdown.to_html(input).should eq(output)
+    expect(Markdown.to_html(input)).to eq(output)
   end
 end
 

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -3,27 +3,27 @@ require "spec"
 describe "Math" do
   describe "Mathematical constants" do
     it "E" do
-      Math::E.should be_close(2.718281828459045, 1e-7)
+      expect(Math::E).to be_close(2.718281828459045, 1e-7)
     end
 
     it "LOG2" do
-      Math::LOG2.should be_close(0.6931471805599453, 1e-7)
+      expect(Math::LOG2).to be_close(0.6931471805599453, 1e-7)
     end
 
     it "LOG10" do
-      Math::LOG10.should be_close(2.302585092994046, 1e-7)
+      expect(Math::LOG10).to be_close(2.302585092994046, 1e-7)
     end
   end
 
   describe "Functions manipulating signs" do
     it "copysign" do
-      Math.copysign(6.9, -0.2).should eq(-6.9)
+      expect(Math.copysign(6.9, -0.2)).to eq(-6.9)
     end
   end
 
   describe "Order-related functions" do
-    Math.min(2.1, 2.11).should eq(2.1)
-    Math.max(3.2, 3.11).should eq(3.2)
+    expect(Math.min(2.1, 2.11)).to eq(2.1)
+    expect(Math.max(3.2, 3.11)).to eq(3.2)
   end
 
   pending "Functions for computing quotient and remainder" do
@@ -31,215 +31,215 @@ describe "Math" do
 
   describe "Roots" do
     it "cbrt" do
-      Math.cbrt(6.5_f32).should be_close(1.866255578408624, 1e-7)
-      Math.cbrt(6.5).should be_close(1.866255578408624, 1e-7)
+      expect(Math.cbrt(6.5_f32)).to be_close(1.866255578408624, 1e-7)
+      expect(Math.cbrt(6.5)).to be_close(1.866255578408624, 1e-7)
     end
 
     it "sqrt" do
-      Math.sqrt(5.2_f32).should be_close(2.280350850198276, 1e-7)
-      Math.sqrt(5.2).should be_close(2.280350850198276, 1e-7)
-      Math.sqrt(4_f32).should eq(2)
-      Math.sqrt(4).should eq(2)
+      expect(Math.sqrt(5.2_f32)).to be_close(2.280350850198276, 1e-7)
+      expect(Math.sqrt(5.2)).to be_close(2.280350850198276, 1e-7)
+      expect(Math.sqrt(4_f32)).to eq(2)
+      expect(Math.sqrt(4)).to eq(2)
     end
   end
 
   describe "Exponents" do
     it "exp" do
-      Math.exp(0.211_f32).should be_close(1.2349123550613943, 1e-7)
-      Math.exp(0.211).should be_close(1.2349123550613943, 1e-7)
+      expect(Math.exp(0.211_f32)).to be_close(1.2349123550613943, 1e-7)
+      expect(Math.exp(0.211)).to be_close(1.2349123550613943, 1e-7)
     end
 
     it "exp2" do
-      Math.exp2(0.41_f32).should be_close(1.3286858140965117, 1e-7)
-      Math.exp2(0.41).should be_close(1.3286858140965117, 1e-7)
+      expect(Math.exp2(0.41_f32)).to be_close(1.3286858140965117, 1e-7)
+      expect(Math.exp2(0.41)).to be_close(1.3286858140965117, 1e-7)
     end
 
     it "expm1" do
-      Math.expm1(0.99_f32).should be_close(1.6912344723492623, 1e-7)
-      Math.expm1(0.99).should be_close(1.6912344723492623, 1e-7)
+      expect(Math.expm1(0.99_f32)).to be_close(1.6912344723492623, 1e-7)
+      expect(Math.expm1(0.99)).to be_close(1.6912344723492623, 1e-7)
     end
 
     it "ilogb" do
-      Math.ilogb(0.5_f32).should eq(-1)
-      Math.ilogb(0.5).should eq(-1)
+      expect(Math.ilogb(0.5_f32)).to eq(-1)
+      expect(Math.ilogb(0.5)).to eq(-1)
     end
 
     it "ldexp" do
-      Math.ldexp(0.27_f32, 2).should be_close(1.08, 1e-7)
-      Math.ldexp(0.27, 2).should be_close(1.08, 1e-7)
+      expect(Math.ldexp(0.27_f32, 2)).to be_close(1.08, 1e-7)
+      expect(Math.ldexp(0.27, 2)).to be_close(1.08, 1e-7)
     end
 
     it "logb" do
-      Math.logb(10_f32).should be_close(3.0, 1e-7)
-      Math.logb(10.0).should be_close(3.0, 1e-7)
+      expect(Math.logb(10_f32)).to be_close(3.0, 1e-7)
+      expect(Math.logb(10.0)).to be_close(3.0, 1e-7)
     end
 
     it "scalbn" do
-      Math.scalbn(0.2_f32, 3).should be_close(1.6, 1e-7)
-      Math.scalbn(0.2, 3).should be_close(1.6, 1e-7)
+      expect(Math.scalbn(0.2_f32, 3)).to be_close(1.6, 1e-7)
+      expect(Math.scalbn(0.2, 3)).to be_close(1.6, 1e-7)
     end
 
     it "scalbln" do
-      Math.scalbln(0.11_f32, 2).should be_close(0.44, 1e-7)
-      Math.scalbln(0.11, 2).should be_close(0.44, 1e-7)
+      expect(Math.scalbln(0.11_f32, 2)).to be_close(0.44, 1e-7)
+      expect(Math.scalbln(0.11, 2)).to be_close(0.44, 1e-7)
     end
   end
 
   describe "Logarithms" do
     it "log" do
-      Math.log(3.24_f32).should be_close(1.1755733298042381, 1e-7)
-      Math.log(3.24).should be_close(1.1755733298042381, 1e-7)
-      Math.log(0.3_f32, 3).should be_close(-1.0959032742893848, 1e-7)
-      Math.log(0.3, 3).should be_close(-1.0959032742893848, 1e-7)
+      expect(Math.log(3.24_f32)).to be_close(1.1755733298042381, 1e-7)
+      expect(Math.log(3.24)).to be_close(1.1755733298042381, 1e-7)
+      expect(Math.log(0.3_f32, 3)).to be_close(-1.0959032742893848, 1e-7)
+      expect(Math.log(0.3, 3)).to be_close(-1.0959032742893848, 1e-7)
     end
 
     it "log2" do
-      Math.log2(1.2_f32).should be_close(0.2630344058337938, 1e-7)
-      Math.log2(1.2).should be_close(0.2630344058337938, 1e-7)
+      expect(Math.log2(1.2_f32)).to be_close(0.2630344058337938, 1e-7)
+      expect(Math.log2(1.2)).to be_close(0.2630344058337938, 1e-7)
     end
 
     it "log10" do
-      Math.log10(0.5_f32).should be_close(-0.3010299956639812, 1e-7)
-      Math.log10(0.5).should be_close(-0.3010299956639812, 1e-7)
+      expect(Math.log10(0.5_f32)).to be_close(-0.3010299956639812, 1e-7)
+      expect(Math.log10(0.5)).to be_close(-0.3010299956639812, 1e-7)
     end
 
     it "log1p" do
-      Math.log1p(0.67_f32).should be_close(0.5128236264286637, 1e-7)
-      Math.log1p(0.67).should be_close(0.5128236264286637, 1e-7)
+      expect(Math.log1p(0.67_f32)).to be_close(0.5128236264286637, 1e-7)
+      expect(Math.log1p(0.67)).to be_close(0.5128236264286637, 1e-7)
     end
   end
 
   describe "Trigonometric functions" do
     it "cos" do
-      Math.cos(2.23_f32).should be_close(-0.6124875656583851, 1e-7)
-      Math.cos(2.23).should be_close(-0.6124875656583851, 1e-7)
+      expect(Math.cos(2.23_f32)).to be_close(-0.6124875656583851, 1e-7)
+      expect(Math.cos(2.23)).to be_close(-0.6124875656583851, 1e-7)
     end
 
     it "sin" do
-      Math.sin(3.3_f32).should be_close(-0.1577456941432482, 1e-7)
-      Math.sin(3.3).should be_close(-0.1577456941432482, 1e-7)
+      expect(Math.sin(3.3_f32)).to be_close(-0.1577456941432482, 1e-7)
+      expect(Math.sin(3.3)).to be_close(-0.1577456941432482, 1e-7)
     end
 
     it "tan" do
-      Math.tan(0.91_f32).should be_close(1.2863693807208076, 1e-7)
-      Math.tan(0.91).should be_close(1.2863693807208076, 1e-7)
+      expect(Math.tan(0.91_f32)).to be_close(1.2863693807208076, 1e-7)
+      expect(Math.tan(0.91)).to be_close(1.2863693807208076, 1e-7)
     end
 
     it "hypot" do
-      Math.hypot(2.1_f32, 1.5_f32).should be_close(2.5806975801127883, 1e-7)
-      Math.hypot(2.1, 1.5).should be_close(2.5806975801127883, 1e-7)
+      expect(Math.hypot(2.1_f32, 1.5_f32)).to be_close(2.5806975801127883, 1e-7)
+      expect(Math.hypot(2.1, 1.5)).to be_close(2.5806975801127883, 1e-7)
     end
   end
 
   describe "Inverse trigonometric functions" do
     it "acos" do
-      Math.acos(0.125_f32).should be_close(1.445468495626831, 1e-7)
-      Math.acos(0.125).should be_close(1.445468495626831, 1e-7)
+      expect(Math.acos(0.125_f32)).to be_close(1.445468495626831, 1e-7)
+      expect(Math.acos(0.125)).to be_close(1.445468495626831, 1e-7)
     end
 
     it "asin" do
-      Math.asin(-0.4_f32).should be_close(-0.41151684606748806, 1e-7)
-      Math.asin(-0.4).should be_close(-0.41151684606748806, 1e-7)
+      expect(Math.asin(-0.4_f32)).to be_close(-0.41151684606748806, 1e-7)
+      expect(Math.asin(-0.4)).to be_close(-0.41151684606748806, 1e-7)
     end
 
     it "atan" do
-      Math.atan(4.3_f32).should be_close(1.3422996875030344, 1e-7)
-      Math.atan(4.3).should be_close(1.3422996875030344, 1e-7)
+      expect(Math.atan(4.3_f32)).to be_close(1.3422996875030344, 1e-7)
+      expect(Math.atan(4.3)).to be_close(1.3422996875030344, 1e-7)
     end
 
     it "atan2" do
-      Math.atan2(3.5_f32, 2.1_f32).should be_close(1.0303768265243125, 1e-7)
-      Math.atan2(3.5, 2.1).should be_close(1.0303768265243125, 1e-7)
+      expect(Math.atan2(3.5_f32, 2.1_f32)).to be_close(1.0303768265243125, 1e-7)
+      expect(Math.atan2(3.5, 2.1)).to be_close(1.0303768265243125, 1e-7)
     end
   end
 
   describe "Hyperbolic functions" do
     it "cosh" do
-      Math.cosh(0.79_f32).should be_close(1.3286206107691463, 1e-7)
-      Math.cosh(0.79).should be_close(1.3286206107691463, 1e-7)
+      expect(Math.cosh(0.79_f32)).to be_close(1.3286206107691463, 1e-7)
+      expect(Math.cosh(0.79)).to be_close(1.3286206107691463, 1e-7)
     end
 
     it "sinh" do
-      Math.sinh(0.12_f32).should be_close(0.12028820743110909, 1e-7)
-      Math.sinh(0.12).should be_close(0.12028820743110909, 1e-7)
+      expect(Math.sinh(0.12_f32)).to be_close(0.12028820743110909, 1e-7)
+      expect(Math.sinh(0.12)).to be_close(0.12028820743110909, 1e-7)
     end
 
     it "tanh" do
-      Math.tanh(4.1_f32).should be_close(0.9994508436877974, 1e-7)
-      Math.tanh(4.1).should be_close(0.9994508436877974, 1e-7)
+      expect(Math.tanh(4.1_f32)).to be_close(0.9994508436877974, 1e-7)
+      expect(Math.tanh(4.1)).to be_close(0.9994508436877974, 1e-7)
     end
   end
 
   describe "Inverse hyperbolic functions" do
     it "acosh" do
-      Math.acosh(1.1_f32).should be_close(0.4435682543851154, 1e-7)
-      Math.acosh(1.1).should be_close(0.4435682543851154, 1e-7)
+      expect(Math.acosh(1.1_f32)).to be_close(0.4435682543851154, 1e-7)
+      expect(Math.acosh(1.1)).to be_close(0.4435682543851154, 1e-7)
     end
 
     it "asinh" do
-      Math.asinh(-2.3_f32).should be_close(-1.570278543484978, 1e-7)
-      Math.asinh(-2.3).should be_close(-1.570278543484978, 1e-7)
+      expect(Math.asinh(-2.3_f32)).to be_close(-1.570278543484978, 1e-7)
+      expect(Math.asinh(-2.3)).to be_close(-1.570278543484978, 1e-7)
     end
 
     it "atanh" do
-      Math.atanh(0.13_f32).should be_close(0.13073985002887845, 1e-7)
-      Math.atanh(0.13).should be_close(0.13073985002887845, 1e-7)
+      expect(Math.atanh(0.13_f32)).to be_close(0.13073985002887845, 1e-7)
+      expect(Math.atanh(0.13)).to be_close(0.13073985002887845, 1e-7)
     end
   end
 
   describe "Gamma functions" do
     it "gamma" do
-      Math.gamma(3.2_f32).should be_close(2.4239654799353683, 1e-6)
-      Math.gamma(3.2).should be_close(2.4239654799353683, 1e-7)
+      expect(Math.gamma(3.2_f32)).to be_close(2.4239654799353683, 1e-6)
+      expect(Math.gamma(3.2)).to be_close(2.4239654799353683, 1e-7)
     end
 
     it "lgamma" do
-      Math.lgamma(2.96_f32).should be_close(0.6565534110944214, 1e-7)
-      Math.lgamma(2.96).should be_close(0.6565534110944214, 1e-7)
+      expect(Math.lgamma(2.96_f32)).to be_close(0.6565534110944214, 1e-7)
+      expect(Math.lgamma(2.96)).to be_close(0.6565534110944214, 1e-7)
     end
   end
 
   describe "Bessel functions" do
     it "besselj0" do
-      Math.besselj0(9.1_f32).should be_close(-0.11423923268319867, 1e-7)
-      Math.besselj0(9.1).should be_close(-0.11423923268319867, 1e-7)
+      expect(Math.besselj0(9.1_f32)).to be_close(-0.11423923268319867, 1e-7)
+      expect(Math.besselj0(9.1)).to be_close(-0.11423923268319867, 1e-7)
     end
 
     it "besselj1" do
-      Math.besselj1(-2.1_f32).should be_close(-0.5682921357570385, 1e-7)
-      Math.besselj1(-2.1).should be_close(-0.5682921357570385, 1e-7)
+      expect(Math.besselj1(-2.1_f32)).to be_close(-0.5682921357570385, 1e-7)
+      expect(Math.besselj1(-2.1)).to be_close(-0.5682921357570385, 1e-7)
     end
 
     it "besselj" do
-      Math.besselj(4, -6.4_f32).should be_close(0.2945338623574655, 1e-7)
-      Math.besselj(4, -6.4).should be_close(0.2945338623574655, 1e-7)
+      expect(Math.besselj(4, -6.4_f32)).to be_close(0.2945338623574655, 1e-7)
+      expect(Math.besselj(4, -6.4)).to be_close(0.2945338623574655, 1e-7)
     end
 
     it "bessely0" do
-      Math.bessely0(2.14_f32).should be_close(0.5199289108068015, 1e-7)
-      Math.bessely0(2.14).should be_close(0.5199289108068015, 1e-7)
+      expect(Math.bessely0(2.14_f32)).to be_close(0.5199289108068015, 1e-7)
+      expect(Math.bessely0(2.14)).to be_close(0.5199289108068015, 1e-7)
     end
 
     it "bessely1" do
-      Math.bessely1(7.7_f32).should be_close(-0.2243184743430081, 1e-7)
-      Math.bessely1(7.7).should be_close(-0.2243184743430081, 1e-7)
+      expect(Math.bessely1(7.7_f32)).to be_close(-0.2243184743430081, 1e-7)
+      expect(Math.bessely1(7.7)).to be_close(-0.2243184743430081, 1e-7)
     end
 
     it "bessely" do
-      Math.bessely(3, 2.7_f32).should be_close(-0.6600575162477298, 1e-7)
-      Math.bessely(3, 2.7).should be_close(-0.6600575162477298, 1e-7)
+      expect(Math.bessely(3, 2.7_f32)).to be_close(-0.6600575162477298, 1e-7)
+      expect(Math.bessely(3, 2.7)).to be_close(-0.6600575162477298, 1e-7)
     end
   end
 
   describe "Gauss error functions" do
     it "erf" do
-      Math.erf(0.72_f32).should be_close(0.6914331231387512, 1e-7)
-      Math.erf(0.72).should be_close(0.6914331231387512, 1e-7)
+      expect(Math.erf(0.72_f32)).to be_close(0.6914331231387512, 1e-7)
+      expect(Math.erf(0.72)).to be_close(0.6914331231387512, 1e-7)
     end
 
     it "erfc" do
-      Math.erfc(-0.66_f32).should be_close(1.6493766879629543, 1e-7)
-      Math.erfc(-0.66).should be_close(1.6493766879629543, 1e-7)
+      expect(Math.erfc(-0.66_f32)).to be_close(1.6493766879629543, 1e-7)
+      expect(Math.erfc(-0.66)).to be_close(1.6493766879629543, 1e-7)
     end
   end
 

--- a/spec/std/matrix_spec.cr
+++ b/spec/std/matrix_spec.cr
@@ -5,12 +5,12 @@ describe Matrix do
   describe "Matrix.rows" do
     it "creates a matrix with the args as an array/tuple of rows (1)" do
       m = Matrix.rows([[1, 2], [3, 4], [5, 6]])
-      m.to_a.should eq([1, 2, 3, 4, 5, 6])
+      expect(m.to_a).to eq([1, 2, 3, 4, 5, 6])
     end
 
     it "creates a matrix with the args as an array/tuple of rows (2)" do
       m = Matrix.rows([['1', '2', '3', '4'], ['5', '6', '7', '8']])
-      m.to_a.should eq(['1', '2', '3', '4', '5', '6', '7', '8'])
+      expect(m.to_a).to eq(['1', '2', '3', '4', '5', '6', '7', '8'])
     end
 
     it "raises when given rows of different size" do
@@ -23,12 +23,12 @@ describe Matrix do
   describe "Matrix.columns" do
     it "creates a matrix with the args as an array/tuple of columns (1)" do
       m = Matrix.columns([[1, 2], [3, 4], [5, 6]])
-      m.to_a.should eq([1, 3, 5, 2, 4, 6])
+      expect(m.to_a).to eq([1, 3, 5, 2, 4, 6])
     end
 
     it "creates a matrix with the args as an array/tuple of columns (2)" do
       m = Matrix.columns([['1', '2', '3', '4'], ['5', '6', '7', '8']])
-      m.to_a.should eq(['1', '5', '2', '6', '3', '7', '4', '8'])
+      expect(m.to_a).to eq(['1', '5', '2', '6', '3', '7', '4', '8'])
     end
 
     it "raises when given rows of different size" do
@@ -41,40 +41,40 @@ describe Matrix do
   describe "Matrix.diagonal" do
     it "creates a square matrix where args are the diagonal values" do
       m = Matrix(Int32).diagonal(1, 2, 3)
-      m.rows.should eq([[1, 0, 0], [0, 2, 0], [0, 0, 3]])
+      expect(m.rows).to eq([[1, 0, 0], [0, 2, 0], [0, 0, 3]])
     end
   end
 
   describe "Matrix.identity" do
     it "creates a matrix whose diagonal elements are 1 and the rest are 0" do
       m = Matrix.identity(3)
-      m.rows.should eq([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+      expect(m.rows).to eq([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     end
   end
 
   describe "Matrix.row" do
     it "creates a single row matrix" do
       m = Matrix.row(1, 2, 3, 4)
-      m.rows.should eq([[1, 2, 3, 4]])
+      expect(m.rows).to eq([[1, 2, 3, 4]])
     end
   end
 
   describe "Matrix.column" do
     it "creates a single column matrix" do
       m = Matrix.column(1, 2, 3, 4)
-      m.columns.should eq([[1, 2, 3, 4]])
+      expect(m.columns).to eq([[1, 2, 3, 4]])
     end
   end
 
   describe "Matrix.[]" do
     it "creates a matrix with each arg as a row" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.rows.should eq([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+      expect(m.rows).to eq([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     end
 
     it "works with tuples" do
       m = Matrix[{1, 2, 3}, {4, 5, 6}, {7, 8, 9}]
-      m.rows.should eq([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+      expect(m.rows).to eq([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     end
 
     it "raises when given rows of different size" do
@@ -96,26 +96,26 @@ describe Matrix do
     it "does addition with another matrix (1)" do
       a = Matrix[[1, 2], [3, 4], [5, 6], [7, 8]]
       b = Matrix[[2, 4], [6, 8], [10, 12], [14, 16]]
-      (a + a).should eq(b)
+      expect((a + a)).to eq(b)
     end
 
     it "does addition with another matrix (2)" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = a.reverse
       c = Matrix.new(3, 3, 10)
-      c.should eq(a + b)
+      expect(c).to eq(a + b)
     end
 
     it "does addition with another T (1)" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = Matrix[[6, 7, 8], [9, 10, 11], [12, 13, 14]]
-      (a + 5).should eq(b)
+      expect((a + 5)).to eq(b)
     end
 
     it "does addition with another T (2)" do
       a = Matrix[["a", "b"], ["c", "d"], ["e", "f"]]
       b = Matrix[["ax", "bx"], ["cx", "dx"], ["ex", "fx"]]
-      (a + "x").should eq(b)
+      expect((a + "x")).to eq(b)
     end
   end
 
@@ -132,20 +132,20 @@ describe Matrix do
       a = Matrix[[1, 2], [3, 4], [5, 6], [7, 8]]
       b = Matrix[[2, 4], [6, 8], [10, 12], [14, 16]]
       c = Matrix[[-1, -2], [-3, -4], [-5, -6], [-7, -8]]
-      (a - b).should eq(c)
+      expect((a - b)).to eq(c)
     end
 
     it "does substraction with another matrix (2)" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = a.reverse
       c = Matrix[[-8, -6, -4], [-2, 0, 2], [4, 6, 8]]
-      (a - b).should eq(c)
+      expect((a - b)).to eq(c)
     end
 
     it "does substraction with another T" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = Matrix[[-4, -3, -2], [-1, 0, 1], [2, 3, 4]]
-      (a - 5).should eq(b)
+      expect((a - 5)).to eq(b)
     end
   end
 
@@ -153,27 +153,27 @@ describe Matrix do
     it "returns the product of two matrices (1)" do
       a = Matrix[[1, 2], [3, 4]]
       b = Matrix[[5, 6], [7, 8]]
-      (a * b).to_a.should eq([19, 22, 43, 50])
+      expect((a * b).to_a).to eq([19, 22, 43, 50])
     end
 
     it "returns the product of two matrices (2)" do
       a = Matrix.row(10, 11, 12)
       b = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      (a * b).to_a.should eq([138, 171, 204])
+      expect((a * b).to_a).to eq([138, 171, 204])
     end
 
     it "has the correct rows and columns after a product (1)" do
       a = Matrix.row(10, 11, 12)
       b = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      (a * b).row_count.should eq(1)
-      (a * b).column_count.should eq(3)
+      expect((a * b).row_count).to eq(1)
+      expect((a * b).column_count).to eq(3)
     end
 
     it "has the correct rows and columns after a product (2)" do
       a = Matrix[[1,2], [3,4], [5,6], [7,8]]
       b = Matrix[[1, 2, 3], [4, 5, 6]]
-      (a * b).row_count.should eq(4)
-      (a * b).column_count.should eq(3)
+      expect((a * b).row_count).to eq(4)
+      expect((a * b).column_count).to eq(3)
     end
   end
 
@@ -182,13 +182,13 @@ describe Matrix do
       a = Matrix[[7, 6], [3, 9]]
       b = Matrix[[2, 9], [3, 1]]
       c = Matrix[["0.44", "2.04"], ["0.96", "0.36"]]
-      (a / b).map(&.to_s).should eq(c)
+      expect((a / b).map(&.to_s)).to eq(c)
     end
 
     it "does division with another matrix (2)" do
       a = Matrix[[7, 6], [3, 9]]
       b = Matrix[[1, 0], [0, 1]]
-      (a / a).map(&.round).should eq(b)
+      expect((a / a).map(&.round)).to eq(b)
     end
 
     it "does division with another matrix (3)" do
@@ -197,7 +197,7 @@ describe Matrix do
       c = Matrix[[0.7000000000000002, -0.3, -1.1102230246251565e-16],
                  [-0.2999999999999998, 0.7, -5.551115123125783e-17],
                  [1.2000000000000002, 0.19999999999999996, -1.0]]
-      (a / b).should eq(c)
+      expect((a / b)).to eq(c)
     end
   end
 
@@ -205,34 +205,34 @@ describe Matrix do
     it "does ** with an Int" do
       a = Matrix[[1, 1], [1, 0]]
       b = Matrix[[3, 2], [2, 1]]
-      (a ** 3).should eq(b)
+      expect((a ** 3)).to eq(b)
 
       a = Matrix[[7, 6], [3, 9]]
       b = Matrix[[67, 96], [48, 99]]
-      (a ** 2).should eq(b)
+      expect((a ** 2)).to eq(b)
 
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      (a ** 1).should eq(a)
+      expect((a ** 1)).to eq(a)
 
       a = Matrix[[1, 1], [1, 0]]
       b = Matrix[[1, -1], [-1, 2]]
-      (a ** -2).should eq(b)
+      expect((a ** -2)).to eq(b)
 
       a = Matrix[[1, 1], [1, 0]]
       b = Matrix[[1, 0], [0, 1]]
-      (a ** 0).should eq(b)
+      expect((a ** 0)).to eq(b)
     end
   end
 
   describe "determinant" do
     it "returns the correct determinant (1)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.determinant.should eq(0)
+      expect(m.determinant).to eq(0)
     end
 
     it "returns the correct determinant (2)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 5]]
-      m.determinant.should eq(12)
+      expect(m.determinant).to eq(12)
     end
 
     it "returns the correct determinant (3)" do
@@ -242,7 +242,7 @@ describe Matrix do
         [2.63287e+08, 5.28931e+08, 1.39454e+09, 1.52471e+09, 4.30514e+08],
         [2.02314e+09, 1.92594e+08, 7.72298e+08, 1.72581e+09, 2.05689e+09],
         [7.35774e+08, 1.71179e+09, 9.40757e+08, 9.72277e+08, 1.46371e+09]]
-      m.determinant.should eq(1.2592223449008756e+45)
+      expect(m.determinant).to eq(1.2592223449008756e+45)
     end
 
     it "returns the correct determinant (4)" do
@@ -250,17 +250,17 @@ describe Matrix do
         [0.435, 0.337, 0.494],
         [0.096, 0.569, 0.304],
         [0.891, 0.347, 0.460]]
-      m.determinant.round(7).should eq(-0.0896226)
+      expect(m.determinant.round(7)).to eq(-0.0896226)
     end
 
     it "returns the correct determinant (5)" do
       m = Matrix[[1.23, 2.34], [3.45, 4.56]]
-      m.determinant.round(4).should eq(-2.4642)
+      expect(m.determinant.round(4)).to eq(-2.4642)
     end
 
     it "returns the correct determinant (6)" do
       m = Matrix[[3.45]]
-      m.determinant.should eq(3.45)
+      expect(m.determinant).to eq(3.45)
     end
   end
 
@@ -269,49 +269,49 @@ describe Matrix do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each { |e| b += e }
-      b.should eq(45)
+      expect(b).to eq(45)
     end
 
     it "iterates the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:diagonal) { |e| b += e }
-      b.should eq(15)
+      expect(b).to eq(15)
     end
 
     it "iterates skipping the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:off_diagonal) { |e| b += e }
-      b.should eq(30)
+      expect(b).to eq(30)
     end
 
     it "iterates at or below the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:lower) { |e| b += e }
-      b.should eq(34)
+      expect(b).to eq(34)
     end
 
     it "iterates below the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:strict_lower) { |e| b += e }
-      b.should eq(19)
+      expect(b).to eq(19)
     end
 
     it "iterates at or above the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:upper) { |e| b += e }
-      b.should eq(26)
+      expect(b).to eq(26)
     end
 
     it "iterates above the diagonal" do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = 0
       a.each(:strict_upper) { |e| b += e }
-      b.should eq(11)
+      expect(b).to eq(11)
     end
   end
 
@@ -320,64 +320,64 @@ describe Matrix do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({21, 6, 3})
+      expect({x, y, z}).to eq({21, 6, 3})
     end
 
     it "iterates the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:diagonal) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({5, 1, 1})
+      expect({x, y, z}).to eq({5, 1, 1})
     end
 
     it "iterates skipping the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:off_diagonal) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({16, 5, 2})
+      expect({x, y, z}).to eq({16, 5, 2})
     end
 
     it "iterates at or below the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:lower) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({19, 6, 2})
+      expect({x, y, z}).to eq({19, 6, 2})
     end
 
     it "iterates below the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:strict_lower) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({14, 5, 1})
+      expect({x, y, z}).to eq({14, 5, 1})
     end
 
     it "iterates at or above the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:upper) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({7, 1, 2})
+      expect({x, y, z}).to eq({7, 1, 2})
     end
 
     it "iterates above the diagonal" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
       x, y, z = 0, 0, 0
       m.each_with_index(:strict_upper) { |e, r, c| x += e; y += r; z += c }
-      {x, y, z}.should eq({2, 0, 1})
+      expect({x, y, z}).to eq({2, 0, 1})
     end
   end
 
   describe "index" do
     it "returns the first index when the block returns true, nil otherwise" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.index(&.even?).should eq({0, 1})
-      m.index(&.>(7)).should eq({2, 1})
-      m.index(&.<(1)).should eq(nil)
+      expect(m.index(&.even?)).to eq({0, 1})
+      expect(m.index(&.>(7))).to eq({2, 1})
+      expect(m.index(&.<(1))).to eq(nil)
     end
 
     it "returns the first index when the given value is found, nil otherwise" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.index(5, :diagonal).should eq({1, 1})
-      m.index(7, :upper).should eq(nil)
+      expect(m.index(5, :diagonal)).to eq({1, 1})
+      expect(m.index(7, :upper)).to eq(nil)
     end
   end
 
@@ -385,45 +385,45 @@ describe Matrix do
     it "returns the inverse of the matrix (1)" do
       a = Matrix[[-1, -1], [0, -1]]
       b = Matrix[[-1, 1], [0, -1]]
-      a.inverse.should eq(b)
+      expect(a.inverse).to eq(b)
     end
 
     it "returns the inverse of the matrix (2)" do
       a = Matrix[[4, 3], [3, 2]]
       b = Matrix[[-2, 3], [3, -4]]
-      a.inverse.should eq(b)
+      expect(a.inverse).to eq(b)
     end
 
     it "returns the inverse of the matrix (3)" do
       a = Matrix[[4, 7], [2, 6]]
       b = Matrix[[0.6, -0.7], [-0.2, 0.4]]
-      a.inverse.should eq(b)
+      expect(a.inverse).to eq(b)
     end
   end
 
   describe "minor" do
     it "returns a section of the matrix (1)" do
       m = Matrix(Int32).diagonal(9, 5, -3).minor(0, 3, 0, 2)
-      m.rows.should eq([[9, 0], [0, 5], [0, 0]])
+      expect(m.rows).to eq([[9, 0], [0, 5], [0, 0]])
     end
 
     it "returns a section of the matrix (2)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.minor(0, 3, 0, 3).rows.should eq(m.rows)
-      m.minor(1, 2, 0, 1).rows.should eq([[4], [7]])
-      m.minor(0, 3, 0, 2).rows.should eq([[1, 2], [4, 5], [7, 8]])
-      m.minor(1, 1, 1, 1).rows.should eq([[5]])
-      m.minor(-1, 1, -1, 1).rows.should eq([[9]])
+      expect(m.minor(0, 3, 0, 3).rows).to eq(m.rows)
+      expect(m.minor(1, 2, 0, 1).rows).to eq([[4], [7]])
+      expect(m.minor(0, 3, 0, 2).rows).to eq([[1, 2], [4, 5], [7, 8]])
+      expect(m.minor(1, 1, 1, 1).rows).to eq([[5]])
+      expect(m.minor(-1, 1, -1, 1).rows).to eq([[9]])
     end
 
     it "returns a section of the matrix (3)" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
-      m.minor(1, 2, 1, 1).rows.should eq([[4], [6]])
+      expect(m.minor(1, 2, 1, 1).rows).to eq([[4], [6]])
     end
 
     it "returns a section of the matrix given ranges as args" do
       m = Matrix(Int32).diagonal(9, 5, -3).minor(0..1, 0..2)
-      m.rows.should eq([[9, 0, 0], [0, 5, 0]])
+      expect(m.rows).to eq([[9, 0, 0], [0, 5, 0]])
     end
   end
 
@@ -431,7 +431,7 @@ describe Matrix do
     it "returns an array with the row corresponding to the given index" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       a = [4, 5, 6]
-      m.row(1).should eq(a)
+      expect(m.row(1)).to eq(a)
     end
   end
 
@@ -440,7 +440,7 @@ describe Matrix do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = a.row_vectors
       c = [Matrix[[1, 2, 3]], Matrix[[4, 5, 6]], Matrix[[7, 8, 9]]]
-      b.should eq(c)
+      expect(b).to eq(c)
     end
   end
 
@@ -448,7 +448,7 @@ describe Matrix do
     it "returns an array with the rows of the matrix" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.rows.should eq(a)
+      expect(m.rows).to eq(a)
     end
   end
 
@@ -456,7 +456,7 @@ describe Matrix do
     it "returns an array with the column corresponding to the given index" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       a = [2, 5, 8]
-      m.column(1).should eq(a)
+      expect(m.column(1)).to eq(a)
     end
   end
 
@@ -465,7 +465,7 @@ describe Matrix do
       a = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       b = a.column_vectors
       c = [Matrix[[1], [4], [7]], Matrix[[2], [5], [8]], Matrix[[3], [6], [9]]]
-      b.should eq(c)
+      expect(b).to eq(c)
     end
   end
 
@@ -473,140 +473,140 @@ describe Matrix do
     it "returns an array with the columns of the matrix" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       a = [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
-      m.columns.should eq(a)
+      expect(m.columns).to eq(a)
     end
   end
 
   describe "lower_triangular?" do
     it "returns true if the matrix is lower triangular (1)" do
       m = Matrix[[1, 0, 0], [2, 8, 0], [4, 9, 7]]
-      m.lower_triangular?.should be_true
+      expect(m.lower_triangular?).to be_true
     end
 
     it "returns true if the matrix is lower triangular (2)" do
       m = Matrix[[1, 2], [3, 4]]
-      m.lower_triangular?.should be_false
+      expect(m.lower_triangular?).to be_false
     end
 
     it "returns true if the matrix is lower triangular (3)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.lower_triangular?.should be_false
+      expect(m.lower_triangular?).to be_false
     end
   end
 
   describe "upper_triangular?" do
     it "returns true if the matrix is upper triangular (1)" do
       m = Matrix[[1, 4, 2], [0, 3, 4], [0, 0, 1]]
-      m.upper_triangular?.should be_true
+      expect(m.upper_triangular?).to be_true
     end
 
     it "returns true if the matrix is upper triangular (2)" do
       m = Matrix[[1, 2], [3, 4]]
-      m.upper_triangular?.should be_false
+      expect(m.upper_triangular?).to be_false
     end
 
     it "returns true if the matrix is upper triangular (3)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.upper_triangular?.should be_false
+      expect(m.upper_triangular?).to be_false
     end
   end
 
   describe "permutation?" do
     it "returns true if the matrix is a permutation matrix (1)" do
       m = Matrix.identity(10)
-      m.permutation?.should be_true
+      expect(m.permutation?).to be_true
     end
 
     it "returns true if the matrix is a permutation matrix (2)" do
       m = Matrix[[1, 0, 0], [0, 1, 0], [0, 1, 0]]
-      m.permutation?.should be_false
+      expect(m.permutation?).to be_false
     end
 
     it "returns true if the matrix is a permutation matrix (3)" do
       m = Matrix[[1, 0, 0], [0, 1, 0], [0, 0, 0]]
-      m.permutation?.should be_false
+      expect(m.permutation?).to be_false
     end
 
     it "returns true if the matrix is a permutation matrix (4)" do
-      Matrix[[0, 0, 1], [1, 0, 1], [0, 0, 0]].permutation?.should be_false
-      Matrix[[0, 1, 1], [0, 0, 0], [0, 1, 0]].permutation?.should be_false
-      Matrix[[0, 0, 0], [1, 0, 0], [1, 1, 0]].permutation?.should be_false
-      Matrix[[0, 0, 1], [1, 0, 1], [0, 0, 0]].permutation?.should be_false
+      expect(Matrix[[0, 0, 1], [1, 0, 1], [0, 0, 0]].permutation?).to be_false
+      expect(Matrix[[0, 1, 1], [0, 0, 0], [0, 1, 0]].permutation?).to be_false
+      expect(Matrix[[0, 0, 0], [1, 0, 0], [1, 1, 0]].permutation?).to be_false
+      expect(Matrix[[0, 0, 1], [1, 0, 1], [0, 0, 0]].permutation?).to be_false
     end
   end
 
   describe "regular?" do
     it "returns true if the matrix is regular (1)" do
       m = Matrix[[2, 6], [1, 3]]
-      m.regular?.should be_false
+      expect(m.regular?).to be_false
     end
 
     it "returns true if the matrix is regular (2)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.regular?.should be_false
+      expect(m.regular?).to be_false
     end
 
     it "returns true if the matrix is regular (3)" do
       m = Matrix[[1, 2], [3, 4]]
-      m.regular?.should be_true
+      expect(m.regular?).to be_true
     end
   end
 
   describe "rank" do
     it "returns the rank of the matrix (1)" do
       m = Matrix[[1, 1, 0, 2], [-1, -1, 0, -2]]
-      m.rank.should eq(1)
+      expect(m.rank).to eq(1)
     end
 
     it "returns the rank of the matrix (2)" do
       m = Matrix[[7,6], [3,9]]
-      m.rank.should eq(2)
+      expect(m.rank).to eq(2)
     end
 
     it "returns the rank of the matrix (3)" do
       m = Matrix[[1.23, 2.34, 3.45], [4.56, 5.67, 6.78], [7.89, 8.91, 9.10]]
-      m.rank.should eq(3)
+      expect(m.rank).to eq(3)
     end
   end
 
   describe "singular?" do
     it "returns true if the matrix is singular (1)" do
       m = Matrix[[2, 6], [1, 3]]
-      m.singular?.should be_true
+      expect(m.singular?).to be_true
     end
 
     it "returns true if the matrix is singular (2)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.singular?.should be_true
+      expect(m.singular?).to be_true
     end
 
     it "returns true if the matrix is singular (3)" do
       m = Matrix[[1, 2], [3, 4]]
-      m.singular?.should be_false
+      expect(m.singular?).to be_false
     end
   end
 
   describe "square?" do
     it "returns true if the matrix is square, false otherwise (1)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-      m.square?.should be_true
+      expect(m.square?).to be_true
     end
 
     it "returns true if the matrix is square, false otherwise (1)" do
       m = Matrix[[1, 2], [3, 4], [5, 6]]
-      m.square?.should be_false
+      expect(m.square?).to be_false
     end
   end
 
   describe "symmetric?" do
     it "returns true if the matrix is symmetric (1)" do
       m = Matrix[[1, 2, 3], [2, 5, 6], [3, 6, 9]]
-      m.symmetric?.should be_true
+      expect(m.symmetric?).to be_true
     end
 
     it "returns true if the matrix is symmetric (2)" do
       m = Matrix[[1, 2, 3], [4, 5, 6], [3, 6, 9]]
-      m.symmetric?.should be_false
+      expect(m.symmetric?).to be_false
     end
   end
 
@@ -614,19 +614,19 @@ describe Matrix do
     it "returns an array with each element in the matrix (1)" do
       m = Matrix.rows([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
       a = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-      m.to_a.should eq(a)
+      expect(m.to_a).to eq(a)
     end
 
     it "returns an array with each element in the matrix (2)" do
       m = Matrix.columns([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
       a = [1, 4, 7, 2, 5, 8, 3, 6, 9]
-      m.to_a.should eq(a)
+      expect(m.to_a).to eq(a)
     end
 
     it "returns an array with each element in the matrix (3)" do
       m = Matrix.identity(5)
       a = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1]
-      m.to_a.should eq(a)
+      expect(m.to_a).to eq(a)
     end
   end
 
@@ -635,14 +635,14 @@ describe Matrix do
       m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
       h = { {0, 0} => 1, {0, 1} => 2, {0, 2} => 3, {1, 0} => 4, {1, 1} => 5,
         {1, 2} => 6, {2, 0} => 7, {2, 1} => 8, {2, 2} => 9}
-      m.to_h.should eq(h)
+      expect(m.to_h).to eq(h)
     end
 
     it "returns a hash: {row_index, column_index} => value (2)" do
       m = Matrix[[1,2], [3,4], [5,6], [7,8]]
       h = { {0, 0} => 1, {0, 1} => 2, {1, 0} => 3, {1, 1} => 4, {2, 0} => 5,
         {2, 1} => 6, {3, 0} => 7, {3, 1} => 8}
-      m.to_h.should eq(h)
+      expect(m.to_h).to eq(h)
     end
 
     it "returns a hash: {row_index, column_index} => value (3)" do
@@ -683,19 +683,19 @@ describe Matrix do
         {8, 8} => 0.26, {8, 9} => 0.85, {9, 0} => 0.36, {9, 1} => 0.15,
         {9, 2} => 0.76, {9, 3} => 0.92, {9, 4} => 0.14, {9, 5} => 0.50,
         {9, 6} => 0.84, {9, 7} => 0.91, {9, 8} => 0.07, {9, 9} => 0.88}
-      m.to_h.should eq(h)
+      expect(m.to_h).to eq(h)
     end
   end
 
   describe "trace" do
     it "returns the sum of the diagonal elements of the matrix (1)" do
       m = Matrix[{1, 2}, {3, 4}]
-      m.trace.should eq(5)
+      expect(m.trace).to eq(5)
     end
 
     it "returns the sum of the diagonal elements of the matrix (2)" do
       m = Matrix[{1.1, 2.2, 3.3}, {4.4, 5.5, 6.6}, {7.7, 8.8, 9.9}]
-      m.trace.should eq(16.5)
+      expect(m.trace).to eq(16.5)
     end
   end
 
@@ -703,25 +703,25 @@ describe Matrix do
     it "transposes the elements in a square matrix" do
       a = Matrix.rows([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
       b = Matrix.rows([[1, 4, 7], [2, 5, 8], [3, 6, 9]])
-      a.transpose.should eq(b)
+      expect(a.transpose).to eq(b)
     end
 
     it "transposes the elements in a non-square matrix" do
       a = Matrix.rows([['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h']])
       b = Matrix.rows([['a', 'c', 'e', 'g'], ['b', 'd', 'f', 'h']])
-      a.transpose.should eq(b)
+      expect(a.transpose).to eq(b)
     end
 
     it "transposes the elements in a single row matrix" do
       a = Matrix.row(:a, :b, :c, :d)
       b = Matrix.column(:a, :b, :c, :d)
-      a.transpose.should eq(b)
+      expect(a.transpose).to eq(b)
     end
 
     it "transposes the elements in a single column matrix" do
       a = Matrix.column(:a, :b, :c, :d)
       b = Matrix.row(:a, :b, :c, :d)
-      a.transpose.should eq(b)
+      expect(a.transpose).to eq(b)
     end
   end
 end

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -3,90 +3,90 @@ require "spec"
 describe "Number" do
   describe "significant" do
     it "10 base " do
-      1234.567.significant(1).should eq(1000)
-      1234.567.significant(2).should eq(1200)
-      1234.567.significant(3).should eq(1230)
-      1234.567.significant(4).should eq(1235)
-      1234.567.significant(5).should be_close(1234.6, 1e-7)
-      1234.567.significant(6).should eq(1234.57)
-      1234.567.significant(7).should eq(1234.567)
+      expect(1234.567.significant(1)).to eq(1000)
+      expect(1234.567.significant(2)).to eq(1200)
+      expect(1234.567.significant(3)).to eq(1230)
+      expect(1234.567.significant(4)).to eq(1235)
+      expect(1234.567.significant(5)).to be_close(1234.6, 1e-7)
+      expect(1234.567.significant(6)).to eq(1234.57)
+      expect(1234.567.significant(7)).to eq(1234.567)
     end
 
     it "2 base " do
-      -1763.116.significant(2, base = 2).should eq(-1536.0)
-      753.155.significant(3, base = 2).should eq(768.0)
-      15.159.significant(1, base = 2).should eq(16.0)
+      expect(-1763.116.significant(2, base = 2)).to eq(-1536.0)
+      expect(753.155.significant(3, base = 2)).to eq(768.0)
+      expect(15.159.significant(1, base = 2)).to eq(16.0)
     end
 
     it "8 base " do
-      -1763.116.significant(2, base = 8).should eq(-1792.0)
-      753.155.significant(3, base = 8).should eq(752.0)
-      15.159.significant(1, base = 8).should eq(16.0)
+      expect(-1763.116.significant(2, base = 8)).to eq(-1792.0)
+      expect(753.155.significant(3, base = 8)).to eq(752.0)
+      expect(15.159.significant(1, base = 8)).to eq(16.0)
     end
 
     it "preserves type" do
-      123.significant(2).should eq(120)
-      123.significant(2).should be_a(Int32)
+      expect(123.significant(2)).to eq(120)
+      expect(123.significant(2)).to be_a(Int32)
     end
   end
 
   describe "round" do
     it "10 base " do
-      -1763.116.round(2).should eq(-1763.12)
-      753.155.round(2).should eq(753.16)
-      15.151.round(2).should eq(15.15)
+      expect(-1763.116.round(2)).to eq(-1763.12)
+      expect(753.155.round(2)).to eq(753.16)
+      expect(15.151.round(2)).to eq(15.15)
     end
 
     it "2 base " do
-      -1763.116.round(2, base = 2).should eq(-1763.0)
-      753.155.round(2, base = 2).should eq(753.25)
-      15.159.round(2, base = 2).should eq(15.25)
+      expect(-1763.116.round(2, base = 2)).to eq(-1763.0)
+      expect(753.155.round(2, base = 2)).to eq(753.25)
+      expect(15.159.round(2, base = 2)).to eq(15.25)
     end
 
     it "8 base " do
-      -1763.116.round(2, base = 8).should eq(-1763.109375)
-      753.155.round(1, base = 8).should eq(753.125)
-      15.159.round(0, base = 8).should eq(15.0)
+      expect(-1763.116.round(2, base = 8)).to eq(-1763.109375)
+      expect(753.155.round(1, base = 8)).to eq(753.125)
+      expect(15.159.round(0, base = 8)).to eq(15.0)
     end
 
     it "preserves type" do
-      123.round(2).should eq(123)
-      123.round(2).should be_a(Int32)
+      expect(123.round(2)).to eq(123)
+      expect(123.round(2)).to be_a(Int32)
     end
   end
 
   it "creates an array with [] and some elements" do
     ary = Int64[1, 2, 3]
-    ary.should eq([1, 2, 3])
-    ary[0].should be_a(Int64)
+    expect(ary).to eq([1, 2, 3])
+    expect(ary[0]).to be_a(Int64)
   end
 
   it "creates an array with [] and no elements" do
     ary = Int64[]
-    ary.should eq([] of Int64)
+    expect(ary).to eq([] of Int64)
     ary << 1_i64
-    ary.should eq([1])
+    expect(ary).to eq([1])
   end
 
   it "can use methods from Comparable" do
-    5.between?(0, 9).should be_true
-    0.between?(5, 9).should be_false
+    expect(5.between?(0, 9)).to be_true
+    expect(0.between?(5, 9)).to be_false
 
-    5_u64.between?(0_i8, 9_u16).should be_true
-    0_i8.between?(5_u32, 9_i64).should be_false
+    expect(5_u64.between?(0_i8, 9_u16)).to be_true
+    expect(0_i8.between?(5_u32, 9_i64)).to be_false
 
-    25641_i16.between?(594_i64, 487696874_u32).should be_true
-    594_i64.between?(25641_i16, 487696874_u32).should be_false
+    expect(25641_i16.between?(594_i64, 487696874_u32)).to be_true
+    expect(594_i64.between?(25641_i16, 487696874_u32)).to be_false
   end
 
   it "steps from int to float" do
     count = 0
     0.step(by: 0.1, limit: 0.3) do |x|
-      typeof(x).should eq(typeof(0.1))
+      expect(typeof(x)).to eq(typeof(0.1))
       case count
-      when 0 then x.should eq(0.0)
-      when 1 then x.should eq(0.1)
-      when 2 then x.should eq(0.2)
+      when 0 then expect(x).to eq(0.0)
+      when 1 then expect(x).to eq(0.1)
+      when 2 then expect(x).to eq(0.2)
       end
       count += 1
     end

--- a/spec/std/oauth/access_token_spec.cr
+++ b/spec/std/oauth/access_token_spec.cr
@@ -4,9 +4,9 @@ require "oauth"
 describe OAuth::AccessToken do
   it "creates from response body" do
     access_token = OAuth::AccessToken.from_response("oauth_token=1234-nyi1G37179bVdYNZGZqKQEdO&oauth_token_secret=f7T6ibH25q4qkVTAUN&user_id=1234&screen_name=someuser")
-    access_token.token.should eq("1234-nyi1G37179bVdYNZGZqKQEdO")
-    access_token.secret.should eq("f7T6ibH25q4qkVTAUN")
-    access_token.extra["user_id"].should eq("1234")
-    access_token.extra["screen_name"].should eq("someuser")
+    expect(access_token.token).to eq("1234-nyi1G37179bVdYNZGZqKQEdO")
+    expect(access_token.secret).to eq("f7T6ibH25q4qkVTAUN")
+    expect(access_token.extra["user_id"]).to eq("1234")
+    expect(access_token.extra["screen_name"]).to eq("someuser")
   end
 end

--- a/spec/std/oauth/authorization_header_spec.cr
+++ b/spec/std/oauth/authorization_header_spec.cr
@@ -7,6 +7,6 @@ describe OAuth::AuthorizationHeader do
     params.add "foo", "value1"
     params.add "bar", "a+b"
     params.add "baz", "=/="
-    params.to_s.should eq(%(OAuth foo="value1", bar="a%2Bb", baz="%3D%2F%3D"))
+    expect(params.to_s).to eq(%(OAuth foo="value1", bar="a%2Bb", baz="%3D%2F%3D"))
   end
 end

--- a/spec/std/oauth/consumer_spec.cr
+++ b/spec/std/oauth/consumer_spec.cr
@@ -7,21 +7,21 @@ describe OAuth::Consumer do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token
-      uri.should eq("https://example.com/oauth/authorize?oauth_token=request_token")
+      expect(uri).to eq("https://example.com/oauth/authorize?oauth_token=request_token")
     end
 
     it "with callback url" do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token, oauth_callback: "some_callback"
-      uri.should eq("https://example.com/oauth/authorize?oauth_token=request_token&oauth_callback=some_callback")
+      expect(uri).to eq("https://example.com/oauth/authorize?oauth_token=request_token&oauth_callback=some_callback")
     end
 
     it "without custom authorize uri" do
       consumer = OAuth::Consumer.new "example.com", "consumer_key", "consumer_secret", authorize_uri: "/foo"
       request_token = OAuth::RequestToken.new "request_token", "request_secret"
       uri = consumer.get_authorize_uri request_token
-      uri.should eq("https://example.com/foo?oauth_token=request_token")
+      expect(uri).to eq("https://example.com/foo?oauth_token=request_token")
     end
   end
 

--- a/spec/std/oauth/params_spec.cr
+++ b/spec/std/oauth/params_spec.cr
@@ -7,6 +7,6 @@ describe OAuth::Params do
     params.add "foo", "value1"
     params.add "bar", "a+b"
     params.add "a=", "=/="
-    params.to_s.should eq("a%253D%3D%253D%252F%253D%26bar%3Da%252Bb%26foo%3Dvalue1")
+    expect(params.to_s).to eq("a%253D%3D%253D%252F%253D%26bar%3Da%252Bb%26foo%3Dvalue1")
   end
 end

--- a/spec/std/oauth/request_token_spec.cr
+++ b/spec/std/oauth/request_token_spec.cr
@@ -4,7 +4,7 @@ require "oauth"
 describe OAuth::RequestToken do
   it "creates from response" do
     token = OAuth::RequestToken.from_response("oauth_token_secret=p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8&oauth_callback_confirmed=true&oauth_token=qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")
-    token.secret.should eq("p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8")
-    token.token.should eq("qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")
+    expect(token.secret).to eq("p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8")
+    expect(token.token).to eq("qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")
   end
 end

--- a/spec/std/oauth/signature_spec.cr
+++ b/spec/std/oauth/signature_spec.cr
@@ -5,12 +5,12 @@ describe OAuth::Signature do
   describe "key" do
     it "gets when token secret is empty" do
       signature = OAuth::Signature.new "consumer_key", "consumer secret"
-      signature.key.should eq("consumer%20secret&")
+      expect(signature.key).to eq("consumer%20secret&")
     end
 
     it "gets when token secret is not empty" do
       signature = OAuth::Signature.new "consumer_key", "consumer secret", token_shared_secret: "token secret"
-      signature.key.should eq("consumer%20secret&token%20secret")
+      expect(signature.key).to eq("consumer%20secret&token%20secret")
     end
   end
 
@@ -25,7 +25,7 @@ describe OAuth::Signature do
         "oauth_callback": "some+callback"
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
-      base_string.should eq("POST&http%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
+      expect(base_string).to eq("POST&http%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
     it "computes with port in host" do
@@ -38,7 +38,7 @@ describe OAuth::Signature do
         "oauth_callback": "some+callback"
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
-      base_string.should eq("POST&http%3A%2F%2Fsome.host:5678%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
+      expect(base_string).to eq("POST&http%3A%2F%2Fsome.host:5678%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
 
     it "computes when ssl" do
@@ -51,7 +51,7 @@ describe OAuth::Signature do
         "oauth_callback": "some+callback"
       }
       base_string = signature.base_string request, ssl, ts, "nonce"
-      base_string.should eq("POST&https%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
+      expect(base_string).to eq("POST&https%3A%2F%2Fsome.host%2Fsome%2Fpath&oauth_callback%3Dsome%252Bcallback%26oauth_consumer_key%3Dconsumer_key%26oauth_nonce%3Dnonce%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1234%26oauth_version%3D1.0")
     end
   end
 
@@ -72,16 +72,16 @@ describe OAuth::Signature do
     base_string = signature.base_string(request, ssl, ts, nonce)
     expected_base_string = "POST&https%3A%2F%2Fapi.twitter.com%2F1%2Fstatuses%2Fupdate.json&include_entities%3Dtrue%26oauth_consumer_key%3Dxvz1evFS4wEEPTGEFPHBog%26oauth_nonce%3DkYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1318622958%26oauth_token%3D370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb%26oauth_version%3D1.0%26status%3DHello%2520Ladies%2520%252B%2520Gentlemen%252C%2520a%2520signed%2520OAuth%2520request%2521"
 
-    base_string.should eq(expected_base_string)
+    expect(base_string).to eq(expected_base_string)
 
     computed = signature.compute request, ssl, ts, nonce
     expected_computed = "tnnArxj06cWHq44gCs1OSKk/jLY="
 
-    computed.should eq(expected_computed)
+    expect(computed).to eq(expected_computed)
 
     header = signature.authorization_header request, ssl, ts, nonce
     expected_header = %(OAuth oauth_consumer_key="xvz1evFS4wEEPTGEFPHBog", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1318622958", oauth_nonce="kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg", oauth_signature="tnnArxj06cWHq44gCs1OSKk%2FjLY%3D", oauth_token="370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb", oauth_version="1.0")
 
-    header.should eq(expected_header)
+    expect(header).to eq(expected_header)
   end
 end

--- a/spec/std/oauth2/access_token_spec.cr
+++ b/spec/std/oauth2/access_token_spec.cr
@@ -19,24 +19,24 @@ class OAuth2::AccessToken
 
       access_token = AccessToken.from_json(json)
       access_token = access_token as Bearer
-      access_token.token_type.should eq("Bearer")
-      access_token.access_token.should eq(token_value)
-      access_token.expires_in.should eq(expires_in)
-      access_token.refresh_token.should eq(refresh_token)
-      access_token.scope.should eq(scope)
+      expect(access_token.token_type).to eq("Bearer")
+      expect(access_token.access_token).to eq(token_value)
+      expect(access_token.expires_in).to eq(expires_in)
+      expect(access_token.refresh_token).to eq(refresh_token)
+      expect(access_token.scope).to eq(scope)
     end
 
     it "dumps to json" do
       token = Bearer.new("access token", 3600, "refresh token")
       token2 = AccessToken.from_json(token.to_json)
-      token2.should eq(token)
+      expect(token2).to eq(token)
     end
 
     it "authenticates request" do
       token = Bearer.new("access token", 3600, "refresh token")
       request = HTTP::Request.new "GET", "/"
       token.authenticate request, false
-      request.headers["Authorization"].should eq("Bearer access token")
+      expect(request.headers["Authorization"]).to eq("Bearer access token")
     end
   end
 
@@ -60,13 +60,13 @@ class OAuth2::AccessToken
 
       access_token = AccessToken.from_json(json)
       access_token = access_token as Mac
-      access_token.token_type.should eq("Mac")
-      access_token.access_token.should eq(token_value)
-      access_token.expires_in.should eq(expires_in)
-      access_token.refresh_token.should eq(refresh_token)
-      access_token.scope.should eq(scope)
-      access_token.mac_algorithm.should eq(mac_algorithm)
-      access_token.mac_key.should eq(mac_key)
+      expect(access_token.token_type).to eq("Mac")
+      expect(access_token.access_token).to eq(token_value)
+      expect(access_token.expires_in).to eq(expires_in)
+      expect(access_token.refresh_token).to eq(refresh_token)
+      expect(access_token.scope).to eq(scope)
+      expect(access_token.mac_algorithm).to eq(mac_algorithm)
+      expect(access_token.mac_key).to eq(mac_key)
     end
 
     it "builds with null refresh token" do
@@ -80,13 +80,13 @@ class OAuth2::AccessToken
         })
       access_token = AccessToken.from_json(json)
       access_token = access_token as Mac
-      access_token.refresh_token.should be_nil
+      expect(access_token.refresh_token).to be_nil
     end
 
     it "dumps to json" do
       token = Mac.new("access token", 3600, "mac algorithm", "mac key", "refresh token", "scope")
       token2 = AccessToken.from_json(token.to_json)
-      token2.should eq(token)
+      expect(token2).to eq(token)
     end
 
     it "authenticates request" do
@@ -97,12 +97,12 @@ class OAuth2::AccessToken
       request = HTTP::Request.new "GET", "/some/resource.json", headers
       token.authenticate request, false
       auth = request.headers["Authorization"]
-      (auth =~ /MAC id=".+?", nonce=".+?", ts=".+?", mac=".+?"/).should be_truthy
+      expect((auth =~ /MAC id=".+?", nonce=".+?", ts=".+?", mac=".+?"/)).to be_truthy
     end
 
     it "computes signature" do
       mac = Mac.signature 1, "0:1234", "GET", "/resource.json", "localhost", "4000", "", "hmac-sha-256", "i-pt1Lir-yAfUdXbt-AXM1gMupK7vDiOK1SZGWkASDc"
-      mac.should eq("21vVRFACz5NrO+zlVfFuxTjTx5Wb0qBMfKelMTtujpE=")
+      expect(mac).to eq("21vVRFACz5NrO+zlVfFuxTjTx5Wb0qBMfKelMTtujpE=")
     end
   end
 end

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -6,19 +6,19 @@ describe OAuth2::Client do
     it "gets with default endpoint" do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri"
       uri = client.get_authorize_uri(scope: "foo bar")
-      uri.should eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar")
+      expect(uri).to eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar")
     end
 
     it "gets with custom endpoint" do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri", authorize_uri: "/baz"
       uri = client.get_authorize_uri(scope: "foo bar")
-      uri.should eq("https://localhost/baz?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar")
+      expect(uri).to eq("https://localhost/baz?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar")
     end
 
     it "gets with state" do
       client = OAuth2::Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri"
       uri = client.get_authorize_uri(scope: "foo bar", state: "xyz")
-      uri.should eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar&state=xyz")
+      expect(uri).to eq("https://localhost/oauth2/authorize?client_id=client_id&redirect_uri=uri&response_type=code&scope=foo%20bar&state=xyz")
     end
   end
 

--- a/spec/std/openssl/hmac_spec.cr
+++ b/spec/std/openssl/hmac_spec.cr
@@ -16,7 +16,7 @@ describe OpenSSL::HMAC do
     {:ripemd160, "20d23140503df606c91bda9293f1ad4a23afe509"},
   ].each do |tuple|
     it "computes #{tuple[0]}" do
-      OpenSSL::HMAC.hexdigest(tuple[0], "foo", "bar").should eq(tuple[1])
+      expect(OpenSSL::HMAC.hexdigest(tuple[0], "foo", "bar")).to eq(tuple[1])
     end
   end
 end

--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -8,8 +8,8 @@ private def expect_capture_option(args, option, value)
       flag = flag_value
     end
   end
-  flag.should eq(value)
-  args.length.should eq(0)
+  expect(flag).to eq(value)
+  expect(args.length).to eq(0)
 end
 
 private def expect_doesnt_capture_option(args, option)
@@ -19,7 +19,7 @@ private def expect_doesnt_capture_option(args, option)
       flag = true
     end
   end
-  flag.should be_false
+  expect(flag).to be_false
 end
 
 private def expect_missing_option(option)
@@ -145,7 +145,7 @@ describe "OptionParser" do
       opts.on("-g[FLAG]", "some other flag") do
       end
     end
-    parser.to_s.should eq([
+    expect(parser.to_s).to eq([
       "Usage: foo",
       "    -f, --flag                       some flag"
       "    -g[FLAG]                         some other flag"
@@ -164,7 +164,7 @@ describe "OptionParser" do
       opts.on("-g[FLAG]", "some other flag") do
       end
     end
-    parser.to_s.should eq([
+    expect(parser.to_s).to eq([
       "Usage: foo",
       "",
       "Type F flags:",
@@ -192,7 +192,7 @@ describe "OptionParser" do
           count += 1
         end
       end
-      count.should eq(3)
+      expect(count).to eq(3)
     end
 
     it "gets a single flag option multiple times" do
@@ -203,7 +203,7 @@ describe "OptionParser" do
           values << value
         end
       end
-      values.should eq(%w(1 2))
+      expect(values).to eq(%w(1 2))
     end
 
     it "gets a double flag option multiple times" do
@@ -214,7 +214,7 @@ describe "OptionParser" do
           values << value
         end
       end
-      values.should eq(%w(1 2))
+      expect(values).to eq(%w(1 2))
     end
   end
 
@@ -231,9 +231,9 @@ describe "OptionParser" do
           g = true
         end
       end
-      f.should be_true
-      g.should be_false
-      args.should eq(["bar", "baz", "qux", "-g"])
+      expect(f).to be_true
+      expect(g).to be_false
+      expect(args).to eq(["bar", "baz", "qux", "-g"])
     end
 
     it "ignores everything after -- with single flag)" do
@@ -248,9 +248,9 @@ describe "OptionParser" do
           g = v
         end
       end
-      f.should eq("bar")
-      g.should be_nil
-      args.should eq(["x", "baz", "qux", "-g", "lala"])
+      expect(f).to eq("bar")
+      expect(g).to be_nil
+      expect(args).to eq(["x", "baz", "qux", "-g", "lala"])
     end
 
     it "ignores everything after -- with double flag" do
@@ -265,9 +265,9 @@ describe "OptionParser" do
           g = v
         end
       end
-      f.should eq("bar")
-      g.should be_nil
-      args.should eq(["x", "baz", "qux", "--g", "lala"])
+      expect(f).to eq("bar")
+      expect(g).to be_nil
+      expect(args).to eq(["x", "baz", "qux", "--g", "lala"])
     end
 
     it "returns a pair with things coming before and after --" do
@@ -282,9 +282,9 @@ describe "OptionParser" do
           unknown_args = {before_dash, after_dash}
         end
       end
-      f.should eq("bar")
-      args.should eq(["baz", "qux"])
-      unknown_args.should eq({["baz"], ["qux"]})
+      expect(f).to eq("bar")
+      expect(args).to eq(["baz", "qux"])
+      expect(unknown_args).to eq({["baz"], ["qux"]})
     end
 
     it "returns a pair with things coming before and after --, without --" do
@@ -299,9 +299,9 @@ describe "OptionParser" do
           unknown_args = {before_dash, after_dash}
         end
       end
-      f.should eq("bar")
-      args.should eq(["baz"])
-      unknown_args.should eq({["baz"], [] of String})
+      expect(f).to eq("bar")
+      expect(args).to eq(["baz"])
+      expect(unknown_args).to eq({["baz"], [] of String})
     end
 
     it "initializes without block and does parse!" do
@@ -315,7 +315,7 @@ describe "OptionParser" do
             f = v
           end
         end.parse!
-        f.should eq("hi")
+        expect(f).to eq("hi")
       ensure
         ARGV.clear
         ARGV.concat old_argv

--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -4,21 +4,21 @@ describe "Pointer" do
   it "does malloc with value" do
     p1 = Pointer.malloc(4, 1)
     4.times do |i|
-      p1[i].should eq(1)
+      expect(p1[i]).to eq(1)
     end
   end
 
   it "does malloc with value from block" do
     p1 = Pointer.malloc(4) { |i| i }
     4.times do |i|
-      p1[i].should eq(i)
+      expect(p1[i]).to eq(i)
     end
   end
 
   it "does index with count" do
     p1 = Pointer.malloc(4) { |i| i ** 2 }
-    p1.to_slice(4).index(4).should eq(2)
-    p1.to_slice(4).index(5).should be_nil
+    expect(p1.to_slice(4).index(4)).to eq(2)
+    expect(p1.to_slice(4).index(5)).to be_nil
   end
 
   describe "copy_from" do
@@ -27,7 +27,7 @@ describe "Pointer" do
       p2 = Pointer.malloc(4) { 0 }
       p2.copy_from(p1, 4)
       4.times do |i|
-        p2[0].should eq(p1[0])
+        expect(p2[0]).to eq(p1[0])
       end
     end
   end
@@ -38,7 +38,7 @@ describe "Pointer" do
       p2 = Pointer.malloc(4) { 0 }
       p1.copy_to(p2, 4)
       4.times do |i|
-        p2[0].should eq(p1[0])
+        expect(p2[0]).to eq(p1[0])
       end
     end
   end
@@ -47,19 +47,19 @@ describe "Pointer" do
     it "performs with overlap right to left" do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 1).move_from(p1 + 2, 2)
-      p1[0].should eq(0)
-      p1[1].should eq(2)
-      p1[2].should eq(3)
-      p1[3].should eq(3)
+      expect(p1[0]).to eq(0)
+      expect(p1[1]).to eq(2)
+      expect(p1[2]).to eq(3)
+      expect(p1[3]).to eq(3)
     end
 
     it "performs with overlap left to right" do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 2).move_from(p1 + 1, 2)
-      p1[0].should eq(0)
-      p1[1].should eq(1)
-      p1[2].should eq(1)
-      p1[3].should eq(2)
+      expect(p1[0]).to eq(0)
+      expect(p1[1]).to eq(1)
+      expect(p1[2]).to eq(1)
+      expect(p1[3]).to eq(2)
     end
   end
 
@@ -67,19 +67,19 @@ describe "Pointer" do
     it "performs with overlap right to left" do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 2).move_to(p1 + 1, 2)
-      p1[0].should eq(0)
-      p1[1].should eq(2)
-      p1[2].should eq(3)
-      p1[3].should eq(3)
+      expect(p1[0]).to eq(0)
+      expect(p1[1]).to eq(2)
+      expect(p1[2]).to eq(3)
+      expect(p1[3]).to eq(3)
     end
 
     it "performs with overlap left to right" do
       p1 = Pointer.malloc(4) { |i| i }
       (p1 + 1).move_to(p1 + 2, 2)
-      p1[0].should eq(0)
-      p1[1].should eq(1)
-      p1[2].should eq(1)
-      p1[3].should eq(2)
+      expect(p1[0]).to eq(0)
+      expect(p1[1]).to eq(1)
+      expect(p1[2]).to eq(1)
+      expect(p1[3]).to eq(2)
     end
   end
 
@@ -89,46 +89,46 @@ describe "Pointer" do
       p2 = Pointer.malloc(4) { |i| i }
       p3 = Pointer.malloc(4) { |i| i + 1 }
 
-      p1.memcmp(p2, 4).should eq(0)
-      p1.memcmp(p3, 4).should be < 0
-      p3.memcmp(p1, 4).should be > 0
+      expect(p1.memcmp(p2, 4)).to eq(0)
+      expect(p1.memcmp(p3, 4)).to be < 0
+      expect(p3.memcmp(p1, 4)).to be > 0
     end
   end
 
   it "compares two pointers by address" do
     p1 = Pointer(Int32).malloc(1)
     p2 = Pointer(Int32).malloc(1)
-    p1.should eq(p1)
-    p1.should_not eq(p2)
-    p1.should_not eq(1)
+    expect(p1).to eq(p1)
+    expect(p1).to_not eq(p2)
+    expect(p1).to_not eq(1)
   end
 
   it "does to_s" do
-    Pointer(Int32).null.to_s.should eq("Pointer(Int32).null")
-    Pointer(Int32).new(1234_u64).to_s.should eq("Pointer(Int32)@0x4D2")
+    expect(Pointer(Int32).null.to_s).to eq("Pointer(Int32).null")
+    expect(Pointer(Int32).new(1234_u64).to_s).to eq("Pointer(Int32)@0x4D2")
   end
 
   it "creates from int" do
-    Pointer(Int32).new(1234).address.should eq(1234)
+    expect(Pointer(Int32).new(1234).address).to eq(1234)
   end
 
   it "shuffles!" do
     a = Pointer(Int32).malloc(3) { |i| i + 1}
     a.shuffle!(3)
 
-    (a[0] + a[1] + a[2]).should eq(6)
+    expect((a[0] + a[1] + a[2])).to eq(6)
 
     3.times do |i|
-      a.to_slice(3).includes?(i + 1).should be_true
+      expect(a.to_slice(3).includes?(i + 1)).to be_true
     end
   end
 
   it "maps!" do
     a = Pointer(Int32).malloc(3) { |i| i + 1}
     a.map!(3) { |i| i + 1 }
-    a[0].should eq(2)
-    a[1].should eq(3)
-    a[2].should eq(4)
+    expect(a[0]).to eq(2)
+    expect(a[1]).to eq(3)
+    expect(a[2]).to eq(4)
   end
 
   it "raises if mallocs negative size" do

--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -5,7 +5,7 @@ describe "Proc" do
     str = StringIO.new
     f = ->(x : Int32) { x.to_f }
     f.to_s(str)
-    str.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
+    expect(str.to_s).to eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
   it "does to_s(io) when closured" do
@@ -13,51 +13,51 @@ describe "Proc" do
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s(str)
-    str.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")
+    expect(str.to_s).to eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")
   end
 
   it "does to_s" do
     str = StringIO.new
     f = ->(x : Int32) { x.to_f }
-    f.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
+    expect(f.to_s).to eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
   it "does to_s when closured" do
     str = StringIO.new
     a = 1.5
     f = ->(x : Int32) { x + a }
-    f.to_s.should eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")
+    expect(f.to_s).to eq("#<(Int32 -> Float64):0x#{f.pointer.address.to_s(16)}:closure>")
   end
 
   it "gets pointer" do
     f = ->{ 1 }
-    f.pointer.address.should be > 0
+    expect(f.pointer.address).to be > 0
   end
 
   it "gets closure data for non-closure" do
     f = ->{ 1 }
-    f.closure_data.address.should eq(0)
-    f.closure?.should be_false
+    expect(f.closure_data.address).to eq(0)
+    expect(f.closure?).to be_false
   end
 
   it "gets closure data for closure" do
     a = 1
     f = ->{ a }
-    f.closure_data.address.should be > 0
-    f.closure?.should be_true
+    expect(f.closure_data.address).to be > 0
+    expect(f.closure?).to be_true
   end
 
   it "does new" do
     a = 1
     f = ->(x : Int32){ x + a }
     f2 = Proc(Int32, Int32).new(f.pointer, f.closure_data)
-    f2.call(3).should eq(4)
+    expect(f2.call(3)).to eq(4)
   end
 
   it "does ==" do
     func = ->{ 1 }
-    func.should eq(func)
+    expect(func).to eq(func)
     func2 = ->{ 1 }
-    func2.should_not eq(func)
+    expect(func2).to_not eq(func)
   end
 end

--- a/spec/std/process/run_spec.cr
+++ b/spec/std/process/run_spec.cr
@@ -2,51 +2,51 @@ require "spec"
 
 describe "Process.run" do
   it "gets status code from successful process" do
-    Process.run("true").exit.should eq(0)
+    expect(Process.run("true").exit).to eq(0)
   end
 
   it "gets status code from failed process" do
-    Process.run("false").exit.should eq(1)
+    expect(Process.run("false").exit).to eq(1)
   end
 
   it "returns status 127 if command could not be executed" do
-    Process.run("foobarbaz", output: true).exit.should eq(127)
+    expect(Process.run("foobarbaz", output: true).exit).to eq(127)
   end
 
   it "includes PID in process status " do
-    Process.run("true").pid.should be > 0
+    expect(Process.run("true").pid).to be > 0
   end
 
   it "receives arguments in array" do
-    Process.run("/bin/sh", ["-c", "exit 123"]).exit.should eq(123)
+    expect(Process.run("/bin/sh", ["-c", "exit 123"]).exit).to eq(123)
   end
 
   it "receives arguments in tuple" do
-    Process.run("/bin/sh", {"-c", "exit 123"}).exit.should eq(123)
+    expect(Process.run("/bin/sh", {"-c", "exit 123"}).exit).to eq(123)
   end
 
   it "redirects output to /dev/null" do
     # This doesn't test anything but no output should be seen while running tests
-    Process.run("/bin/ls", output: false).exit.should eq(0)
+    expect(Process.run("/bin/ls", output: false).exit).to eq(0)
   end
 
   it "gets output as string" do
-    Process.run("/bin/sh", {"-c", "echo hello"}, output: true).output.should eq("hello\n")
+    expect(Process.run("/bin/sh", {"-c", "echo hello"}, output: true).output).to eq("hello\n")
   end
 
   it "send input from string" do
-    Process.run("/bin/cat", input: "hello", output: true).output.should eq("hello")
+    expect(Process.run("/bin/cat", input: "hello", output: true).output).to eq("hello")
   end
 
   it "send input from IO" do
     File.open(__FILE__, "r") do |file|
-      Process.run("/bin/cat", input: file, output: true).output.should eq(File.read(__FILE__))
+      expect(Process.run("/bin/cat", input: file, output: true).output).to eq(File.read(__FILE__))
     end
   end
 
   it "send output to IO" do
     io = StringIO.new
-    Process.run("/bin/cat", input: "hello", output: io).output.should be_nil
-    io.to_s.should eq("hello")
+    expect(Process.run("/bin/cat", input: "hello", output: io).output).to be_nil
+    expect(io.to_s).to eq("hello")
   end
 end

--- a/spec/std/random/isaac_spec.cr
+++ b/spec/std/random/isaac_spec.cr
@@ -342,7 +342,7 @@ describe "Random::ISAAC" do
 
     m = Random::ISAAC.new seed
     numbers.each do |n|
-      m.next_u32.should eq(n)
+      expect(m.next_u32).to eq(n)
     end
   end
 end

--- a/spec/std/random/mt19937_spec.cr
+++ b/spec/std/random/mt19937_spec.cr
@@ -212,7 +212,7 @@ describe "Random::MT19937" do
 
     m = Random::MT19937.new [0x123, 0x234, 0x345, 0x456]
     numbers.each do |n|
-      m.next_u32.should eq(n)
+      expect(m.next_u32).to eq(n)
     end
   end
 end

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -2,17 +2,17 @@ require "spec"
 
 describe "Random" do
   it "limited number" do
-    rand(1).should eq(0)
+    expect(rand(1)).to eq(0)
 
     x = rand(2)
-    x.should be >= 0
-    x.should be < 2
+    expect(x).to be >= 0
+    expect(x).to be < 2
   end
 
   it "float number" do
     x = rand
-    x.should be > 0
-    x.should be < 1
+    expect(x).to be > 0
+    expect(x).to be < 1
   end
 
   it "raises on invalid number" do
@@ -22,17 +22,17 @@ describe "Random" do
   end
 
   it "does with inclusive range" do
-    rand(1..1).should eq(1)
+    expect(rand(1..1)).to eq(1)
     x = rand(1..3)
-    x.should be >= 1
-    x.should be <= 3
+    expect(x).to be >= 1
+    expect(x).to be <= 3
   end
 
   it "does with exclusive range" do
-    rand(1...2).should eq(1)
+    expect(rand(1...2)).to eq(1)
     x = rand(1...4)
-    x.should be >= 1
-    x.should be < 4
+    expect(x).to be >= 1
+    expect(x).to be < 4
   end
 
   it "raises on invalid range" do
@@ -44,7 +44,7 @@ describe "Random" do
   it "allows creating a new default random" do
     rand = Random.new
     value = rand.rand
-    (0 <= value < 1).should be_true
+    expect((0 <= value < 1)).to be_true
   end
 
   it "allows creating a new default random with a seed" do
@@ -54,10 +54,10 @@ describe "Random" do
     rand = Random.new(1234)
     value2 = rand.rand
 
-    value1.should eq(value2)
+    expect(value1).to eq(value2)
   end
 
   it "gets a random bool" do
-    Random::DEFAULT.next_bool.should be_a(Bool)
+    expect(Random::DEFAULT.next_bool).to be_a(Bool)
   end
 end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -3,30 +3,30 @@ require "spec"
 describe "Range" do
   it "gets basic properties" do
     r = 1 .. 5
-    r.begin.should eq(1)
-    r.end.should eq(5)
-    r.excludes_end?.should be_false
+    expect(r.begin).to eq(1)
+    expect(r.end).to eq(5)
+    expect(r.excludes_end?).to be_false
 
     r = 1 ... 5
-    r.begin.should eq(1)
-    r.end.should eq(5)
-    r.excludes_end?.should be_true
+    expect(r.begin).to eq(1)
+    expect(r.end).to eq(5)
+    expect(r.excludes_end?).to be_true
   end
 
   it "includes?" do
-    (1 .. 5).includes?(1).should be_true
-    (1 .. 5).includes?(5).should be_true
+    expect((1 .. 5).includes?(1)).to be_true
+    expect((1 .. 5).includes?(5)).to be_true
 
-    (1 ... 5).includes?(1).should be_true
-    (1 ... 5).includes?(5).should be_false
+    expect((1 ... 5).includes?(1)).to be_true
+    expect((1 ... 5).includes?(5)).to be_false
   end
 
   it "does to_s" do
-    (1...5).to_s.should eq("1...5")
-    (1..5).to_s.should eq("1..5")
+    expect((1...5).to_s).to eq("1...5")
+    expect((1..5).to_s).to eq("1..5")
   end
 
   it "does inspect" do
-    (1...5).inspect.should eq("1...5")
+    expect((1...5).inspect).to eq("1...5")
   end
 end

--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -15,43 +15,43 @@ describe "Reference" do
   it "compares reference to other reference" do
     o1 = Reference.new
     o2 = Reference.new
-    (o1 == o1).should be_true
-    (o1 == o2).should be_false
-    (o1 == 1).should be_false
+    expect((o1 == o1)).to be_true
+    expect((o1 == o2)).to be_false
+    expect((o1 == 1)).to be_false
   end
 
   it "should not be nil" do
-    Reference.new.nil?.should be_false
+    expect(Reference.new.nil?).to be_false
   end
 
   it "should be false when negated" do
-    (!Reference.new).should be_false
+    expect((!Reference.new)).to be_false
   end
 
   it "does inspect" do
     r = ReferenceSpecTestClass.new(1, "hello")
-    r.inspect.should eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)} @x=1, @y="hello">))
+    expect(r.inspect).to eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)} @x=1, @y="hello">))
   end
 
   it "does to_s" do
     r = ReferenceSpecTestClass.new(1, "hello")
-    r.to_s.should eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)}>))
+    expect(r.to_s).to eq(%(#<ReferenceSpecTestClass:0x#{r.object_id.to_s(16)}>))
   end
 
   it "does inspect for class" do
-    String.inspect.should eq("String")
+    expect(String.inspect).to eq("String")
   end
 
   it "does to_s for class" do
-    String.to_s.should eq("String")
+    expect(String.to_s).to eq("String")
   end
 
   it "does to_s for class if virtual" do
-    [ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass].to_s.should eq("[ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass]")
+    expect([ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass].to_s).to eq("[ReferenceSpecTestClassBase, ReferenceSpecTestClassSubclass]")
   end
 
   it "returns itself" do
     x = "hello"
-    x.itself.should be(x)
+    expect(x.itself).to be(x)
   end
 end

--- a/spec/std/regexp_spec.cr
+++ b/spec/std/regexp_spec.cr
@@ -2,23 +2,23 @@ require "spec"
 
 describe "Regex" do
   it "matches with =~ and captures" do
-    ("fooba" =~ /f(o+)(bar?)/).should eq(0)
-    $~.length.should eq(2)
-    $1.should eq("oo")
-    $2.should eq("ba")
+    expect(("fooba" =~ /f(o+)(bar?)/)).to eq(0)
+    expect($~.length).to eq(2)
+    expect($1).to eq("oo")
+    expect($2).to eq("ba")
   end
 
   it "matches with =~ and gets utf-8 codepoint index" do
     index = "こんに" =~ /ん/
-    index.should eq(1)
+    expect(index).to eq(1)
   end
 
   it "matches with === and captures" do
     "foo" =~ /foo/
-    (/f(o+)(bar?)/ === "fooba").should be_true
-    $~.length.should eq(2)
-    $1.should eq("oo")
-    $2.should eq("ba")
+    expect((/f(o+)(bar?)/ === "fooba")).to be_true
+    expect($~.length).to eq(2)
+    expect($1).to eq("oo")
+    expect($2).to eq("ba")
   end
 
   it "raises if outside match range with []" do
@@ -33,18 +33,18 @@ describe "Regex" do
     end
 
     it "capture named group" do
-      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
-      $~["g1"].should eq("oo")
-      $~["g2"].should eq("ba")
+      expect(("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/)).to eq(0)
+      expect($~["g1"]).to eq("oo")
+      expect($~["g2"]).to eq("ba")
     end
 
     it "capture empty group" do
-      ("foo" =~ /(?<g1>.*)foo/).should eq(0)
-      $~["g1"].should eq("")
+      expect(("foo" =~ /(?<g1>.*)foo/)).to eq(0)
+      expect($~["g1"]).to eq("")
     end
 
     it "raises exception when named group doesn't exist" do
-      ("foo" =~ /foo/).should eq(0)
+      expect(("foo" =~ /foo/)).to eq(0)
       expect_raises(ArgumentError) { $~["group"] }
     end
   end
@@ -52,46 +52,46 @@ describe "Regex" do
   describe "MatchData#[]?" do
     it "returns nil if outside match range with []" do
       "foo" =~ /foo/
-      $~[1]?.should be_nil
+      expect($~[1]?).to be_nil
     end
 
     it "capture named group" do
-      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
-      $~["g1"]?.should eq("oo")
-      $~["g2"]?.should eq("ba")
+      expect(("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/)).to eq(0)
+      expect($~["g1"]?).to eq("oo")
+      expect($~["g2"]?).to eq("ba")
     end
 
     it "capture empty group" do
-      ("foo" =~ /(?<g1>.*)foo/).should eq(0)
-      $~["g1"]?.should eq("")
+      expect(("foo" =~ /(?<g1>.*)foo/)).to eq(0)
+      expect($~["g1"]?).to eq("")
     end
 
     it "returns nil exception when named group doesn't exist" do
-      ("foo" =~ /foo/).should eq(0)
-      $~["group"]?.should be_nil
+      expect(("foo" =~ /foo/)).to eq(0)
+      expect($~["group"]?).to be_nil
     end
   end
 
   it "matches multiline" do
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
+    expect(("foo\n<bar\n>baz" =~ /<bar.*?>/)).to be_nil
+    expect(("foo\n<bar\n>baz" =~ /<bar.*?>/m)).to eq(4)
   end
 
   it "matches ignore case" do
-    ("HeLlO" =~ /hello/).should be_nil
-    ("HeLlO" =~ /hello/i).should eq(0)
+    expect(("HeLlO" =~ /hello/)).to be_nil
+    expect(("HeLlO" =~ /hello/i)).to eq(0)
   end
 
   it "does to_s" do
-    /foo/.to_s.should eq("/foo/")
-    /f(o)(x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
-    /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))
+    expect(/foo/.to_s).to eq("/foo/")
+    expect(/f(o)(x)/.match("the fox").to_s).to eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    expect(/fox/.match("the fox").to_s).to eq(%(#<MatchData "fox">))
+    expect(/f(o)(x)/.match("the fox").inspect).to eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    expect(/fox/.match("the fox").inspect).to eq(%(#<MatchData "fox">))
   end
 
   it "does inspect" do
-    /foo/.inspect.should eq("/foo/")
+    expect(/foo/.inspect).to eq("/foo/")
   end
 
   it "raises exception with invalid regex" do
@@ -99,6 +99,6 @@ describe "Regex" do
   end
 
   it "escapes" do
-    Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
+    expect(Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello")).to eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
   end
 end

--- a/spec/std/secure_random_spec.cr
+++ b/spec/std/secure_random_spec.cr
@@ -5,17 +5,17 @@ describe SecureRandom do
   describe "hex" do
     it "gets hex with default number of digits" do
       hex = SecureRandom.hex
-      hex.length.should eq(32)
+      expect(hex.length).to eq(32)
       hex.each_char do |char|
-        ('0' <= char <= '9' || 'a' <= char <= 'f').should be_true
+        expect(('0' <= char <= '9' || 'a' <= char <= 'f')).to be_true
       end
     end
 
     it "gets hex with requested number of digits" do
       hex = SecureRandom.hex(50)
-      hex.length.should eq(100)
+      expect(hex.length).to eq(100)
       hex.each_char do |char|
-        ('0' <= char <= '9' || 'a' <= char <= 'f').should be_true
+        expect(('0' <= char <= '9' || 'a' <= char <= 'f')).to be_true
       end
     end
   end
@@ -23,12 +23,12 @@ describe SecureRandom do
   describe "random_bytes" do
     it "gets random bytes with default number of digits" do
       bytes = SecureRandom.random_bytes
-      bytes.length.should eq(16)
+      expect(bytes.length).to eq(16)
     end
 
     it "gets random bytes with requested number of digits" do
       bytes = SecureRandom.random_bytes(50)
-      bytes.length.should eq(50)
+      expect(bytes.length).to eq(50)
     end
   end
 end

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -4,11 +4,11 @@ require "set"
 describe "Set" do
   describe "set" do
     it "is empty" do
-      Set(Nil).new.empty?.should be_true
+      expect(Set(Nil).new.empty?).to be_true
     end
 
     it "has length 0" do
-      Set(Nil).new.length.should eq(0)
+      expect(Set(Nil).new.length).to eq(0)
     end
   end
 
@@ -16,8 +16,8 @@ describe "Set" do
     it "adds and includes" do
       set = Set(Int32).new
       set.add 1
-      set.includes?(1).should be_true
-      set.length.should eq(1)
+      expect(set.includes?(1)).to be_true
+      expect(set.length).to eq(1)
     end
   end
 
@@ -25,9 +25,9 @@ describe "Set" do
     it "deletes an object" do
       set = Set{1, 2, 3}
       set.delete 2
-      set.length.should eq(2)
-      set.includes?(1).should be_true
-      set.includes?(3).should be_true
+      expect(set.length).to eq(2)
+      expect(set.includes?(1)).to be_true
+      expect(set.includes?(3)).to be_true
     end
   end
 
@@ -37,9 +37,9 @@ describe "Set" do
       set2 = Set{1, 2, 3}
       set3 = Set{1, 2, 3, 4}
 
-      set1.should eq(set1)
-      set1.should eq(set2)
-      set1.should_not eq(set3)
+      expect(set1).to eq(set1)
+      expect(set1).to eq(set2)
+      expect(set1).to_not eq(set3)
     end
   end
 
@@ -47,36 +47,36 @@ describe "Set" do
     set1 = Set{1, 2, 3}
     set2 = Set{4, 2, 5, 3}
     set3 = set1 & set2
-    set3.should eq(Set{2, 3})
+    expect(set3).to eq(Set{2, 3})
   end
 
   it "does |" do
     set1 = Set{1, 2, 3}
     set2 = Set{4, 2, 5, 3}
     set3 = set1 | set2
-    set3.should eq(Set{1, 2, 3, 4, 5})
+    expect(set3).to eq(Set{1, 2, 3, 4, 5})
   end
 
   it "does to_a" do
-    Set{1, 2, 3}.to_a.should eq([1, 2, 3])
+    expect(Set{1, 2, 3}.to_a).to eq([1, 2, 3])
   end
 
   it "does to_s" do
-    Set{1, 2, 3}.to_s.should eq("Set{1, 2, 3}")
-    Set{"foo"}.to_s.should eq(%(Set{"foo"}))
+    expect(Set{1, 2, 3}.to_s).to eq("Set{1, 2, 3}")
+    expect(Set{"foo"}.to_s).to eq(%(Set{"foo"}))
   end
 
   it "does clear" do
     x = Set{1, 2, 3}
-    x.to_a.should eq([1, 2, 3])
-    x.clear.should be(x)
+    expect(x.to_a).to eq([1, 2, 3])
+    expect(x.clear).to be(x)
     x << 1
-    x.to_a.should eq([1])
+    expect(x.to_a).to eq([1])
   end
 
   it "compares hashes of sets" do
     h1 = { Set{1, 2, 3} => 1 }
     h2 = { Set{1, 2, 3} => 1 }
-    h1.should eq(h2)
+    expect(h1).to eq(h2)
   end
 end

--- a/spec/std/simple_hash_spec.cr
+++ b/spec/std/simple_hash_spec.cr
@@ -5,13 +5,13 @@ describe "SimpleHash" do
   describe "[]" do
     it "returns the value corresponding to the given key" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
-      a[1].should eq(2)
-      a[3].should eq(4)
-      a[5].should eq(6)
-      a[7].should eq(8)
+      expect(a[1]).to eq(2)
+      expect(a[3]).to eq(4)
+      expect(a[5]).to eq(6)
+      expect(a[7]).to eq(8)
 
       a = SimpleHash {one: :two, three: :four, five: :six}
-      a[:three].should eq(:four)
+      expect(a[:three]).to eq(:four)
     end
 
     it "raises on a missing key" do
@@ -25,19 +25,19 @@ describe "SimpleHash" do
   describe "[]?" do
     it "returns nil if the key is missing" do
       a = SimpleHash {"one": 1, "two": 2}
-      a["three"]?.should eq(nil)
-      a[:one]?.should eq(nil)
+      expect(a["three"]?).to eq(nil)
+      expect(a[:one]?).to eq(nil)
     end
   end
 
   describe "fetch" do
     it "returns the value corresponding to the given key, yields otherwise" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
-      a.fetch(1) { 10 }.should eq(2)
-      a.fetch(3) { 10 }.should eq(4)
-      a.fetch(5) { 10 }.should eq(6)
-      a.fetch(7) { 10 }.should eq(8)
-      a.fetch(9) { 10 }.should eq(10)
+      expect(a.fetch(1) { 10 }).to eq(2)
+      expect(a.fetch(3) { 10 }).to eq(4)
+      expect(a.fetch(5) { 10 }).to eq(6)
+      expect(a.fetch(7) { 10 }).to eq(8)
+      expect(a.fetch(9) { 10 }).to eq(10)
     end
   end
 
@@ -45,23 +45,23 @@ describe "SimpleHash" do
     it "adds a new key-value pair if the key is missing" do
       a = SimpleHash(Int32, Int32).new
       a[1] = 2
-      a[1].should eq(2)
+      expect(a[1]).to eq(2)
     end
 
     it "replaces the value if the key already exists" do
       a = SimpleHash(Int32, Int32).new
       a[1] = 2
       a[1] = 3
-      a[1].should eq(3)
+      expect(a[1]).to eq(3)
     end
   end
 
   describe "has_key?" do
     it "returns true if the given key is present, false otherwise" do
       a = SimpleHash {"one": 1, "two": 2}
-      a.has_key?("one").should be_true
-      a.has_key?("two").should be_true
-      a.has_key?(:one).should be_false
+      expect(a.has_key?("one")).to be_true
+      expect(a.has_key?("two")).to be_true
+      expect(a.has_key?(:one)).to be_false
     end
   end
 
@@ -69,8 +69,8 @@ describe "SimpleHash" do
     it "deletes the key-value pair corresponding to the given key" do
       a = SimpleHash {"one": 1, "two": 2}
       a.delete("two")
-      a["two"]?.should eq(nil)
-      a["one"].should eq(1)
+      expect(a["two"]?).to eq(nil)
+      expect(a["one"]).to eq(1)
     end
   end
 
@@ -78,24 +78,24 @@ describe "SimpleHash" do
     it "deletes {K, V} pairs when the block returns true" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       a.delete_if { |k, v| v > 4 }
-      a[1]?.should eq(2)
-      a[3]?.should eq(4)
-      a[5]?.should eq(nil)
-      a[7]?.should eq(nil)
+      expect(a[1]?).to eq(2)
+      expect(a[3]?).to eq(4)
+      expect(a[5]?).to eq(nil)
+      expect(a[7]?).to eq(nil)
 
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       a.delete_if { |k, v| k < 4 }
-      a[1]?.should eq(nil)
-      a[3]?.should eq(nil)
-      a[5]?.should eq(6)
-      a[7]?.should eq(8)
+      expect(a[1]?).to eq(nil)
+      expect(a[3]?).to eq(nil)
+      expect(a[5]?).to eq(6)
+      expect(a[7]?).to eq(8)
     end
   end
 
   describe "dup" do
     it "returns a duplicate of the SimpleHash" do
       a = SimpleHash {"one": "1", "two": "2"}
-      a.should eq(a.dup)
+      expect(a).to eq(a.dup)
     end
   end
 
@@ -104,11 +104,11 @@ describe "SimpleHash" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       count = 0
       a.each { |k, v| count += k - v }
-      count.should eq(-4)
+      expect(count).to eq(-4)
 
       count = 0
       a.each { |k, v| count += v - k }
-      count.should eq(4)
+      expect(count).to eq(4)
     end
   end
 
@@ -117,7 +117,7 @@ describe "SimpleHash" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       count = 0
       a.each_key { |k| count += k }
-      count.should eq(16)
+      expect(count).to eq(16)
     end
   end
 
@@ -126,7 +126,7 @@ describe "SimpleHash" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       count = 0
       a.each_value { |v| count += v }
-      count.should eq(20)
+      expect(count).to eq(20)
     end
   end
 
@@ -134,7 +134,7 @@ describe "SimpleHash" do
     it "returns an array of all the keys" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       b = [1, 3, 5, 7]
-      a.keys.should eq(b)
+      expect(a.keys).to eq(b)
     end
   end
 
@@ -142,33 +142,33 @@ describe "SimpleHash" do
     it "returns an array of all the values" do
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
       b = [2, 4, 6, 8]
-      a.values.should eq(b)
+      expect(a.values).to eq(b)
     end
   end
 
   describe "length" do
     it "returns the number of key-value pairs" do
       a = SimpleHash(Int32, Int32).new
-      a.length.should eq(0)
+      expect(a.length).to eq(0)
 
       a = SimpleHash {1 => 2}
-      a.length.should eq(1)
+      expect(a.length).to eq(1)
 
       a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
-      a.length.should eq(4)
+      expect(a.length).to eq(4)
     end
   end
 
   describe "to_s" do
     it "returns a string representation" do
       a = SimpleHash(Int32, Int32).new
-      a.to_s.should eq("{}")
+      expect(a.to_s).to eq("{}")
 
       a = SimpleHash {1 => 2}
-      a.to_s.should eq("{1 => 2}")
+      expect(a.to_s).to eq("{1 => 2}")
 
       a = SimpleHash {one: 1, two: 2, three: 3}
-      a.to_s.should eq("{:one => 1, :two => 2, :three => 3}")
+      expect(a.to_s).to eq("{:one => 1, :two => 2, :three => 3}")
     end
   end
 end

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -4,18 +4,18 @@ describe "Slice" do
   it "gets pointer and length" do
     pointer = Pointer.malloc(1, 0)
     slice = Slice.new(pointer, 1)
-    slice.pointer(0).should eq(pointer)
-    slice.length.should eq(1)
+    expect(slice.pointer(0)).to eq(pointer)
+    expect(slice.length).to eq(1)
   end
 
   it "does []" do
     slice = Slice.new(3) { |i| i + 1 }
     3.times do |i|
-      slice[i].should eq(i + 1)
+      expect(slice[i]).to eq(i + 1)
     end
-    slice[-1].should eq(3)
-    slice[-2].should eq(2)
-    slice[-3].should eq(1)
+    expect(slice[-1]).to eq(3)
+    expect(slice[-2]).to eq(2)
+    expect(slice[-3]).to eq(1)
 
     expect_raises(IndexOutOfBounds) { slice[-4] }
     expect_raises(IndexOutOfBounds) { slice[3] }
@@ -24,7 +24,7 @@ describe "Slice" do
   it "does []=" do
     slice = Slice.new(3, 0)
     slice[0] = 1
-    slice[0].should eq(1)
+    expect(slice[0]).to eq(1)
 
     expect_raises(IndexOutOfBounds) { slice[-4] = 1 }
     expect_raises(IndexOutOfBounds) { slice[3] = 1 }
@@ -34,12 +34,12 @@ describe "Slice" do
     slice = Slice.new(3) { |i| i + 1}
 
     slice1 = slice + 1
-    slice1.length.should eq(2)
-    slice1[0].should eq(2)
-    slice1[1].should eq(3)
+    expect(slice1.length).to eq(2)
+    expect(slice1[0]).to eq(2)
+    expect(slice1[1]).to eq(3)
 
     slice3 = slice + 3
-    slice3.length.should eq(0)
+    expect(slice3.length).to eq(0)
 
     expect_raises(IndexOutOfBounds) { slice + 4 }
     expect_raises(IndexOutOfBounds) { slice + (-1) }
@@ -48,9 +48,9 @@ describe "Slice" do
   it "does [] with start and count" do
     slice = Slice.new(4) { |i| i + 1}
     slice1 = slice[1, 2]
-    slice1.length.should eq(2)
-    slice1[0].should eq(2)
-    slice1[1].should eq(3)
+    expect(slice1.length).to eq(2)
+    expect(slice1[0]).to eq(2)
+    expect(slice1[1]).to eq(3)
 
     expect_raises(IndexOutOfBounds) { slice[-1, 1] }
     expect_raises(IndexOutOfBounds) { slice[3, 2] }
@@ -59,8 +59,8 @@ describe "Slice" do
   end
 
   it "does empty?" do
-    Slice.new(0, 0).empty?.should be_true
-    Slice.new(1, 0).empty?.should be_false
+    expect(Slice.new(0, 0).empty?).to be_true
+    expect(Slice.new(1, 0).empty?).to be_false
   end
 
   it "raises if length is negative on new" do
@@ -69,7 +69,7 @@ describe "Slice" do
 
   it "does to_s" do
     slice = Slice.new(4) { |i| i + 1}
-    slice.to_s.should eq("[1, 2, 3, 4]")
+    expect(slice.to_s).to eq("[1, 2, 3, 4]")
   end
 
   it "gets pointer" do
@@ -82,7 +82,7 @@ describe "Slice" do
     pointer = Pointer.malloc(4) { |i| i + 1 }
     slice = Slice.new(4, 0)
     slice.copy_from(pointer, 4)
-    4.times { |i| slice[i].should eq(i + 1) }
+    4.times { |i| expect(slice[i]).to eq(i + 1) }
 
     expect_raises(IndexOutOfBounds) { slice.copy_from(pointer, 5) }
   end
@@ -91,13 +91,13 @@ describe "Slice" do
     pointer = Pointer.malloc(4, 0)
     slice = Slice.new(4) { |i| i + 1 }
     slice.copy_to(pointer, 4)
-    4.times { |i| pointer[i].should eq(i + 1) }
+    4.times { |i| expect(pointer[i]).to eq(i + 1) }
 
     expect_raises(IndexOutOfBounds) { slice.copy_to(pointer, 5) }
   end
 
   it "does hexstring" do
     slice = Slice(UInt8).new(4) { |i| i.to_u8 + 1 }
-    slice.hexstring.should eq("01020304")
+    expect(slice.hexstring).to eq("01020304")
   end
 end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -62,17 +62,18 @@ describe "TCPSocket" do
         # so for now we keep it commented. Once we can force the family
         # we can uncomment them.
 
-        expect(# client.addr.family).to eq("AF_INET")
-        expect(# client.addr.ip_address).to eq("127.0.0.1")
+        # TODO: make pending spec
+        #expect(client.addr.family).to eq("AF_INET")
+        #expect(client.addr.ip_address).to eq("127.0.0.1")
 
         sock = server.accept
 
-        expect(# sock.addr.family).to eq("AF_INET6")
-        expect(# sock.addr.ip_port).to eq(12345)
-        expect(# sock.addr.ip_address).to eq("::ffff:127.0.0.1")
+        #expect(sock.addr.family).to eq("AF_INET6")
+        #expect(sock.addr.ip_port).to eq(12345)
+        #expect(sock.addr.ip_address).to eq("::ffff:127.0.0.1")
 
-        expect(# sock.peeraddr.family).to eq("AF_INET6")
-        expect(# sock.peeraddr.ip_address).to eq("::ffff:127.0.0.1")
+        #expect(sock.peeraddr.family).to eq("AF_INET6")
+        #expect(sock.peeraddr.ip_address).to eq("::ffff:127.0.0.1")
 
         client << "ping"
         expect(sock.read(4)).to eq("ping")

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -6,24 +6,24 @@ describe "UNIXSocket" do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do |server|
-      server.addr.family.should eq("AF_UNIX")
-      server.addr.path.should eq(path)
+      expect(server.addr.family).to eq("AF_UNIX")
+      expect(server.addr.path).to eq(path)
 
       UNIXSocket.open(path) do |client|
-        client.addr.family.should eq("AF_UNIX")
-        client.addr.path.should eq(path)
+        expect(client.addr.family).to eq("AF_UNIX")
+        expect(client.addr.path).to eq(path)
 
         server.accept do |sock|
-          sock.addr.family.should eq("AF_UNIX")
-          sock.addr.path.should eq("")
+          expect(sock.addr.family).to eq("AF_UNIX")
+          expect(sock.addr.path).to eq("")
 
-          sock.peeraddr.family.should eq("AF_UNIX")
-          sock.peeraddr.path.should eq("")
+          expect(sock.peeraddr.family).to eq("AF_UNIX")
+          expect(sock.peeraddr.path).to eq("")
 
           client << "ping"
-          sock.read(4).should eq("ping")
+          expect(sock.read(4)).to eq("ping")
           sock << "pong"
-          client.read(4).should eq("pong")
+          expect(client.read(4)).to eq("pong")
         end
       end
     end
@@ -31,13 +31,13 @@ describe "UNIXSocket" do
 
   it "creates a pair of sockets" do
     UNIXSocket.pair do |left, right|
-      left.addr.family.should eq("AF_UNIX")
-      left.addr.path.should eq("")
+      expect(left.addr.family).to eq("AF_UNIX")
+      expect(left.addr.path).to eq("")
 
       left << "ping"
-      right.read(4).should eq("ping")
+      expect(right.read(4)).to eq("ping")
       right << "pong"
-      left.read(4).should eq("pong")
+      expect(left.read(4)).to eq("pong")
     end
   end
 
@@ -45,7 +45,7 @@ describe "UNIXSocket" do
     path = "/tmp/crystal-test-unix-sock"
 
     UNIXServer.open(path) do
-      File.exists?(path).should be_true
+      expect(File.exists?(path)).to be_true
     end
   end
 end
@@ -53,31 +53,31 @@ end
 describe "TCPSocket" do
   it "sends and receives messages" do
     TCPServer.open("::", 12345) do |server|
-      server.addr.family.should eq("AF_INET6")
-      server.addr.ip_port.should eq(12345)
-      server.addr.ip_address.should eq("::")
+      expect(server.addr.family).to eq("AF_INET6")
+      expect(server.addr.ip_port).to eq(12345)
+      expect(server.addr.ip_address).to eq("::")
 
       TCPSocket.open("localhost", 12345) do |client|
         # The commented lines are actually dependant on the system configuration,
         # so for now we keep it commented. Once we can force the family
         # we can uncomment them.
 
-        # client.addr.family.should eq("AF_INET")
-        # client.addr.ip_address.should eq("127.0.0.1")
+        expect(# client.addr.family).to eq("AF_INET")
+        expect(# client.addr.ip_address).to eq("127.0.0.1")
 
         sock = server.accept
 
-        # sock.addr.family.should eq("AF_INET6")
-        # sock.addr.ip_port.should eq(12345)
-        # sock.addr.ip_address.should eq("::ffff:127.0.0.1")
+        expect(# sock.addr.family).to eq("AF_INET6")
+        expect(# sock.addr.ip_port).to eq(12345)
+        expect(# sock.addr.ip_address).to eq("::ffff:127.0.0.1")
 
-        # sock.peeraddr.family.should eq("AF_INET6")
-        # sock.peeraddr.ip_address.should eq("::ffff:127.0.0.1")
+        expect(# sock.peeraddr.family).to eq("AF_INET6")
+        expect(# sock.peeraddr.ip_address).to eq("::ffff:127.0.0.1")
 
         client << "ping"
-        sock.read(4).should eq("ping")
+        expect(sock.read(4)).to eq("ping")
         sock << "pong"
-        client.read(4).should eq("pong")
+        expect(client.read(4)).to eq("pong")
       end
     end
   end
@@ -100,21 +100,21 @@ describe "UDPSocket" do
     server = UDPSocket.new(Socket::Family::INET6)
     server.bind("::", 12346)
 
-    server.addr.family.should eq("AF_INET6")
-    server.addr.ip_port.should eq(12346)
-    server.addr.ip_address.should eq("::")
+    expect(server.addr.family).to eq("AF_INET6")
+    expect(server.addr.ip_port).to eq(12346)
+    expect(server.addr.ip_address).to eq("::")
 
     client = UDPSocket.new(Socket::Family::INET)
     client.connect("localhost", 12346)
 
-    client.addr.family.should eq("AF_INET")
-    client.addr.ip_address.should eq("127.0.0.1")
-    client.peeraddr.family.should eq("AF_INET")
-    client.peeraddr.ip_port.should eq(12346)
-    client.peeraddr.ip_address.should eq("127.0.0.1")
+    expect(client.addr.family).to eq("AF_INET")
+    expect(client.addr.ip_address).to eq("127.0.0.1")
+    expect(client.peeraddr.family).to eq("AF_INET")
+    expect(client.peeraddr.ip_port).to eq(12346)
+    expect(client.peeraddr.ip_address).to eq("127.0.0.1")
 
     client << "message"
-    server.read(7).should eq("message")
+    expect(server.read(7)).to eq("message")
 
     client.close
     server.close

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -3,83 +3,83 @@ require "spec"
 describe "Spec matchers" do
   describe "should be_truthy" do
     it "passes for true" do
-      true.should be_truthy
+      expect(true).to be_truthy
     end
 
     it "passes for some non-nil, non-false value" do
-      42.should be_truthy
+      expect(42).to be_truthy
     end
   end
 
   describe "should_not be_truthy" do
     it "passes for false" do
-      false.should_not be_truthy
+      expect(false).to_not be_truthy
     end
 
     it "passes for nil" do
-      nil.should_not be_truthy
+      expect(nil).to_not be_truthy
     end
   end
 
   describe "should be_falsey" do
     it "passes for false" do
-      false.should be_falsey
+      expect(false).to be_falsey
     end
 
     it "passes for nil" do
-      nil.should be_falsey
+      expect(nil).to be_falsey
     end
   end
 
   describe "should_not be_falsey" do
     it "passses for true" do
-      true.should_not be_falsey
+      expect(true).to_not be_falsey
     end
 
     it "passes for some non-nil, non-false value" do
-      42.should_not be_falsey
+      expect(42).to_not be_falsey
     end
   end
 
   describe "should contain" do
     it "passes when string includes? specified substring" do
-      "hello world!".should contain("hello")
+      expect("hello world!").to contain("hello")
     end
 
     it "works with array" do
-      [1, 2, 3, 5, 8].should contain(5)
+      expect([1, 2, 3, 5, 8]).to contain(5)
     end
 
     it "works with set" do
-      [1, 2, 3, 5, 8].to_set.should contain(8)
+      expect([1, 2, 3, 5, 8].to_set).to contain(8)
     end
 
     it "works with range" do
-      (50 .. 55).should contain(53)
+      expect((50 .. 55)).to contain(53)
     end
 
     it "does not pass when string does not includes? specified substring" do
       expect_raises Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"} do
-        "hello world!".should contain("crystal")
+        expect("hello world!").to contain("crystal")
       end
     end
   end
 
   describe "should_not contain" do
     it "passes when string does not includes? specified substring" do
-      "hello world!".should_not contain("crystal")
+      expect("hello world!").to_not contain("crystal")
     end
 
     it "does not pass when string does not includes? specified substring" do
       expect_raises Spec::AssertionFailed, %{expected: value "hello world!"\nto not include: "world"} do
-        "hello world!".should_not contain("world")
+        expect("hello world!").to_not contain("world")
       end
     end
   end
 
   context "should work as describe" do
     it "is true" do
-      true.should be_truthy
+      expect(true).to be_truthy
     end
   end
 end

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -3,25 +3,25 @@ require "spec"
 describe "StaticArray" do
   it "creates with new" do
     a = StaticArray(Int32, 3).new 0
-    a.length.should eq(3)
-    a.size.should eq(3)
-    a.count.should eq(3)
+    expect(a.length).to eq(3)
+    expect(a.size).to eq(3)
+    expect(a.count).to eq(3)
   end
 
   it "creates with new and value" do
     a = StaticArray(Int32, 3).new 1
-    a.length.should eq(3)
-    a[0].should eq(1)
-    a[1].should eq(1)
-    a[2].should eq(1)
+    expect(a.length).to eq(3)
+    expect(a[0]).to eq(1)
+    expect(a[1]).to eq(1)
+    expect(a[2]).to eq(1)
   end
 
   it "creates with new and block" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
-    a.length.should eq(3)
-    a[0].should eq(1)
-    a[1].should eq(2)
-    a[2].should eq(3)
+    expect(a.length).to eq(3)
+    expect(a[0]).to eq(1)
+    expect(a[1]).to eq(2)
+    expect(a[2]).to eq(3)
   end
 
   it "raises index out of bounds on read" do
@@ -41,40 +41,40 @@ describe "StaticArray" do
   it "allows using negative indices" do
     a = StaticArray(Int32, 3).new 0
     a[-1] = 2
-    a[-1].should eq(2)
-    a[2].should eq(2)
+    expect(a[-1]).to eq(2)
+    expect(a[2]).to eq(2)
   end
 
   it "does to_s" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
-    a.to_s.should eq("[1, 2, 3]")
+    expect(a.to_s).to eq("[1, 2, 3]")
   end
 
   it "shuffles" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.shuffle!
 
-    (a[0] + a[1] + a[2]).should eq(6)
+    expect((a[0] + a[1] + a[2])).to eq(6)
 
     3.times do |i|
-      a.includes?(i + 1).should be_true
+      expect(a.includes?(i + 1)).to be_true
     end
   end
 
   it "maps!" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.map! { |i| i + 1 }
-    a[0].should eq(2)
-    a[1].should eq(3)
-    a[2].should eq(4)
+    expect(a[0]).to eq(2)
+    expect(a[1]).to eq(3)
+    expect(a[2]).to eq(4)
   end
 
 
   it "updates value" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.update(1) { |x| x * 2 }
-    a[0].should eq(1)
-    a[1].should eq(4)
-    a[2].should eq(3)
+    expect(a[0]).to eq(1)
+    expect(a[1]).to eq(4)
+    expect(a[2]).to eq(3)
   end
 end

--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -4,8 +4,8 @@ require "string_pool"
 describe StringPool do
   it "is empty" do
     pool = StringPool.new
-    pool.empty?.should be_true
-    pool.length.should eq(0)
+    expect(pool.empty?).to be_true
+    expect(pool.length).to eq(0)
   end
 
   it "gets string" do
@@ -13,10 +13,10 @@ describe StringPool do
     s1 = pool.get "foo"
     s2 = pool.get "foo"
 
-    s1.should eq("foo")
-    s2.should eq("foo")
-    s1.object_id.should eq(s2.object_id)
-    pool.length.should eq(1)
+    expect(s1).to eq("foo")
+    expect(s2).to eq("foo")
+    expect(s1.object_id).to eq(s2.object_id)
+    expect(pool.length).to eq(1)
   end
 
   it "gets string IO" do
@@ -26,10 +26,10 @@ describe StringPool do
     s1 = pool.get io
     s2 = pool.get "foo"
 
-    s1.should eq("foo")
-    s2.should eq("foo")
-    s1.object_id.should eq(s2.object_id)
-    pool.length.should eq(1)
+    expect(s1).to eq("foo")
+    expect(s2).to eq("foo")
+    expect(s1.object_id).to eq(s2.object_id)
+    expect(pool.length).to eq(1)
   end
 
   it "gets slice" do
@@ -39,10 +39,10 @@ describe StringPool do
     s1 = pool.get(slice)
     s2 = pool.get(slice)
 
-    s1.should eq("aaa")
-    s2.should eq("aaa")
-    s1.object_id.should eq(s2.object_id)
-    pool.length.should eq(1)
+    expect(s1).to eq("aaa")
+    expect(s2).to eq("aaa")
+    expect(s1.object_id).to eq(s2.object_id)
+    expect(pool.length).to eq(1)
   end
 
   it "gets pointer with length" do
@@ -52,10 +52,10 @@ describe StringPool do
     s1 = pool.get(slice.pointer(slice.length), slice.length)
     s2 = pool.get(slice.pointer(slice.length), slice.length)
 
-    s1.should eq("aaa")
-    s2.should eq("aaa")
-    s1.object_id.should eq(s2.object_id)
-    pool.length.should eq(1)
+    expect(s1).to eq("aaa")
+    expect(s2).to eq("aaa")
+    expect(s1.object_id).to eq(s2.object_id)
+    expect(pool.length).to eq(1)
   end
 
   it "puts many" do
@@ -63,6 +63,6 @@ describe StringPool do
     10_000.times do |i|
       pool.get(i.to_s)
     end
-    pool.length.should eq(10_000)
+    expect(pool.length).to eq(10_000)
   end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -4,100 +4,100 @@ describe "String" do
   describe "[]" do
     it "gets with positive index" do
       c = "hello!"[1]
-      c.should be_a(Char)
-      c.should eq('e')
+      expect(c).to be_a(Char)
+      expect(c).to eq('e')
     end
 
     it "gets with negative index" do
-      "hello!"[-1].should eq('!')
+      expect("hello!"[-1]).to eq('!')
     end
 
     it "gets with inclusive range" do
-      "hello!"[1 .. 4].should eq("ello")
+      expect("hello!"[1 .. 4]).to eq("ello")
     end
 
     it "gets with inclusive range with negative indices" do
-      "hello!"[-5 .. -2].should eq("ello")
+      expect("hello!"[-5 .. -2]).to eq("ello")
     end
 
     it "gets with exclusive range" do
-      "hello!"[1 ... 4].should eq("ell")
+      expect("hello!"[1 ... 4]).to eq("ell")
     end
 
     it "gets with start and count" do
-      "hello"[1, 3].should eq("ell")
+      expect("hello"[1, 3]).to eq("ell")
     end
 
     it "gets with exclusive range with unicode" do
-      "há日本語"[1 .. 3].should eq("á日本")
+      expect("há日本語"[1 .. 3]).to eq("á日本")
     end
 
     it "gets with exclusive with start and count" do
-      "há日本語"[1, 3].should eq("á日本")
+      expect("há日本語"[1, 3]).to eq("á日本")
     end
 
     it "gets with exclusive with start and count to end" do
-      "há日本語"[1, 4].should eq("á日本語")
+      expect("há日本語"[1, 4]).to eq("á日本語")
     end
 
     it "gets with single char" do
-      ";"[0 .. -2].should eq("")
+      expect(";"[0 .. -2]).to eq("")
     end
 
     describe "with a regex" do
-      assert { "FooBar"[/o+/].should eq "oo" }
-      assert { "FooBar"[/([A-Z])/, 1].should eq "F" }
-      assert { "FooBar"[/x/]?.should be_nil }
-      assert { "FooBar"[/x/, 1]?.should be_nil }
-      assert { "FooBar"[/(x)/, 1]?.should be_nil }
-      assert { "FooBar"[/o(o)/, 2]?.should be_nil }
-      assert { "FooBar"[/o(?<this>o)/, "this"].should eq "o" }
-      assert { "FooBar"[/(?<this>x)/, "that"]?.should be_nil }
+      assert { expect("FooBar"[/o+/]).to eq "oo" }
+      assert { expect("FooBar"[/([A-Z])/, 1]).to eq "F" }
+      assert { expect("FooBar"[/x/]?).to be_nil }
+      assert { expect("FooBar"[/x/, 1]?).to be_nil }
+      assert { expect("FooBar"[/(x)/, 1]?).to be_nil }
+      assert { expect("FooBar"[/o(o)/, 2]?).to be_nil }
+      assert { expect("FooBar"[/o(?<this>o)/, "this"]).to eq "o" }
+      assert { expect("FooBar"[/(?<this>x)/, "that"]?).to be_nil }
     end
 
     it "gets with a string" do
-      "FooBar"["Bar"].should eq "Bar"
+      expect("FooBar"["Bar"]).to eq "Bar"
       expect_raises { "FooBar"["Baz"] }
-      "FooBar"["Bar"]?.should eq "Bar"
-      "FooBar"["Baz"]?.should be_nil
+      expect("FooBar"["Bar"]?).to eq "Bar"
+      expect("FooBar"["Baz"]?).to be_nil
     end
 
     it "gets with index and []?" do
-      "hello"[1]?.should eq('e')
-      "hello"[5]?.should be_nil
-      "hello"[-1]?.should eq('o')
-      "hello"[-6]?.should be_nil
+      expect("hello"[1]?).to eq('e')
+      expect("hello"[5]?).to be_nil
+      expect("hello"[-1]?).to eq('o')
+      expect("hello"[-6]?).to be_nil
     end
   end
 
   describe "byte_slice" do
     it "gets byte_slice" do
-      "hello".byte_slice(1, 3).should eq("ell")
+      expect("hello".byte_slice(1, 3)).to eq("ell")
     end
 
     it "gets byte_slice with negative count" do
-      "hello".byte_slice(1, -10).should eq("")
+      expect("hello".byte_slice(1, -10)).to eq("")
     end
 
     it "gets byte_slice with start out of bounds" do
-      "hello".byte_slice(10, 3).should eq("")
+      expect("hello".byte_slice(10, 3)).to eq("")
     end
 
     it "gets byte_slice with large count" do
-      "hello".byte_slice(1, 10).should eq("ello")
+      expect("hello".byte_slice(1, 10)).to eq("ello")
     end
 
     it "gets byte_slice with negative index" do
-      "hello".byte_slice(-2, 3).should eq("lo")
+      expect("hello".byte_slice(-2, 3)).to eq("lo")
     end
   end
 
   it "does to_i" do
-    "1234".to_i.should eq(1234)
+    expect("1234".to_i).to eq(1234)
   end
 
   it "does to_i with base" do
-    "12ab".to_i(16).should eq(4779)
+    expect("12ab".to_i(16)).to eq(4779)
   end
 
   it "raises on to_i(1)" do
@@ -109,338 +109,338 @@ describe "String" do
   end
 
   it "does to_i32" do
-    "1234".to_i32.should eq(1234)
+    expect("1234".to_i32).to eq(1234)
   end
 
   it "does to_i64" do
-    "1234123412341234".to_i64.should eq(1234123412341234_i64)
+    expect("1234123412341234".to_i64).to eq(1234123412341234_i64)
   end
 
   it "does to_u64" do
-    "9223372036854775808".to_u64.should eq(9223372036854775808_u64)
+    expect("9223372036854775808".to_u64).to eq(9223372036854775808_u64)
   end
 
   it "does to_f" do
-    "1234.56".to_f.should eq(1234.56_f64)
+    expect("1234.56".to_f).to eq(1234.56_f64)
   end
 
   it "does to_f32" do
-    "1234.56".to_f32.should eq(1234.56_f32)
+    expect("1234.56".to_f32).to eq(1234.56_f32)
   end
 
   it "does to_f64" do
-    "1234.56".to_f64.should eq(1234.56_f64)
+    expect("1234.56".to_f64).to eq(1234.56_f64)
   end
 
   it "compares strings: different length" do
-    "foo".should_not eq("fo")
+    expect("foo").to_not eq("fo")
   end
 
   it "compares strings: same object" do
     f = "foo"
-    f.should eq(f)
+    expect(f).to eq(f)
   end
 
   it "compares strings: same length, same string" do
-    "foo".should eq("fo" + "o")
+    expect("foo").to eq("fo" + "o")
   end
 
   it "compares strings: same length, different string" do
-    "foo".should_not eq("bar")
+    expect("foo").to_not eq("bar")
   end
 
   it "interpolates string" do
     foo = "<foo>"
     bar = 123
-    "foo #{bar}".should eq("foo 123")
-    "foo #{ bar}".should eq("foo 123")
-    "#{foo} bar".should eq("<foo> bar")
+    expect("foo #{bar}").to eq("foo 123")
+    expect("foo #{ bar}").to eq("foo 123")
+    expect("#{foo} bar").to eq("<foo> bar")
   end
 
   it "multiplies" do
     str = "foo"
-    (str * 0).should eq("")
-    (str * 3).should eq("foofoofoo")
+    expect((str * 0)).to eq("")
+    expect((str * 3)).to eq("foofoofoo")
   end
 
   it "multiplies with length one" do
     str = "f"
-    (str * 0).should eq("")
-    (str * 10).should eq("ffffffffff")
+    expect((str * 0)).to eq("")
+    expect((str * 10)).to eq("ffffffffff")
   end
 
   describe "downcase" do
-    assert { "HELLO!".downcase.should eq("hello!") }
-    assert { "HELLO MAN!".downcase.should eq("hello man!") }
+    assert { expect("HELLO!".downcase).to eq("hello!") }
+    assert { expect("HELLO MAN!".downcase).to eq("hello man!") }
   end
 
   describe "upcase" do
-    assert { "hello!".upcase.should eq("HELLO!") }
-    assert { "hello man!".upcase.should eq("HELLO MAN!") }
+    assert { expect("hello!".upcase).to eq("HELLO!") }
+    assert { expect("hello man!".upcase).to eq("HELLO MAN!") }
   end
 
   describe "capitalize" do
-    assert { "HELLO!".capitalize.should eq("Hello!") }
-    assert { "HELLO MAN!".capitalize.should eq("Hello man!") }
-    assert { "".capitalize.should eq("") }
+    assert { expect("HELLO!".capitalize).to eq("Hello!") }
+    assert { expect("HELLO MAN!".capitalize).to eq("Hello man!") }
+    assert { expect("".capitalize).to eq("") }
   end
 
   describe "chomp" do
-    assert { "hello\n".chomp.should eq("hello") }
-    assert { "hello\r".chomp.should eq("hello") }
-    assert { "hello\r\n".chomp.should eq("hello") }
-    assert { "hello".chomp.should eq("hello") }
-    assert { "hello".chomp.should eq("hello") }
-    assert { "かたな\n".chomp.should eq("かたな") }
-    assert { "かたな\r".chomp.should eq("かたな") }
-    assert { "かたな\r\n".chomp.should eq("かたな") }
-    assert { "hello\n\n".chomp.should eq("hello\n") }
-    assert { "hello\r\n\n".chomp.should eq("hello\r\n") }
+    assert { expect("hello\n".chomp).to eq("hello") }
+    assert { expect("hello\r".chomp).to eq("hello") }
+    assert { expect("hello\r\n".chomp).to eq("hello") }
+    assert { expect("hello".chomp).to eq("hello") }
+    assert { expect("hello".chomp).to eq("hello") }
+    assert { expect("かたな\n".chomp).to eq("かたな") }
+    assert { expect("かたな\r".chomp).to eq("かたな") }
+    assert { expect("かたな\r\n".chomp).to eq("かたな") }
+    assert { expect("hello\n\n".chomp).to eq("hello\n") }
+    assert { expect("hello\r\n\n".chomp).to eq("hello\r\n") }
   end
 
   describe "strip" do
-    assert { "  hello  \n\t\f\v\r".strip.should eq("hello") }
-    assert { "hello".strip.should eq("hello") }
-    assert { "かたな \n\f\v".strip.should eq("かたな") }
-    assert { "  \n\t かたな \n\f\v".strip.should eq("かたな") }
-    assert { "  \n\t かたな".strip.should eq("かたな") }
-    assert { "かたな".strip.should eq("かたな") }
+    assert { expect("  hello  \n\t\f\v\r".strip).to eq("hello") }
+    assert { expect("hello".strip).to eq("hello") }
+    assert { expect("かたな \n\f\v".strip).to eq("かたな") }
+    assert { expect("  \n\t かたな \n\f\v".strip).to eq("かたな") }
+    assert { expect("  \n\t かたな".strip).to eq("かたな") }
+    assert { expect("かたな".strip).to eq("かたな") }
   end
 
   describe "rstrip" do
-    assert { "  hello  ".rstrip.should eq("  hello") }
-    assert { "hello".rstrip.should eq("hello") }
-    assert { "  かたな \n\f\v".rstrip.should eq("  かたな") }
-    assert { "かたな".rstrip.should eq("かたな") }
+    assert { expect("  hello  ".rstrip).to eq("  hello") }
+    assert { expect("hello".rstrip).to eq("hello") }
+    assert { expect("  かたな \n\f\v".rstrip).to eq("  かたな") }
+    assert { expect("かたな".rstrip).to eq("かたな") }
   end
 
   describe "lstrip" do
-    assert { "  hello  ".lstrip.should eq("hello  ") }
-    assert { "hello".lstrip.should eq("hello") }
-    assert { "  \n\v かたな  ".lstrip.should eq("かたな  ") }
-    assert { "  かたな".lstrip.should eq("かたな") }
+    assert { expect("  hello  ".lstrip).to eq("hello  ") }
+    assert { expect("hello".lstrip).to eq("hello") }
+    assert { expect("  \n\v かたな  ".lstrip).to eq("かたな  ") }
+    assert { expect("  かたな".lstrip).to eq("かたな") }
   end
 
   describe "empty?" do
-    assert { "a".empty?.should be_false }
-    assert { "".empty?.should be_true }
+    assert { expect("a".empty?).to be_false }
+    assert { expect("".empty?).to be_true }
   end
 
   describe "index" do
     describe "by char" do
-      assert { "foo".index('o').should eq(1) }
-      assert { "foo".index('g').should be_nil }
-      assert { "bar".index('r').should eq(2) }
-      assert { "日本語".index('本').should eq(1) }
-      assert { "bar".index('あ').should be_nil }
+      assert { expect("foo".index('o')).to eq(1) }
+      assert { expect("foo".index('g')).to be_nil }
+      assert { expect("bar".index('r')).to eq(2) }
+      assert { expect("日本語".index('本')).to eq(1) }
+      assert { expect("bar".index('あ')).to be_nil }
 
       describe "with offset" do
-        assert { "foobarbaz".index('a', 5).should eq(7) }
-        assert { "foobarbaz".index('a', -4).should eq(7) }
-        assert { "foo".index('g', 1).should be_nil }
-        assert { "foo".index('g', -20).should be_nil }
-        assert { "日本語日本語".index('本', 2).should eq(4) }
+        assert { expect("foobarbaz".index('a', 5)).to eq(7) }
+        assert { expect("foobarbaz".index('a', -4)).to eq(7) }
+        assert { expect("foo".index('g', 1)).to be_nil }
+        assert { expect("foo".index('g', -20)).to be_nil }
+        assert { expect("日本語日本語".index('本', 2)).to eq(4) }
       end
     end
 
     describe "by string" do
-      assert { "foo bar".index("o b").should eq(2) }
-      assert { "foo".index("fg").should be_nil }
-      assert { "foo".index("").should eq(0) }
-      assert { "foo".index("foo").should eq(0) }
-      assert { "日本語日本語".index("本語").should eq(1) }
+      assert { expect("foo bar".index("o b")).to eq(2) }
+      assert { expect("foo".index("fg")).to be_nil }
+      assert { expect("foo".index("")).to eq(0) }
+      assert { expect("foo".index("foo")).to eq(0) }
+      assert { expect("日本語日本語".index("本語")).to eq(1) }
 
       describe "with offset" do
-        assert { "foobarbaz".index("ba", 4).should eq(6) }
-        assert { "foobarbaz".index("ba", -5).should eq(6) }
-        assert { "foo".index("ba", 1).should be_nil }
-        assert { "foo".index("ba", -20).should be_nil }
-        assert { "日本語日本語".index("本語", 2).should eq(4) }
+        assert { expect("foobarbaz".index("ba", 4)).to eq(6) }
+        assert { expect("foobarbaz".index("ba", -5)).to eq(6) }
+        assert { expect("foo".index("ba", 1)).to be_nil }
+        assert { expect("foo".index("ba", -20)).to be_nil }
+        assert { expect("日本語日本語".index("本語", 2)).to eq(4) }
       end
     end
   end
 
   describe "rindex" do
     describe "by char" do
-      assert { "foobar".rindex('a').should eq(4) }
-      assert { "foobar".rindex('g').should be_nil }
-      assert { "日本語日本語".rindex('本').should eq(4) }
+      assert { expect("foobar".rindex('a')).to eq(4) }
+      assert { expect("foobar".rindex('g')).to be_nil }
+      assert { expect("日本語日本語".rindex('本')).to eq(4) }
 
       describe "with offset" do
-        assert { "faobar".rindex('a', 3).should eq(1) }
-        assert { "faobarbaz".rindex('a', -3).should eq(4) }
-        assert { "日本語日本語".rindex('本', 3).should eq(1) }
+        assert { expect("faobar".rindex('a', 3)).to eq(1) }
+        assert { expect("faobarbaz".rindex('a', -3)).to eq(4) }
+        assert { expect("日本語日本語".rindex('本', 3)).to eq(1) }
       end
     end
 
     describe "by string" do
-      assert { "foo baro baz".rindex("o b").should eq(7) }
-      assert { "foo baro baz".rindex("fg").should be_nil }
-      assert { "日本語日本語".rindex("日本").should eq(3) }
+      assert { expect("foo baro baz".rindex("o b")).to eq(7) }
+      assert { expect("foo baro baz".rindex("fg")).to be_nil }
+      assert { expect("日本語日本語".rindex("日本")).to eq(3) }
 
       describe "with offset" do
-        assert { "foo baro baz".rindex("o b", 6).should eq(2) }
-        assert { "foo baro baz".rindex("fg").should be_nil }
-        assert { "日本語日本語".rindex("日本", 2).should eq(0) }
+        assert { expect("foo baro baz".rindex("o b", 6)).to eq(2) }
+        assert { expect("foo baro baz".rindex("fg")).to be_nil }
+        assert { expect("日本語日本語".rindex("日本", 2)).to eq(0) }
       end
     end
   end
 
   describe "byte_index" do
-    assert { "foo".byte_index('o'.ord).should eq(1) }
-    assert { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
-    assert { "foo".byte_index('a'.ord).should be_nil }
+    assert { expect("foo".byte_index('o'.ord)).to eq(1) }
+    assert { expect("foo bar booz".byte_index('o'.ord, 3)).to eq(9) }
+    assert { expect("foo".byte_index('a'.ord)).to be_nil }
 
     it "gets byte index of string" do
-      "hello world".byte_index("lo").should eq(3)
+      expect("hello world".byte_index("lo")).to eq(3)
     end
   end
 
   describe "includes?" do
     describe "by char" do
-      assert { "foo".includes?('o').should be_true }
-      assert { "foo".includes?('g').should be_false }
+      assert { expect("foo".includes?('o')).to be_true }
+      assert { expect("foo".includes?('g')).to be_false }
     end
 
     describe "by string" do
-      assert { "foo bar".includes?("o b").should be_true }
-      assert { "foo".includes?("fg").should be_false }
-      assert { "foo".includes?("").should be_true }
+      assert { expect("foo bar".includes?("o b")).to be_true }
+      assert { expect("foo".includes?("fg")).to be_false }
+      assert { expect("foo".includes?("")).to be_true }
     end
   end
 
   describe "split" do
     describe "by char" do
-      assert { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo".split(',').should eq(["foo"]) }
-      assert { "foo".split(' ').should eq(["foo"]) }
-      assert { "   foo".split(' ').should eq(["foo"]) }
-      assert { "foo   ".split(' ').should eq(["foo"]) }
-      assert { "   foo  bar".split(' ').should eq(["foo", "bar"]) }
-      assert { "   foo   bar\n\t  baz   ".split(' ').should eq(["foo", "bar", "baz"]) }
-      assert { "   foo   bar\n\t  baz   ".split.should eq(["foo", "bar", "baz"]) }
-      assert { "   foo   bar\n\t  baz   ".split(2).should eq(["foo", "bar\n\t  baz   "]) }
-      assert { "   foo   bar\n\t  baz   ".split(" ").should eq(["foo", "bar", "baz"]) }
-      assert { "foo,bar,baz,qux".split(',', 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(',', 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(',', 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "foo bar baz qux".split(' ', 1).should eq(["foo bar baz qux"]) }
-      assert { "foo bar baz qux".split(' ', 3).should eq(["foo", "bar", "baz qux"]) }
-      assert { "foo bar baz qux".split(' ', 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "日本語 \n\t 日本 \n\n 語".split.should eq(["日本語", "日本", "語"]) }
-      assert { "日本ん語日本ん語".split('ん').should eq(["日本", "語日本", "語"]) }
+      assert { expect("foo,bar,,baz,".split(',')).to eq(["foo", "bar", "", "baz"]) }
+      assert { expect("foo,bar,,baz".split(',')).to eq(["foo", "bar", "", "baz"]) }
+      assert { expect("foo".split(',')).to eq(["foo"]) }
+      assert { expect("foo".split(' ')).to eq(["foo"]) }
+      assert { expect("   foo".split(' ')).to eq(["foo"]) }
+      assert { expect("foo   ".split(' ')).to eq(["foo"]) }
+      assert { expect("   foo  bar".split(' ')).to eq(["foo", "bar"]) }
+      assert { expect("   foo   bar\n\t  baz   ".split(' ')).to eq(["foo", "bar", "baz"]) }
+      assert { expect("   foo   bar\n\t  baz   ".split).to eq(["foo", "bar", "baz"]) }
+      assert { expect("   foo   bar\n\t  baz   ".split(2)).to eq(["foo", "bar\n\t  baz   "]) }
+      assert { expect("   foo   bar\n\t  baz   ".split(" ")).to eq(["foo", "bar", "baz"]) }
+      assert { expect("foo,bar,baz,qux".split(',', 1)).to eq(["foo,bar,baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(',', 3)).to eq(["foo", "bar", "baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(',', 30)).to eq(["foo", "bar", "baz", "qux"]) }
+      assert { expect("foo bar baz qux".split(' ', 1)).to eq(["foo bar baz qux"]) }
+      assert { expect("foo bar baz qux".split(' ', 3)).to eq(["foo", "bar", "baz qux"]) }
+      assert { expect("foo bar baz qux".split(' ', 30)).to eq(["foo", "bar", "baz", "qux"]) }
+      assert { expect("日本語 \n\t 日本 \n\n 語".split).to eq(["日本語", "日本", "語"]) }
+      assert { expect("日本ん語日本ん語".split('ん')).to eq(["日本", "語日本", "語"]) }
     end
 
     describe "by string" do
-      assert { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo:-bar:-:-baz".split(":-").should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo".split(":-").should eq(["foo"]) }
-      assert { "foo".split("").should eq(["f", "o", "o"]) }
-      assert { "日本さん語日本さん語".split("さん").should eq(["日本", "語日本", "語"]) }
-      assert { "foo,bar,baz,qux".split(",", 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(",", 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(",", 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "a b c".split(" ", 2).should eq(["a", "b c"]) }
+      assert { expect("foo:-bar:-:-baz:-".split(":-")).to eq(["foo", "bar", "", "baz"]) }
+      assert { expect("foo:-bar:-:-baz".split(":-")).to eq(["foo", "bar", "", "baz"]) }
+      assert { expect("foo".split(":-")).to eq(["foo"]) }
+      assert { expect("foo".split("")).to eq(["f", "o", "o"]) }
+      assert { expect("日本さん語日本さん語".split("さん")).to eq(["日本", "語日本", "語"]) }
+      assert { expect("foo,bar,baz,qux".split(",", 1)).to eq(["foo,bar,baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(",", 3)).to eq(["foo", "bar", "baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(",", 30)).to eq(["foo", "bar", "baz", "qux"]) }
+      assert { expect("a b c".split(" ", 2)).to eq(["a", "b c"]) }
     end
 
     describe "by regex" do
-      assert { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
-      assert { "foo\n\tbar\n\t\n\tbaz".split(/(\n\t)+/).should eq(["foo", "bar", "baz"]) }
-      assert { "foo,bar".split(/,/, 1).should eq(["foo,bar"]) }
-      assert { "foo,bar,baz,qux".split(/,/, 1).should eq(["foo,bar,baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(/,/, 3).should eq(["foo", "bar", "baz,qux"]) }
-      assert { "foo,bar,baz,qux".split(/,/, 30).should eq(["foo", "bar", "baz", "qux"]) }
-      assert { "a b c".split(Regex.new(" "), 2).should eq(["a", "b c"]) }
-      assert { "日本ん語日本ん語".split(/ん/).should eq(["日本", "語日本", "語"]) }
-      assert { "hello world".split(/\b/).should eq(["hello", " ", "world"]) }
-      assert { "abc".split(//).should eq(["a", "b", "c"]) }
-      assert { "hello".split(/\w+/).empty?.should be_true }
-      assert { "foo".split(/o/).should eq(["f"]) }
+      assert { expect("foo\n\tbar\n\t\n\tbaz".split(/\n\t/)).to eq(["foo", "bar", "", "baz"]) }
+      assert { expect("foo\n\tbar\n\t\n\tbaz".split(/(\n\t)+/)).to eq(["foo", "bar", "baz"]) }
+      assert { expect("foo,bar".split(/,/, 1)).to eq(["foo,bar"]) }
+      assert { expect("foo,bar,baz,qux".split(/,/, 1)).to eq(["foo,bar,baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(/,/, 3)).to eq(["foo", "bar", "baz,qux"]) }
+      assert { expect("foo,bar,baz,qux".split(/,/, 30)).to eq(["foo", "bar", "baz", "qux"]) }
+      assert { expect("a b c".split(Regex.new(" "), 2)).to eq(["a", "b c"]) }
+      assert { expect("日本ん語日本ん語".split(/ん/)).to eq(["日本", "語日本", "語"]) }
+      assert { expect("hello world".split(/\b/)).to eq(["hello", " ", "world"]) }
+      assert { expect("abc".split(//)).to eq(["a", "b", "c"]) }
+      assert { expect("hello".split(/\w+/).empty?).to be_true }
+      assert { expect("foo".split(/o/)).to eq(["f"]) }
 
       it "works with complex regex" do
         r = %r([\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*))
-        "hello".split(r).should eq(["", "hello"])
+        expect("hello".split(r)).to eq(["", "hello"])
       end
     end
   end
 
   describe "starts_with?" do
-    assert { "foobar".starts_with?("foo").should be_true }
-    assert { "foobar".starts_with?("").should be_true }
-    assert { "foobar".starts_with?("foobarbaz").should be_false }
-    assert { "foobar".starts_with?("foox").should be_false }
-    assert { "foobar".starts_with?('f').should be_true }
-    assert { "foobar".starts_with?('g').should be_false }
-    assert { "よし".starts_with?('よ').should be_true }
-    assert { "よし!".starts_with?("よし").should be_true }
+    assert { expect("foobar".starts_with?("foo")).to be_true }
+    assert { expect("foobar".starts_with?("")).to be_true }
+    assert { expect("foobar".starts_with?("foobarbaz")).to be_false }
+    assert { expect("foobar".starts_with?("foox")).to be_false }
+    assert { expect("foobar".starts_with?('f')).to be_true }
+    assert { expect("foobar".starts_with?('g')).to be_false }
+    assert { expect("よし".starts_with?('よ')).to be_true }
+    assert { expect("よし!".starts_with?("よし")).to be_true }
   end
 
   describe "ends_with?" do
-    assert { "foobar".ends_with?("bar").should be_true }
-    assert { "foobar".ends_with?("").should be_true }
-    assert { "foobar".ends_with?("foobarbaz").should be_false }
-    assert { "foobar".ends_with?("xbar").should be_false }
-    assert { "foobar".ends_with?('r').should be_true }
-    assert { "foobar".ends_with?('x').should be_false }
-    assert { "よし".ends_with?('し').should be_true }
-    assert { "よし".ends_with?('な').should be_false }
+    assert { expect("foobar".ends_with?("bar")).to be_true }
+    assert { expect("foobar".ends_with?("")).to be_true }
+    assert { expect("foobar".ends_with?("foobarbaz")).to be_false }
+    assert { expect("foobar".ends_with?("xbar")).to be_false }
+    assert { expect("foobar".ends_with?('r')).to be_true }
+    assert { expect("foobar".ends_with?('x')).to be_false }
+    assert { expect("よし".ends_with?('し')).to be_true }
+    assert { expect("よし".ends_with?('な')).to be_false }
   end
 
   describe "=~" do
     it "matches with group" do
       "foobar" =~ /(o+)ba(r?)/
-      $1.should eq("oo")
-      $2.should eq("r")
+      expect($1).to eq("oo")
+      expect($2).to eq("r")
     end
   end
 
   describe "delete" do
-    assert { "foobar".delete {|char| char == 'o' }.should eq("fbar") }
-    assert { "hello world".delete("lo").should eq("he wrd") }
-    assert { "hello world".delete("lo", "o").should eq("hell wrld") }
-    assert { "hello world".delete("hello", "^l").should eq("ll wrld") }
-    assert { "hello world".delete("ej-m").should eq("ho word") }
-    assert { "hello^world".delete("\\^aeiou").should eq("hllwrld") }
-    assert { "hello-world".delete("a\\-eo").should eq("hllwrld") }
-    assert { "hello world\\r\\n".delete("\\").should eq("hello worldrn") }
-    assert { "hello world\\r\\n".delete("\\A").should eq("hello world\\r\\n") }
-    assert { "hello world\\r\\n".delete("X-\\w").should eq("hello orldrn") }
+    assert { expect("foobar".delete {|char| char == 'o' }).to eq("fbar") }
+    assert { expect("hello world".delete("lo")).to eq("he wrd") }
+    assert { expect("hello world".delete("lo", "o")).to eq("hell wrld") }
+    assert { expect("hello world".delete("hello", "^l")).to eq("ll wrld") }
+    assert { expect("hello world".delete("ej-m")).to eq("ho word") }
+    assert { expect("hello^world".delete("\\^aeiou")).to eq("hllwrld") }
+    assert { expect("hello-world".delete("a\\-eo")).to eq("hllwrld") }
+    assert { expect("hello world\\r\\n".delete("\\")).to eq("hello worldrn") }
+    assert { expect("hello world\\r\\n".delete("\\A")).to eq("hello world\\r\\n") }
+    assert { expect("hello world\\r\\n".delete("X-\\w")).to eq("hello orldrn") }
 
     it "deletes one char" do
       deleted = "foobar".delete('o')
-      deleted.bytesize.should eq(4)
-      deleted.should eq("fbar")
+      expect(deleted.bytesize).to eq(4)
+      expect(deleted).to eq("fbar")
 
       deleted = "foobar".delete('x')
-      deleted.bytesize.should eq(6)
-      deleted.should eq("foobar")
+      expect(deleted.bytesize).to eq(6)
+      expect(deleted).to eq("foobar")
     end
   end
 
   it "reverses string" do
     reversed = "foobar".reverse
-    reversed.bytesize.should eq(6)
-    reversed.should eq("raboof")
+    expect(reversed.bytesize).to eq(6)
+    expect(reversed).to eq("raboof")
   end
 
   it "reverses utf-8 string" do
     reversed = "こんいちは".reverse
-    reversed.bytesize.should eq(15)
-    reversed.length.should eq(5)
-    reversed.should eq("はちいんこ")
+    expect(reversed.bytesize).to eq(15)
+    expect(reversed.length).to eq(5)
+    expect(reversed).to eq("はちいんこ")
   end
 
   it "gsubs char with char" do
     replaced = "foobar".gsub('o', 'e')
-    replaced.bytesize.should eq(6)
-    replaced.should eq("feebar")
+    expect(replaced.bytesize).to eq(6)
+    expect(replaced).to eq("feebar")
   end
 
   it "gsubs char with string" do
     replaced = "foobar".gsub('o', "ex")
-    replaced.bytesize.should eq(8)
-    replaced.should eq("fexexbar")
+    expect(replaced.bytesize).to eq(8)
+    expect(replaced).to eq("fexexbar")
   end
 
   it "gsubs char with string depending on the char" do
@@ -456,251 +456,251 @@ describe "String" do
         char
       end
     end
-    replaced.bytesize.should eq(18)
-    replaced.should eq("somethingthingbexr")
+    expect(replaced.bytesize).to eq(18)
+    expect(replaced).to eq("somethingthingbexr")
   end
 
   it "gsubs with regex and block" do
     actual = "foo booor booooz".gsub(/o+/) do |str|
       "#{str}#{str.length}"
     end
-    actual.should eq("foo2 booo3r boooo4z")
+    expect(actual).to eq("foo2 booo3r boooo4z")
   end
 
   it "gsubs with regex and block with group" do
     actual = "foo booor booooz".gsub(/(o+).*?(o+)/) do |str, match|
       "#{match[1].length}#{match[2].length}"
     end
-    actual.should eq("f23r b31z")
+    expect(actual).to eq("f23r b31z")
   end
 
   it "gsubs with regex and string" do
-    "foo boor booooz".gsub(/o+/, "a").should eq("fa bar baz")
+    expect("foo boor booooz".gsub(/o+/, "a")).to eq("fa bar baz")
   end
 
   it "gsubs with regex and string, returns self if no match" do
     str = "hello"
-    str.gsub(/a/, "b").should be(str)
+    expect(str.gsub(/a/, "b")).to be(str)
   end
 
   it "gsubs with regex and string (utf-8)" do
-    "fここ bここr bここここz".gsub(/こ+/, "そこ").should eq("fそこ bそこr bそこz")
+    expect("fここ bここr bここここz".gsub(/こ+/, "そこ")).to eq("fそこ bそこr bそこz")
   end
 
   it "gsubs with string and string" do
-    "foo boor booooz".gsub("oo", "a").should eq("fa bar baaz")
+    expect("foo boor booooz".gsub("oo", "a")).to eq("fa bar baaz")
   end
 
   it "gsubs with string and string return self if no match" do
     str = "hello"
-    str.gsub("a", "b").should be(str)
+    expect(str.gsub("a", "b")).to be(str)
   end
 
   it "gsubs with string and string (utf-8)" do
-    "fここ bここr bここここz".gsub("ここ", "そこ").should eq("fそこ bそこr bそこそこz")
+    expect("fここ bここr bここここz".gsub("ここ", "そこ")).to eq("fそこ bそこr bそこそこz")
   end
 
   it "gsubs with string and block" do
     i = 0
     result = "foo boo".gsub("oo") do |value|
-      value.should eq("oo")
+      expect(value).to eq("oo")
       i += 1
       i == 1 ? "a" : "e"
     end
-    result.should eq("fa be")
+    expect(result).to eq("fa be")
   end
 
   it "gsubs with char hash" do
     str = "hello"
-    str.gsub({'e' => 'a', 'l' => 'd'}).should eq("haddo")
+    expect(str.gsub({'e' => 'a', 'l' => 'd'})).to eq("haddo")
   end
 
   it "gsubs with regex and hash" do
     str = "hello"
-    str.gsub(/(he|l|o)/, {"he": "ha", "l": "la"}).should eq("halala")
+    expect(str.gsub(/(he|l|o)/, {"he": "ha", "l": "la"})).to eq("halala")
   end
 
   it "dumps" do
-    "a".dump.should eq("\"a\"")
-    "\\".dump.should eq("\"\\\\\"")
-    "\"".dump.should eq("\"\\\"\"")
-    "\b".dump.should eq("\"\\b\"")
-    "\e".dump.should eq("\"\\e\"")
-    "\f".dump.should eq("\"\\f\"")
-    "\n".dump.should eq("\"\\n\"")
-    "\r".dump.should eq("\"\\r\"")
-    "\t".dump.should eq("\"\\t\"")
-    "\v".dump.should eq("\"\\v\"")
-    "\#{".dump.should eq("\"\\\#{\"")
-    "á".dump.should eq("\"\\u{E1}\"")
-    "\u{81}".dump.should eq("\"\\u{81}\"")
+    expect("a".dump).to eq("\"a\"")
+    expect("\\".dump).to eq("\"\\\\\"")
+    expect("\"".dump).to eq("\"\\\"\"")
+    expect("\b".dump).to eq("\"\\b\"")
+    expect("\e".dump).to eq("\"\\e\"")
+    expect("\f".dump).to eq("\"\\f\"")
+    expect("\n".dump).to eq("\"\\n\"")
+    expect("\r".dump).to eq("\"\\r\"")
+    expect("\t".dump).to eq("\"\\t\"")
+    expect("\v".dump).to eq("\"\\v\"")
+    expect("\#{".dump).to eq("\"\\\#{\"")
+    expect("á".dump).to eq("\"\\u{E1}\"")
+    expect("\u{81}".dump).to eq("\"\\u{81}\"")
   end
 
   it "inspects" do
-    "a".inspect.should eq("\"a\"")
-    "\\".inspect.should eq("\"\\\\\"")
-    "\"".inspect.should eq("\"\\\"\"")
-    "\b".inspect.should eq("\"\\b\"")
-    "\e".inspect.should eq("\"\\e\"")
-    "\f".inspect.should eq("\"\\f\"")
-    "\n".inspect.should eq("\"\\n\"")
-    "\r".inspect.should eq("\"\\r\"")
-    "\t".inspect.should eq("\"\\t\"")
-    "\v".inspect.should eq("\"\\v\"")
-    "\#{".inspect.should eq("\"\\\#{\"")
-    "á".inspect.should eq("\"á\"")
-    "\u{81}".inspect.should eq("\"\\u{81}\"")
+    expect("a".inspect).to eq("\"a\"")
+    expect("\\".inspect).to eq("\"\\\\\"")
+    expect("\"".inspect).to eq("\"\\\"\"")
+    expect("\b".inspect).to eq("\"\\b\"")
+    expect("\e".inspect).to eq("\"\\e\"")
+    expect("\f".inspect).to eq("\"\\f\"")
+    expect("\n".inspect).to eq("\"\\n\"")
+    expect("\r".inspect).to eq("\"\\r\"")
+    expect("\t".inspect).to eq("\"\\t\"")
+    expect("\v".inspect).to eq("\"\\v\"")
+    expect("\#{".inspect).to eq("\"\\\#{\"")
+    expect("á".inspect).to eq("\"á\"")
+    expect("\u{81}".inspect).to eq("\"\\u{81}\"")
   end
 
   it "does *" do
     str = "foo" * 10
-    str.bytesize.should eq(30)
-    str.should eq("foofoofoofoofoofoofoofoofoofoo")
+    expect(str.bytesize).to eq(30)
+    expect(str).to eq("foofoofoofoofoofoofoofoofoofoo")
   end
 
   describe "+" do
     it "does for both ascii" do
       str = "foo" + "bar"
-      str.bytesize.should eq(6)
-      str.@length.should eq(6)
-      str.should eq("foobar")
+      expect(str.bytesize).to eq(6)
+      expect(str.@length).to eq(6)
+      expect(str).to eq("foobar")
     end
 
     it "does for both unicode" do
       str = "青い" + "旅路"
-      str.@length.should eq(4)
-      str.should eq("青い旅路")
+      expect(str.@length).to eq(4)
+      expect(str).to eq("青い旅路")
     end
 
     it "does with ascii char" do
       str = "foo"
       str2 = str + '/'
-      str2.should eq("foo/")
-      str2.bytesize.should eq(4)
-      str2.length.should eq(4)
+      expect(str2).to eq("foo/")
+      expect(str2.bytesize).to eq(4)
+      expect(str2.length).to eq(4)
     end
 
     it "does with unicode char" do
       str = "fooba"
       str2 = str + 'る'
-      str2.should eq("foobaる")
-      str2.bytesize.should eq(8)
-      str2.length.should eq(6)
+      expect(str2).to eq("foobaる")
+      expect(str2.bytesize).to eq(8)
+      expect(str2.length).to eq(6)
     end
   end
 
   it "does %" do
-    ("foo" % 1).should        eq("foo")
-    ("foo %d" % 1).should     eq("foo 1")
-    ("%d" % 123).should       eq("123")
-    ("%+d" % 123).should      eq("+123")
-    ("%+d" % -123).should     eq("-123")
-    ("% d" % 123).should      eq(" 123")
-    ("%20d" % 123).should     eq("                 123")
-    ("%+20d" % 123).should    eq("                +123")
-    ("%+20d" % -123).should   eq("                -123")
-    ("% 20d" % 123).should    eq("                 123")
-    ("%020d" % 123).should    eq("00000000000000000123")
-    ("%+020d" % 123).should   eq("+0000000000000000123")
-    ("% 020d" % 123).should   eq(" 0000000000000000123")
-    ("%-d" % 123).should      eq("123")
-    ("%-20d" % 123).should    eq("123                 ")
-    ("%-+20d" % 123).should   eq("+123                ")
-    ("%-+20d" % -123).should  eq("-123                ")
-    ("%- 20d" % 123).should   eq(" 123                ")
-    ("%s" % 'a').should       eq("a")
-    ("%-s" % 'a').should      eq("a")
-    ("%20s" % 'a').should     eq("                   a")
-    ("%-20s" % 'a').should    eq("a                   ")
+    expect(("foo" % 1)).to        eq("foo")
+    expect(("foo %d" % 1)).to     eq("foo 1")
+    expect(("%d" % 123)).to       eq("123")
+    expect(("%+d" % 123)).to      eq("+123")
+    expect(("%+d" % -123)).to     eq("-123")
+    expect(("% d" % 123)).to      eq(" 123")
+    expect(("%20d" % 123)).to     eq("                 123")
+    expect(("%+20d" % 123)).to    eq("                +123")
+    expect(("%+20d" % -123)).to   eq("                -123")
+    expect(("% 20d" % 123)).to    eq("                 123")
+    expect(("%020d" % 123)).to    eq("00000000000000000123")
+    expect(("%+020d" % 123)).to   eq("+0000000000000000123")
+    expect(("% 020d" % 123)).to   eq(" 0000000000000000123")
+    expect(("%-d" % 123)).to      eq("123")
+    expect(("%-20d" % 123)).to    eq("123                 ")
+    expect(("%-+20d" % 123)).to   eq("+123                ")
+    expect(("%-+20d" % -123)).to  eq("-123                ")
+    expect(("%- 20d" % 123)).to   eq(" 123                ")
+    expect(("%s" % 'a')).to       eq("a")
+    expect(("%-s" % 'a')).to      eq("a")
+    expect(("%20s" % 'a')).to     eq("                   a")
+    expect(("%-20s" % 'a')).to    eq("a                   ")
 
-    ("%%%d" % 1).should eq("%1")
-    ("foo %d bar %s baz %d goo" % [1, "hello", 2]).should eq("foo 1 bar hello baz 2 goo")
+    expect(("%%%d" % 1)).to eq("%1")
+    expect(("foo %d bar %s baz %d goo" % [1, "hello", 2])).to eq("foo 1 bar hello baz 2 goo")
 
-    ("%b" % 123).should eq("1111011")
-    ("%+b" % 123).should eq("+1111011")
-    ("% b" % 123).should eq(" 1111011")
-    ("%-b" % 123).should eq("1111011")
-    ("%10b" % 123).should eq("   1111011")
-    ("%-10b" % 123).should eq("1111011   ")
+    expect(("%b" % 123)).to eq("1111011")
+    expect(("%+b" % 123)).to eq("+1111011")
+    expect(("% b" % 123)).to eq(" 1111011")
+    expect(("%-b" % 123)).to eq("1111011")
+    expect(("%10b" % 123)).to eq("   1111011")
+    expect(("%-10b" % 123)).to eq("1111011   ")
 
-    ("%o" % 123).should eq("173")
-    ("%+o" % 123).should eq("+173")
-    ("% o" % 123).should eq(" 173")
-    ("%-o" % 123).should eq("173")
-    ("%6o" % 123).should eq("   173")
-    ("%-6o" % 123).should eq("173   ")
+    expect(("%o" % 123)).to eq("173")
+    expect(("%+o" % 123)).to eq("+173")
+    expect(("% o" % 123)).to eq(" 173")
+    expect(("%-o" % 123)).to eq("173")
+    expect(("%6o" % 123)).to eq("   173")
+    expect(("%-6o" % 123)).to eq("173   ")
 
-    ("%x" % 123).should eq("7B")
-    ("%+x" % 123).should eq("+7B")
-    ("% x" % 123).should eq(" 7B")
-    ("%-x" % 123).should eq("7B")
-    ("%6x" % 123).should eq("    7B")
-    ("%-6x" % 123).should eq("7B    ")
+    expect(("%x" % 123)).to eq("7B")
+    expect(("%+x" % 123)).to eq("+7B")
+    expect(("% x" % 123)).to eq(" 7B")
+    expect(("%-x" % 123)).to eq("7B")
+    expect(("%6x" % 123)).to eq("    7B")
+    expect(("%-6x" % 123)).to eq("7B    ")
 
-    ("こんに%xちは" % 123).should eq("こんに7Bちは")
+    expect(("こんに%xちは" % 123)).to eq("こんに7Bちは")
 
-    ("%f" % 123).should eq("123.000000")
+    expect(("%f" % 123)).to eq("123.000000")
 
-    ("%g" % 123).should eq("123")
-    ("%12f" % 123.45).should eq("  123.450000")
-    ("%-12f" % 123.45).should eq("123.450000  ")
-    ("% f" % 123.45).should eq(" 123.450000")
-    ("%+f" % 123).should eq("+123.000000")
-    ("%012f" % 123).should eq("00123.000000")
-    ("%.f" % 1234.56).should eq("1235")
-    ("%.2f" % 1234.5678).should eq("1234.57")
-    ("%10.2f" % 1234.5678).should eq("   1234.57")
-    ("%e" % 123.45).should eq("1.234500e+02")
-    ("%E" % 123.45).should eq("1.234500E+02")
-    ("%G" % 12345678.45).should eq("1.23457E+07")
-    ("%a" % 12345678.45).should eq("0x1.78c29ce666666p+23")
-    ("%A" % 12345678.45).should eq("0X1.78C29CE666666P+23")
-    ("%100.50g" % 123.45).should eq("                                                  123.4500000000000028421709430404007434844970703125")
+    expect(("%g" % 123)).to eq("123")
+    expect(("%12f" % 123.45)).to eq("  123.450000")
+    expect(("%-12f" % 123.45)).to eq("123.450000  ")
+    expect(("% f" % 123.45)).to eq(" 123.450000")
+    expect(("%+f" % 123)).to eq("+123.000000")
+    expect(("%012f" % 123)).to eq("00123.000000")
+    expect(("%.f" % 1234.56)).to eq("1235")
+    expect(("%.2f" % 1234.5678)).to eq("1234.57")
+    expect(("%10.2f" % 1234.5678)).to eq("   1234.57")
+    expect(("%e" % 123.45)).to eq("1.234500e+02")
+    expect(("%E" % 123.45)).to eq("1.234500E+02")
+    expect(("%G" % 12345678.45)).to eq("1.23457E+07")
+    expect(("%a" % 12345678.45)).to eq("0x1.78c29ce666666p+23")
+    expect(("%A" % 12345678.45)).to eq("0X1.78C29CE666666P+23")
+    expect(("%100.50g" % 123.45)).to eq("                                                  123.4500000000000028421709430404007434844970703125")
   end
 
   it "escapes chars" do
-    "\b"[0].should eq('\b')
-    "\t"[0].should eq('\t')
-    "\n"[0].should eq('\n')
-    "\v"[0].should eq('\v')
-    "\f"[0].should eq('\f')
-    "\r"[0].should eq('\r')
-    "\e"[0].should eq('\e')
-    "\""[0].should eq('"')
-    "\\"[0].should eq('\\')
+    expect("\b"[0]).to eq('\b')
+    expect("\t"[0]).to eq('\t')
+    expect("\n"[0]).to eq('\n')
+    expect("\v"[0]).to eq('\v')
+    expect("\f"[0]).to eq('\f')
+    expect("\r"[0]).to eq('\r')
+    expect("\e"[0]).to eq('\e')
+    expect("\""[0]).to eq('"')
+    expect("\\"[0]).to eq('\\')
   end
 
   it "escapes with octal" do
-    "\3"[0].ord.should eq(3)
-    "\23"[0].ord.should eq((2 * 8) + 3)
-    "\123"[0].ord.should eq((1 * 8 * 8) + (2 * 8) + 3)
-    "\033"[0].ord.should eq((3 * 8) + 3)
-    "\033a"[1].should eq('a')
+    expect("\3"[0].ord).to eq(3)
+    expect("\23"[0].ord).to eq((2 * 8) + 3)
+    expect("\123"[0].ord).to eq((1 * 8 * 8) + (2 * 8) + 3)
+    expect("\033"[0].ord).to eq((3 * 8) + 3)
+    expect("\033a"[1]).to eq('a')
   end
 
   it "escapes with unicode" do
-    "\u{12}".codepoint_at(0).should eq(1 * 16 + 2)
-    "\u{A}".codepoint_at(0).should eq(10)
-    "\u{AB}".codepoint_at(0).should eq(10 * 16 + 11)
-    "\u{AB}1".codepoint_at(1).should eq('1'.ord)
+    expect("\u{12}".codepoint_at(0)).to eq(1 * 16 + 2)
+    expect("\u{A}".codepoint_at(0)).to eq(10)
+    expect("\u{AB}".codepoint_at(0)).to eq(10 * 16 + 11)
+    expect("\u{AB}1".codepoint_at(1)).to eq('1'.ord)
   end
 
   it "does char_at" do
-    "いただきます".char_at(2).should eq('だ')
+    expect("いただきます".char_at(2)).to eq('だ')
   end
 
   it "does byte_at" do
-    "hello".byte_at(1).should eq('e'.ord)
+    expect("hello".byte_at(1)).to eq('e'.ord)
     expect_raises(IndexOutOfBounds) { "hello".byte_at(5) }
   end
 
   it "does byte_at?" do
-    "hello".byte_at?(1).should eq('e'.ord)
-    "hello".byte_at?(5).should be_nil
+    expect("hello".byte_at?(1)).to eq('e'.ord)
+    expect("hello".byte_at?(5)).to be_nil
   end
 
   it "does chars" do
-    "ぜんぶ".chars.should eq(['ぜ', 'ん', 'ぶ'])
+    expect("ぜんぶ".chars).to eq(['ぜ', 'ん', 'ぶ'])
   end
 
   it "allows creating a string with zeros" do
@@ -709,72 +709,72 @@ describe "String" do
     p[1] = '\0'.ord.to_u8
     p[2] = 'b'.ord.to_u8
     s = String.new(p, 3)
-    s[0].should eq('a')
-    s[1].should eq('\0')
-    s[2].should eq('b')
-    s.bytesize.should eq(3)
+    expect(s[0]).to eq('a')
+    expect(s[1]).to eq('\0')
+    expect(s[2]).to eq('b')
+    expect(s.bytesize).to eq(3)
   end
 
   it "tr" do
-    "bla".tr("a", "h").should eq("blh")
-    "bla".tr("a", "⊙").should eq("bl⊙")
-    "bl⊙a".tr("⊙", "a").should eq("blaa")
-    "bl⊙a".tr("⊙", "ⓧ").should eq("blⓧa")
-    "bl⊙a⊙asdfd⊙dsfsdf⊙⊙⊙".tr("a⊙", "ⓧt").should eq("bltⓧtⓧsdfdtdsfsdfttt")
-    "hello".tr("aeiou", "*").should eq("h*ll*")
-    "hello".tr("el", "ip").should eq("hippo")
-    "Lisp".tr("Lisp", "Crys").should eq("Crys")
-    "hello".tr("helo", "1212").should eq("12112")
-    "this".tr("this", "ⓧ").should eq("ⓧⓧⓧⓧ")
-    "über".tr("ü","u").should eq("uber")
+    expect("bla".tr("a", "h")).to eq("blh")
+    expect("bla".tr("a", "⊙")).to eq("bl⊙")
+    expect("bl⊙a".tr("⊙", "a")).to eq("blaa")
+    expect("bl⊙a".tr("⊙", "ⓧ")).to eq("blⓧa")
+    expect("bl⊙a⊙asdfd⊙dsfsdf⊙⊙⊙".tr("a⊙", "ⓧt")).to eq("bltⓧtⓧsdfdtdsfsdfttt")
+    expect("hello".tr("aeiou", "*")).to eq("h*ll*")
+    expect("hello".tr("el", "ip")).to eq("hippo")
+    expect("Lisp".tr("Lisp", "Crys")).to eq("Crys")
+    expect("hello".tr("helo", "1212")).to eq("12112")
+    expect("this".tr("this", "ⓧ")).to eq("ⓧⓧⓧⓧ")
+    expect("über".tr("ü","u")).to eq("uber")
   end
 
   describe "compare" do
     it "compares with == when same string" do
-      "foo".should eq("foo")
+      expect("foo").to eq("foo")
     end
 
     it "compares with == when different strings same contents" do
       s1 = "foo#{1}"
       s2 = "foo#{1}"
-      s1.should eq(s2)
+      expect(s1).to eq(s2)
     end
 
     it "compares with == when different contents" do
       s1 = "foo#{1}"
       s2 = "foo#{2}"
-      s1.should_not eq(s2)
+      expect(s1).to_not eq(s2)
     end
 
     it "sorts strings" do
       s1 = "foo1"
       s2 = "foo"
       s3 = "bar"
-      [s1, s2, s3].sort.should eq(["bar", "foo", "foo1"])
+      expect([s1, s2, s3].sort).to eq(["bar", "foo", "foo1"])
     end
   end
 
   it "does underscore" do
-    "Foo".underscore.should eq("foo")
-    "FooBar".underscore.should eq("foo_bar")
-    "ABCde".underscore.should eq("ab_cde")
-    "FOO_bar".underscore.should eq("foo_bar")
+    expect("Foo".underscore).to eq("foo")
+    expect("FooBar".underscore).to eq("foo_bar")
+    expect("ABCde".underscore).to eq("ab_cde")
+    expect("FOO_bar".underscore).to eq("foo_bar")
   end
 
   it "does camelcase" do
-    "foo".camelcase.should eq("Foo")
-    "foo_bar".camelcase.should eq("FooBar")
+    expect("foo".camelcase).to eq("Foo")
+    expect("foo_bar".camelcase).to eq("FooBar")
   end
 
   it "answers ascii_only?" do
-    "a".ascii_only?.should be_true
-    "あ".ascii_only?.should be_false
+    expect("a".ascii_only?).to be_true
+    expect("あ".ascii_only?).to be_false
 
     str = String.new(1) do |buffer|
       buffer.value = 'a'.ord.to_u8
       {1, 0}
     end
-    str.ascii_only?.should be_true
+    expect(str.ascii_only?).to be_true
 
     str = String.new(4) do |buffer|
       count = 0
@@ -784,16 +784,16 @@ describe "String" do
       end
       {count, 0}
     end
-    str.ascii_only?.should be_false
+    expect(str.ascii_only?).to be_false
   end
 
   describe "scan" do
     it "does without block" do
       a = "cruel world"
-      a.scan(/\w+/).map(&.[0]).should eq(["cruel", "world"])
-      a.scan(/.../).map(&.[0]).should eq(["cru", "el ", "wor"])
-      a.scan(/(...)/).map(&.[1]).should eq(["cru", "el ", "wor"])
-      a.scan(/(..)(..)/).map { |m| {m[1], m[2]} }.should eq([{"cr", "ue"}, {"l ", "wo"}])
+      expect(a.scan(/\w+/).map(&.[0])).to eq(["cruel", "world"])
+      expect(a.scan(/.../).map(&.[0])).to eq(["cru", "el ", "wor"])
+      expect(a.scan(/(...)/).map(&.[1])).to eq(["cru", "el ", "wor"])
+      expect(a.scan(/(..)(..)/).map { |m| {m[1], m[2]} }).to eq([{"cr", "ue"}, {"l ", "wo"}])
     end
 
     it "does with block" do
@@ -802,11 +802,11 @@ describe "String" do
       a.scan(/\w(o+)/) do |match|
         case i
         when 0
-          match[0].should eq("foo")
-          match[1].should eq("oo")
+          expect(match[0]).to eq("foo")
+          expect(match[1]).to eq("oo")
         when 1
-          match[0].should eq("goo")
-          match[1].should eq("oo")
+          expect(match[0]).to eq("goo")
+          expect(match[1]).to eq("oo")
         else
           fail "expected two matches"
         end
@@ -816,87 +816,87 @@ describe "String" do
 
     it "does with utf-8" do
       a = "こん こん"
-      a.scan(/こ/).map(&.[0]).should eq(["こ", "こ"])
+      expect(a.scan(/こ/).map(&.[0])).to eq(["こ", "こ"])
     end
 
     it "works when match is empty" do
       r = %r([\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*))
-      "hello".scan(r).map(&.[0]).should eq(["hello", ""])
+      expect("hello".scan(r).map(&.[0])).to eq(["hello", ""])
     end
 
     it "works with strings with block" do
       res = [] of String
       "bla bla ablf".scan("bl") { |s| res << s }
-      res.should eq(["bl", "bl", "bl"])
+      expect(res).to eq(["bl", "bl", "bl"])
     end
 
     it "works with strings" do
-      "bla bla ablf".scan("bl").should eq(["bl", "bl", "bl"])
-      "hello".scan("world").should eq([] of String)
-      "bbb".scan("bb").should eq(["bb"])
-      "ⓧⓧⓧ".scan("ⓧⓧ").should eq(["ⓧⓧ"])
-      "ⓧ".scan("ⓧ").should eq(["ⓧ"])
-      "ⓧ ⓧ ⓧ".scan("ⓧ").should eq(["ⓧ", "ⓧ", "ⓧ"])
-      "".scan("").should eq([] of String)
-      "a".scan("").should eq([] of String)
-      "".scan("a").should eq([] of String)
+      expect("bla bla ablf".scan("bl")).to eq(["bl", "bl", "bl"])
+      expect("hello".scan("world")).to eq([] of String)
+      expect("bbb".scan("bb")).to eq(["bb"])
+      expect("ⓧⓧⓧ".scan("ⓧⓧ")).to eq(["ⓧⓧ"])
+      expect("ⓧ".scan("ⓧ")).to eq(["ⓧ"])
+      expect("ⓧ ⓧ ⓧ".scan("ⓧ")).to eq(["ⓧ", "ⓧ", "ⓧ"])
+      expect("".scan("")).to eq([] of String)
+      expect("a".scan("")).to eq([] of String)
+      expect("".scan("a")).to eq([] of String)
     end
 
     it "does with number and string" do
-      "1ab4".scan(/\d+/).map(&.[0]).should eq(["1", "4"])
+      expect("1ab4".scan(/\d+/).map(&.[0])).to eq(["1", "4"])
     end
   end
 
   it "has match" do
-    "FooBar".match(/oo/).not_nil![0].should eq("oo")
+    expect("FooBar".match(/oo/).not_nil![0]).to eq("oo")
   end
 
   it "matches with position" do
-    "こんにちは".match(/./, 1).not_nil![0].should eq("ん")
+    expect("こんにちは".match(/./, 1).not_nil![0]).to eq("ん")
   end
 
   it "has size (same as length)" do
-    "テスト".size.should eq(3)
+    expect("テスト".size).to eq(3)
   end
 
   describe "count" do
-    assert { "hello world".count("lo").should eq(5) }
-    assert { "hello world".count("lo", "o").should eq(2) }
-    assert { "hello world".count("hello", "^l").should eq(4) }
-    assert { "hello world".count("ej-m").should eq(4) }
-    assert { "hello^world".count("\\^aeiou").should eq(4) }
-    assert { "hello-world".count("a\\-eo").should eq(4) }
-    assert { "hello world\\r\\n".count("\\").should eq(2) }
-    assert { "hello world\\r\\n".count("\\A").should eq(0) }
-    assert { "hello world\\r\\n".count("X-\\w").should eq(3) }
-    assert { "aabbcc".count('a').should eq(2) }
-    assert { "aabbcc".count {|c| ['a', 'b'].includes?(c) }.should eq(4) }
+    assert { expect("hello world".count("lo")).to eq(5) }
+    assert { expect("hello world".count("lo", "o")).to eq(2) }
+    assert { expect("hello world".count("hello", "^l")).to eq(4) }
+    assert { expect("hello world".count("ej-m")).to eq(4) }
+    assert { expect("hello^world".count("\\^aeiou")).to eq(4) }
+    assert { expect("hello-world".count("a\\-eo")).to eq(4) }
+    assert { expect("hello world\\r\\n".count("\\")).to eq(2) }
+    assert { expect("hello world\\r\\n".count("\\A")).to eq(0) }
+    assert { expect("hello world\\r\\n".count("X-\\w")).to eq(3) }
+    assert { expect("aabbcc".count('a')).to eq(2) }
+    assert { expect("aabbcc".count {|c| ['a', 'b'].includes?(c) }).to eq(4) }
   end
 
   describe "squeeze" do
-    assert { "aaabbbccc".squeeze {|c| ['a', 'b'].includes?(c) }.should eq("abccc") }
-    assert { "aaabbbccc".squeeze {|c| ['a', 'c'].includes?(c) }.should eq("abbbc") }
-    assert { "a       bbb".squeeze.should eq("a b") }
-    assert { "a    bbb".squeeze(' ').should eq("a bbb") }
-    assert { "aaabbbcccddd".squeeze("b-d").should eq("aaabcd") }
+    assert { expect("aaabbbccc".squeeze {|c| ['a', 'b'].includes?(c) }).to eq("abccc") }
+    assert { expect("aaabbbccc".squeeze {|c| ['a', 'c'].includes?(c) }).to eq("abbbc") }
+    assert { expect("a       bbb".squeeze).to eq("a b") }
+    assert { expect("a    bbb".squeeze(' ')).to eq("a bbb") }
+    assert { expect("aaabbbcccddd".squeeze("b-d")).to eq("aaabcd") }
   end
 
   describe "ljust" do
-    assert { "123".ljust(2).should eq("123") }
-    assert { "123".ljust(5).should eq("123  ") }
-    assert { "12".ljust(7, '-').should eq("12-----") }
-    assert { "12".ljust(7, 'あ').should eq("12あああああ") }
+    assert { expect("123".ljust(2)).to eq("123") }
+    assert { expect("123".ljust(5)).to eq("123  ") }
+    assert { expect("12".ljust(7, '-')).to eq("12-----") }
+    assert { expect("12".ljust(7, 'あ')).to eq("12あああああ") }
   end
 
   describe "rjust" do
-    assert { "123".rjust(2).should eq("123") }
-    assert { "123".rjust(5).should eq("  123") }
-    assert { "12".rjust(7, '-').should eq("-----12") }
-    assert { "12".rjust(7, 'あ').should eq("あああああ12") }
+    assert { expect("123".rjust(2)).to eq("123") }
+    assert { expect("123".rjust(5)).to eq("  123") }
+    assert { expect("12".rjust(7, '-')).to eq("-----12") }
+    assert { expect("12".rjust(7, 'あ')).to eq("あああああ12") }
   end
 
   it "uses sprintf from top-level" do
-    sprintf("Hello %d world", 123).should eq("Hello 123 world")
-    sprintf("Hello %d world", [123]).should eq("Hello 123 world")
+    expect(sprintf("Hello %d world", 123)).to eq("Hello 123 world")
+    expect(sprintf("Hello %d world", [123])).to eq("Hello 123 world")
   end
 end

--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -8,16 +8,16 @@ end
 describe "Struct" do
   it "does to_s" do
     s = StructSpecTestClass.new(1, "hello")
-    s.to_s.should eq(%(StructSpecTestClass(@x=1, @y="hello")))
+    expect(s.to_s).to eq(%(StructSpecTestClass(@x=1, @y="hello")))
   end
 
   it "does ==" do
     s = StructSpecTestClass.new(1, "hello")
-    s.should eq(s)
+    expect(s).to eq(s)
   end
 
   it "does hash" do
     s = StructSpecTestClass.new(1, "hello")
-    s.hash.should eq(31 + "hello".hash)
+    expect(s.hash).to eq(31 + "hello".hash)
   end
 end

--- a/spec/std/symbol_spec.cr
+++ b/spec/std/symbol_spec.cr
@@ -2,26 +2,26 @@ require "spec"
 
 describe Symbol do
   it "inspects" do
-    :foo.inspect.should eq(%(:foo))
-    :"{".inspect.should eq(%(:"{"))
-    :"hi there".inspect.should eq(%(:"hi there"))
-    # :かたな.inspect.should eq(%(:かたな))
+    expect(:foo.inspect).to eq(%(:foo))
+    expect(:"{".inspect).to eq(%(:"{"))
+    expect(:"hi there".inspect).to eq(%(:"hi there"))
+    expect(# :かたな.inspect).to eq(%(:かたな))
   end
   
   it "can be compared with another symbol" do
-    :s.between?(:a, :z).should be_true
-    :a.between?(:s, :z).should be_false
-    (:foo > :bar).should be_true
-    (:foo < :bar).should be_false
+    expect(:s.between?(:a, :z)).to be_true
+    expect(:a.between?(:s, :z)).to be_false
+    expect((:foo > :bar)).to be_true
+    expect((:foo < :bar)).to be_false
 
     a = %i(q w e r t y u i o p a s d f g h j k l z x c v b n m)
     b = %i(a b c d e f g h i j k l m n o p q r s t u v w x y z)
-    a.sort.should eq(b)
+    expect(a.sort).to eq(b)
   end
 
   it "displays symbols that don't need quotes without quotes" do
     a = %i(+ - * / == < <= > >= ! != =~ !~ & | ^ ~ ** >> << % [] <=> === []? []=)
     b = "[:+, :-, :*, :/, :==, :<, :<=, :>, :>=, :!, :!=, :=~, :!~, :&, :|, :^, :~, :**, :>>, :<<, :%, :[], :<=>, :===, :[]?, :[]=]"
-    a.inspect.should eq(b)
+    expect(a.inspect).to eq(b)
   end
 end

--- a/spec/std/symbol_spec.cr
+++ b/spec/std/symbol_spec.cr
@@ -5,9 +5,10 @@ describe Symbol do
     expect(:foo.inspect).to eq(%(:foo))
     expect(:"{".inspect).to eq(%(:"{"))
     expect(:"hi there".inspect).to eq(%(:"hi there"))
-    expect(# :かたな.inspect).to eq(%(:かたな))
+    # TODO: make it a pending spec
+    #expect(:かたな.inspect).to eq(%(:かたな))
   end
-  
+
   it "can be compared with another symbol" do
     expect(:s.between?(:a, :z)).to be_true
     expect(:a.between?(:s, :z)).to be_false

--- a/spec/std/tempfile_spec.cr
+++ b/spec/std/tempfile_spec.cr
@@ -7,8 +7,8 @@ describe Tempfile do
     tempfile.print "Hello!"
     tempfile.close
 
-    File.exists?(tempfile.path).should be_true
-    File.read(tempfile.path).should eq("Hello!")
+    expect(File.exists?(tempfile.path)).to be_true
+    expect(File.read(tempfile.path)).to eq("Hello!")
   end
 
   it "creates and deletes" do
@@ -16,14 +16,14 @@ describe Tempfile do
     tempfile.close
     tempfile.delete
 
-    File.exists?(tempfile.path).should be_false
+    expect(File.exists?(tempfile.path)).to be_false
   end
 
   it "doesn't delete on open with block" do
     tempfile = Tempfile.open("foo") do |f|
       f.print "Hello!"
     end
-    File.exists?(tempfile.path).should be_true
+    expect(File.exists?(tempfile.path)).to be_true
   end
 
   it "creates and writes with TMPDIR environment variable" do
@@ -35,8 +35,8 @@ describe Tempfile do
       tempfile.print "Hello!"
       tempfile.close
 
-      File.exists?(tempfile.path).should be_true
-      File.read(tempfile.path).should eq("Hello!")
+      expect(File.exists?(tempfile.path)).to be_true
+      expect(File.read(tempfile.path)).to eq("Hello!")
     ensure
       ENV["TMPDIR"] = old_tmpdir if old_tmpdir
     end

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -4,15 +4,15 @@ describe "Thread" do
   it "allows passing an argumentless fun to execute" do
     a = 0
     thread = Thread.new { a = 1; 10 }
-    thread.join.should eq(10)
-    a.should eq(1)
+    expect(thread.join).to eq(10)
+    expect(a).to eq(1)
   end
 
   it "allows passing a fun with an argument to execute" do
     a = 0
     thread = Thread.new(3) { |i| a += i; 20 }
-    thread.join.should eq(20)
-    a.should eq(3)
+    expect(thread.join).to eq(20)
+    expect(a).to eq(3)
   end
 
   it "raises inside thread and gets it on join" do
@@ -25,7 +25,7 @@ describe "Thread" do
   it "gets a non-nilable value from join" do
     thread = Thread.new { 1 }
     value = thread.join
-    (value + 2).should eq(3)
+    expect((value + 2)).to eq(3)
   end
 end
 
@@ -42,10 +42,10 @@ describe "ConditionVariable" do
       end
     end
 
-    a.should eq(0)
+    expect(a).to eq(0)
     3.times do |i|
       m.synchronize { cv1.signal; cv2.wait(m) }
-      a.should eq(i + 1)
+      expect(a).to eq(i + 1)
     end
 
     thread.join

--- a/spec/std/time/time_span_spec.cr
+++ b/spec/std/time/time_span_spec.cr
@@ -9,22 +9,22 @@ end
 describe TimeSpan do
   it "initializes" do
     t1 = TimeSpan.new 1234567890
-    t1.to_s.should eq("00:02:03.4567890")
+    expect(t1.to_s).to eq("00:02:03.4567890")
 
     t1 = TimeSpan.new 1, 2, 3
-    t1.to_s.should eq("01:02:03")
+    expect(t1.to_s).to eq("01:02:03")
 
     t1 = TimeSpan.new 1, 2, 3, 4
-    t1.to_s.should eq("1.02:03:04")
+    expect(t1.to_s).to eq("1.02:03:04")
 
     t1 = TimeSpan.new 1, 2, 3, 4, 5
-    t1.to_s.should eq("1.02:03:04.0050000")
+    expect(t1.to_s).to eq("1.02:03:04.0050000")
 
     t1 = TimeSpan.new -1, 2, -3, 4, -5
-    t1.to_s.should eq("-22:02:56.0050000")
+    expect(t1.to_s).to eq("-22:02:56.0050000")
 
     t1 = TimeSpan.new 0, 25, 0, 0, 0
-    t1.to_s.should eq("1.01:00:00")
+    expect(t1.to_s).to eq("1.01:00:00")
   end
 
   it "days overflows" do
@@ -48,69 +48,69 @@ describe TimeSpan do
 
   it "max seconds" do
     ts = Int32::MAX.seconds
-    ts.days.should eq(24855)
-    ts.hours.should eq(3)
-    ts.minutes.should eq(14)
-    ts.seconds.should eq(7)
-    ts.milliseconds.should eq(0)
-    ts.ticks.should eq(21474836470000000)
+    expect(ts.days).to eq(24855)
+    expect(ts.hours).to eq(3)
+    expect(ts.minutes).to eq(14)
+    expect(ts.seconds).to eq(7)
+    expect(ts.milliseconds).to eq(0)
+    expect(ts.ticks).to eq(21474836470000000)
   end
 
   it "min seconds" do
     ts = Int32::MIN.seconds
-    ts.days.should eq(-24855)
-    ts.hours.should eq(-3)
-    ts.minutes.should eq(-14)
-    ts.seconds.should eq(-8)
-    ts.milliseconds.should eq(0)
-    ts.ticks.should eq(-21474836480000000)
+    expect(ts.days).to eq(-24855)
+    expect(ts.hours).to eq(-3)
+    expect(ts.minutes).to eq(-14)
+    expect(ts.seconds).to eq(-8)
+    expect(ts.milliseconds).to eq(0)
+    expect(ts.ticks).to eq(-21474836480000000)
   end
 
   it "max milliseconds" do
     ts = Int32::MAX.milliseconds
-    ts.days.should eq(24)
-    ts.hours.should eq(20)
-    ts.minutes.should eq(31)
-    ts.seconds.should eq(23)
-    ts.milliseconds.should eq(647)
-    ts.ticks.should eq(21474836470000)
+    expect(ts.days).to eq(24)
+    expect(ts.hours).to eq(20)
+    expect(ts.minutes).to eq(31)
+    expect(ts.seconds).to eq(23)
+    expect(ts.milliseconds).to eq(647)
+    expect(ts.ticks).to eq(21474836470000)
   end
 
   it "min milliseconds" do
     ts = Int32::MIN.milliseconds
-    ts.days.should eq(-24)
-    ts.hours.should eq(-20)
-    ts.minutes.should eq(-31)
-    ts.seconds.should eq(-23)
-    ts.milliseconds.should eq(-648)
-    ts.ticks.should eq(-21474836480000)
+    expect(ts.days).to eq(-24)
+    expect(ts.hours).to eq(-20)
+    expect(ts.minutes).to eq(-31)
+    expect(ts.seconds).to eq(-23)
+    expect(ts.milliseconds).to eq(-648)
+    expect(ts.ticks).to eq(-21474836480000)
   end
 
   it "negative timespan" do
     ts = TimeSpan.new -23, -59, -59
-    ts.days.should eq(0)
-    ts.hours.should eq(-23)
-    ts.minutes.should eq(-59)
-    ts.seconds.should eq(-59)
-    ts.milliseconds.should eq(0)
-    ts.ticks.should eq(-863990000000)
+    expect(ts.days).to eq(0)
+    expect(ts.hours).to eq(-23)
+    expect(ts.minutes).to eq(-59)
+    expect(ts.seconds).to eq(-59)
+    expect(ts.milliseconds).to eq(0)
+    expect(ts.ticks).to eq(-863990000000)
   end
 
   it "test properties" do
     t1 = TimeSpan.new 1, 2, 3, 4, 5
     t2 = -t1
 
-    t1.days.should eq(1)
-    t1.hours.should eq(2)
-    t1.minutes.should eq(3)
-    t1.seconds.should eq(4)
-    t1.milliseconds.should eq(5)
+    expect(t1.days).to eq(1)
+    expect(t1.hours).to eq(2)
+    expect(t1.minutes).to eq(3)
+    expect(t1.seconds).to eq(4)
+    expect(t1.milliseconds).to eq(5)
 
-    t2.days.should eq(-1)
-    t2.hours.should eq(-2)
-    t2.minutes.should eq(-3)
-    t2.seconds.should eq(-4)
-    t2.milliseconds.should eq(-5)
+    expect(t2.days).to eq(-1)
+    expect(t2.hours).to eq(-2)
+    expect(t2.minutes).to eq(-3)
+    expect(t2.seconds).to eq(-4)
+    expect(t2.milliseconds).to eq(-5)
   end
 
   it "test add" do
@@ -118,12 +118,12 @@ describe TimeSpan do
     t2 = TimeSpan.new 1, 2, 3, 4, 5
     t3 = t1 + t2;
 
-    t3.days.should eq(3)
-    t3.hours.should eq(5)
-    t3.minutes.should eq(7)
-    t3.seconds.should eq(9)
-    t3.milliseconds.should eq(11)
-    t3.to_s.should eq("3.05:07:09.0110000")
+    expect(t3.days).to eq(3)
+    expect(t3.hours).to eq(5)
+    expect(t3.minutes).to eq(7)
+    expect(t3.seconds).to eq(9)
+    expect(t3.milliseconds).to eq(11)
+    expect(t3.to_s).to eq("3.05:07:09.0110000")
 
     # TODO check overflow
   end
@@ -132,51 +132,51 @@ describe TimeSpan do
     t1 = TimeSpan.new -1
     t2 = TimeSpan.new 1
 
-    (t1 <=> t2).should eq(-1)
-    (t2 <=> t1).should eq(1)
-    (t2 <=> t2).should eq(0)
-    (TimeSpan::MinValue <=> TimeSpan::MaxValue).should eq(-1)
+    expect((t1 <=> t2)).to eq(-1)
+    expect((t2 <=> t1)).to eq(1)
+    expect((t2 <=> t2)).to eq(0)
+    expect((TimeSpan::MinValue <=> TimeSpan::MaxValue)).to eq(-1)
 
-    (t1 == t2).should be_false
-    (t1 > t2).should be_false
-    (t1 >= t2).should be_false
-    (t1 != t2).should be_true
-    (t1 < t2).should be_true
-    (t1 <= t2).should be_true
+    expect((t1 == t2)).to be_false
+    expect((t1 > t2)).to be_false
+    expect((t1 >= t2)).to be_false
+    expect((t1 != t2)).to be_true
+    expect((t1 < t2)).to be_true
+    expect((t1 <= t2)).to be_true
   end
 
   it "test equals" do
     t1 = TimeSpan.new 1
     t2 = TimeSpan.new 2
 
-    (t1 == t1).should be_true
-    (t1 == t2).should be_false
-    (t1 == "hello").should be_false
+    expect((t1 == t1)).to be_true
+    expect((t1 == t2)).to be_false
+    expect((t1 == "hello")).to be_false
   end
 
   it "test float extension methods" do
-    12.345.days.to_s.should eq("12.08:16:48")
-    12.345.hours.to_s.should eq("12:20:42")
-    12.345.minutes.to_s.should eq("00:12:20.7000000")
-    12.345.seconds.to_s.should eq("00:00:12.3450000")
-    12.345.milliseconds.to_s.should eq("00:00:00.0120000")
-    -0.5.milliseconds.to_s.should eq("-00:00:00.0010000")
-    0.5.milliseconds.to_s.should eq("00:00:00.0010000")
-    -2.5.milliseconds.to_s.should eq("-00:00:00.0030000")
-    2.5.milliseconds.to_s.should eq("00:00:00.0030000")
-    0.0005.seconds.to_s.should eq("00:00:00.0010000")
+    expect(12.345.days.to_s).to eq("12.08:16:48")
+    expect(12.345.hours.to_s).to eq("12:20:42")
+    expect(12.345.minutes.to_s).to eq("00:12:20.7000000")
+    expect(12.345.seconds.to_s).to eq("00:00:12.3450000")
+    expect(12.345.milliseconds.to_s).to eq("00:00:00.0120000")
+    expect(-0.5.milliseconds.to_s).to eq("-00:00:00.0010000")
+    expect(0.5.milliseconds.to_s).to eq("00:00:00.0010000")
+    expect(-2.5.milliseconds.to_s).to eq("-00:00:00.0030000")
+    expect(2.5.milliseconds.to_s).to eq("00:00:00.0030000")
+    expect(0.0005.seconds.to_s).to eq("00:00:00.0010000")
   end
 
   it "test negate and duration" do
-    (-TimeSpan.new(12345)).to_s.should eq("-00:00:00.0012345")
-    TimeSpan.new(-12345).duration.to_s.should eq("00:00:00.0012345")
-    TimeSpan.new(-12345).abs.to_s.should eq("00:00:00.0012345")
-    (-TimeSpan.new(77)).to_s.should eq("-00:00:00.0000077")
-    (+TimeSpan.new(77)).to_s.should eq("00:00:00.0000077")
+    expect((-TimeSpan.new(12345)).to_s).to eq("-00:00:00.0012345")
+    expect(TimeSpan.new(-12345).duration.to_s).to eq("00:00:00.0012345")
+    expect(TimeSpan.new(-12345).abs.to_s).to eq("00:00:00.0012345")
+    expect((-TimeSpan.new(77)).to_s).to eq("-00:00:00.0000077")
+    expect((+TimeSpan.new(77)).to_s).to eq("00:00:00.0000077")
   end
 
   it "test hash code" do
-    TimeSpan.new(77).hash.should eq(77)
+    expect(TimeSpan.new(77).hash).to eq(77)
   end
 
   it "test subtract" do
@@ -184,7 +184,7 @@ describe TimeSpan do
     t2 = TimeSpan.new 1, 2, 3, 4, 5
     t3 = t1 - t2
 
-    t3.to_s.should eq("1.01:01:01.0010000")
+    expect(t3.to_s).to eq("1.01:01:01.0010000")
 
     # TODO check overflow
   end
@@ -193,21 +193,21 @@ describe TimeSpan do
     t1 = TimeSpan.new 1, 2, 3, 4, 5
     t2 = -t1
 
-    t1.to_s.should eq("1.02:03:04.0050000")
-    t2.to_s.should eq("-1.02:03:04.0050000")
-    TimeSpan::MaxValue.to_s.should eq("10675199.02:48:05.4775807")
-    TimeSpan::MinValue.to_s.should eq("-10675199.02:48:05.4775808")
-    TimeSpan::Zero.to_s.should eq("00:00:00")
+    expect(t1.to_s).to eq("1.02:03:04.0050000")
+    expect(t2.to_s).to eq("-1.02:03:04.0050000")
+    expect(TimeSpan::MaxValue.to_s).to eq("10675199.02:48:05.4775807")
+    expect(TimeSpan::MinValue.to_s).to eq("-10675199.02:48:05.4775808")
+    expect(TimeSpan::Zero.to_s).to eq("00:00:00")
   end
 
   it "test totals" do
     t1 = TimeSpan.new 1, 2, 3, 4, 5
-    t1.total_days.should be_close(1.08546, 1e-05)
-    t1.total_hours.should be_close(26.0511, 1e-04)
-    t1.total_minutes.should be_close(1563.07, 1e-02)
-    t1.total_seconds.should be_close(93784, 1e-01)
-    t1.total_milliseconds.should be_close(9.3784e+07, 1e+01)
-    t1.to_f.should be_close(93784, 1e-01)
-    t1.to_i.should eq(93784)
+    expect(t1.total_days).to be_close(1.08546, 1e-05)
+    expect(t1.total_hours).to be_close(26.0511, 1e-04)
+    expect(t1.total_minutes).to be_close(1563.07, 1e-02)
+    expect(t1.total_seconds).to be_close(93784, 1e-01)
+    expect(t1.total_milliseconds).to be_close(9.3784e+07, 1e+01)
+    expect(t1.to_f).to be_close(93784, 1e-01)
+    expect(t1.to_i).to eq(93784)
   end
 end

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -15,26 +15,26 @@ end
 describe Time do
   it "initialize" do
     t1 = Time.new 2002, 2, 25
-    t1.ticks.should eq(TimeSpecTicks[0])
+    expect(t1.ticks).to eq(TimeSpecTicks[0])
 
     t2 = Time.new 2002, 2, 25, 15, 25, 13, 8
-    t2.ticks.should eq(TimeSpecTicks[1])
+    expect(t2.ticks).to eq(TimeSpecTicks[1])
 
-    t2.date.ticks.should eq(TimeSpecTicks[0])
-    t2.year.should eq(2002)
-    t2.month.should eq(2)
-    t2.day.should eq(25)
-    t2.hour.should eq(15)
-    t2.minute.should eq(25)
-    t2.second.should eq(13)
-    t2.millisecond.should eq(8)
+    expect(t2.date.ticks).to eq(TimeSpecTicks[0])
+    expect(t2.year).to eq(2002)
+    expect(t2.month).to eq(2)
+    expect(t2.day).to eq(25)
+    expect(t2.hour).to eq(15)
+    expect(t2.minute).to eq(25)
+    expect(t2.second).to eq(13)
+    expect(t2.millisecond).to eq(8)
 
     t3 = Time.new 2002, 2, 25, 5, 25, 13, 8
-    t3.ticks.should eq(TimeSpecTicks[2])
+    expect(t3.ticks).to eq(TimeSpecTicks[2])
   end
 
   it "initialize max" do
-    Time.new(9999, 12, 31, 23, 59, 59, 999).ticks.should eq(3155378975999990000)
+    expect(Time.new(9999, 12, 31, 23, 59, 59, 999).ticks).to eq(3155378975999990000)
   end
 
   it "initialize millisecond negative" do
@@ -50,8 +50,8 @@ describe Time do
   end
 
   it "fields" do
-    Time::MaxValue.ticks.should eq(3155378975999999999)
-    Time::MinValue.ticks.should eq(0)
+    expect(Time::MaxValue.ticks).to eq(3155378975999999999)
+    expect(Time::MinValue.ticks).to eq(0)
   end
 
   it "add" do
@@ -59,15 +59,15 @@ describe Time do
     span = TimeSpan.new 3, 54, 1
     t2 = t1 + span
 
-    t2.day.should eq(25)
-    t2.hour.should eq(19)
-    t2.minute.should eq(19)
-    t2.second.should eq(14)
+    expect(t2.day).to eq(25)
+    expect(t2.hour).to eq(19)
+    expect(t2.minute).to eq(19)
+    expect(t2.second).to eq(14)
 
-    t1.day.should eq(25)
-    t1.hour.should eq(15)
-    t1.minute.should eq(25)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(25)
+    expect(t1.hour).to eq(15)
+    expect(t1.minute).to eq(25)
+    expect(t1.second).to eq(13)
   end
 
   it "add out of range 1" do
@@ -90,22 +90,22 @@ describe Time do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 3.days
 
-    t1.day.should eq(28)
-    t1.hour.should eq(15)
-    t1.minute.should eq(25)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(28)
+    expect(t1.hour).to eq(15)
+    expect(t1.minute).to eq(25)
+    expect(t1.second).to eq(13)
 
     t1 = t1 + 1.9.days
-    t1.day.should eq(2)
-    t1.hour.should eq(13)
-    t1.minute.should eq(1)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(2)
+    expect(t1.hour).to eq(13)
+    expect(t1.minute).to eq(1)
+    expect(t1.second).to eq(13)
 
     t1 = t1 + 0.2.days
-    t1.day.should eq(2)
-    t1.hour.should eq(17)
-    t1.minute.should eq(49)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(2)
+    expect(t1.hour).to eq(17)
+    expect(t1.minute).to eq(49)
+    expect(t1.second).to eq(13)
   end
 
   it "add days out of range 1" do
@@ -125,182 +125,182 @@ describe Time do
   it "add months" do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t2 = t + 1.month
-    t2.to_s.should eq("2014-11-30 21:18:13")
+    expect(t2.to_s).to eq("2014-11-30 21:18:13")
 
     t2 = t + 1.months
-    t2.to_s.should eq("2014-11-30 21:18:13")
+    expect(t2.to_s).to eq("2014-11-30 21:18:13")
 
     t = Time.new 2014, 10, 31, 21, 18, 13
     t2 = t + 1.month
-    t2.to_s.should eq("2014-11-30 21:18:13")
+    expect(t2.to_s).to eq("2014-11-30 21:18:13")
 
     t = Time.new 2014, 10, 31, 21, 18, 13
     t2 = t - 1.month
-    t2.to_s.should eq("2014-09-30 21:18:13")
+    expect(t2.to_s).to eq("2014-09-30 21:18:13")
   end
 
   it "add years" do
     t = Time.new 2014, 10, 30, 21, 18, 13
     t2 = t + 1.year
-    t2.to_s.should eq("2015-10-30 21:18:13")
+    expect(t2.to_s).to eq("2015-10-30 21:18:13")
 
     t = Time.new 2014, 10, 30, 21, 18, 13
     t2 = t - 2.years
-    t2.to_s.should eq("2012-10-30 21:18:13")
+    expect(t2.to_s).to eq("2012-10-30 21:18:13")
   end
 
   it "add hours" do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 10.hours
 
-    t1.day.should eq(26)
-    t1.hour.should eq(1)
-    t1.minute.should eq(25)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(26)
+    expect(t1.hour).to eq(1)
+    expect(t1.minute).to eq(25)
+    expect(t1.second).to eq(13)
 
     t1 = t1 - 3.7.hours
-    t1.day.should eq(25)
-    t1.hour.should eq(21)
-    t1.minute.should eq(43)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(25)
+    expect(t1.hour).to eq(21)
+    expect(t1.minute).to eq(43)
+    expect(t1.second).to eq(13)
 
     t1 = t1 + 3.732.hours
-    t1.day.should eq(26)
-    t1.hour.should eq(1)
-    t1.minute.should eq(27)
-    t1.second.should eq(8)
+    expect(t1.day).to eq(26)
+    expect(t1.hour).to eq(1)
+    expect(t1.minute).to eq(27)
+    expect(t1.second).to eq(8)
   end
 
   it "add milliseconds" do
     t1 = Time.new TimeSpecTicks[1]
     t1 = t1 + 1e10.milliseconds
 
-    t1.day.should eq(21)
-    t1.hour.should eq(9)
-    t1.minute.should eq(11)
-    t1.second.should eq(53)
+    expect(t1.day).to eq(21)
+    expect(t1.hour).to eq(9)
+    expect(t1.minute).to eq(11)
+    expect(t1.second).to eq(53)
 
     t1 = t1 - 19e10.milliseconds
-    t1.day.should eq(13)
-    t1.hour.should eq(7)
-    t1.minute.should eq(25)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(13)
+    expect(t1.hour).to eq(7)
+    expect(t1.minute).to eq(25)
+    expect(t1.second).to eq(13)
 
     t1 = t1 + 15.623.milliseconds
-    t1.day.should eq(13)
-    t1.hour.should eq(7)
-    t1.minute.should eq(25)
-    t1.second.should eq(13)
+    expect(t1.day).to eq(13)
+    expect(t1.hour).to eq(7)
+    expect(t1.minute).to eq(25)
+    expect(t1.second).to eq(13)
   end
 
   it "gets time of day" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.time_of_day.should eq(TimeSpan.new(21, 18, 13))
+    expect(t.time_of_day).to eq(TimeSpan.new(21, 18, 13))
   end
 
   it "gets day of week" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.day_of_week.should eq(DayOfWeek::Thursday)
+    expect(t.day_of_week).to eq(DayOfWeek::Thursday)
   end
 
   it "gets day of year" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.day_of_year.should eq(303)
+    expect(t.day_of_year).to eq(303)
   end
 
   it "compares" do
     t1 = Time.new 2014, 10, 30, 21, 18, 13
     t2 = Time.new 2014, 10, 30, 21, 18, 14
 
-    (t1 <=> t2).should eq(-1)
-    (t1 == t2).should be_false
-    (t1 < t2).should be_true
+    expect((t1 <=> t2)).to eq(-1)
+    expect((t1 == t2)).to be_false
+    expect((t1 < t2)).to be_true
   end
 
   it "gets unix epoch seconds" do
     t1 = Time.new 2014, 10, 30, 21, 18, 13
-    t1.to_i.should eq(1414703893)
-    t1.to_f.should be_close(1414703893, 1e-01)
+    expect(t1.to_i).to eq(1414703893)
+    expect(t1.to_f).to be_close(1414703893, 1e-01)
   end
 
   it "to_s" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.to_s.should eq("2014-10-30 21:18:13")
+    expect(t.to_s).to eq("2014-10-30 21:18:13")
 
     t = Time.new 2014, 1, 30, 21, 18, 13
-    t.to_s.should eq("2014-01-30 21:18:13")
+    expect(t.to_s).to eq("2014-01-30 21:18:13")
 
     t = Time.new 2014, 10, 1, 21, 18, 13
-    t.to_s.should eq("2014-10-01 21:18:13")
+    expect(t.to_s).to eq("2014-10-01 21:18:13")
 
     t = Time.new 2014, 10, 30, 1, 18, 13
-    t.to_s.should eq("2014-10-30 01:18:13")
+    expect(t.to_s).to eq("2014-10-30 01:18:13")
 
     t = Time.new 2014, 10, 30, 21, 1, 13
-    t.to_s.should eq("2014-10-30 21:01:13")
+    expect(t.to_s).to eq("2014-10-30 21:01:13")
 
     t = Time.new 2014, 10, 30, 21, 18, 1
-    t.to_s.should eq("2014-10-30 21:18:01")
+    expect(t.to_s).to eq("2014-10-30 21:18:01")
   end
 
   it "formats" do
     t = Time.new 2014, 1, 2, 3, 4, 5, 6
     t2 = Time.new 2014, 1, 2, 15, 4, 5, 6
 
-    t.to_s("%Y").should eq("2014")
-    Time.new(1, 1, 2, 3, 4, 5, 6).to_s("%Y").should eq("0001")
+    expect(t.to_s("%Y")).to eq("2014")
+    expect(Time.new(1, 1, 2, 3, 4, 5, 6).to_s("%Y")).to eq("0001")
 
-    t.to_s("%C").should eq("20")
-    t.to_s("%y").should eq("14")
-    t.to_s("%m").should eq("01")
-    t.to_s("%_m").should eq(" 1")
-    t.to_s("%-m").should eq("1")
-    t.to_s("%B").should eq("January")
-    t.to_s("%^B").should eq("JANUARY")
-    t.to_s("%b").should eq("Jan")
-    t.to_s("%^b").should eq("JAN")
-    t.to_s("%h").should eq("Jan")
-    t.to_s("%^h").should eq("JAN")
-    t.to_s("%d").should eq("02")
-    t.to_s("%-d").should eq("2")
-    t.to_s("%e").should eq(" 2")
-    t.to_s("%j").should eq("002")
-    t.to_s("%H").should eq("03")
+    expect(t.to_s("%C")).to eq("20")
+    expect(t.to_s("%y")).to eq("14")
+    expect(t.to_s("%m")).to eq("01")
+    expect(t.to_s("%_m")).to eq(" 1")
+    expect(t.to_s("%-m")).to eq("1")
+    expect(t.to_s("%B")).to eq("January")
+    expect(t.to_s("%^B")).to eq("JANUARY")
+    expect(t.to_s("%b")).to eq("Jan")
+    expect(t.to_s("%^b")).to eq("JAN")
+    expect(t.to_s("%h")).to eq("Jan")
+    expect(t.to_s("%^h")).to eq("JAN")
+    expect(t.to_s("%d")).to eq("02")
+    expect(t.to_s("%-d")).to eq("2")
+    expect(t.to_s("%e")).to eq(" 2")
+    expect(t.to_s("%j")).to eq("002")
+    expect(t.to_s("%H")).to eq("03")
 
-    t.to_s("%k").should eq(" 3")
-    t2.to_s("%k").should eq("15")
+    expect(t.to_s("%k")).to eq(" 3")
+    expect(t2.to_s("%k")).to eq("15")
 
-    t.to_s("%I").should eq("03")
-    t2.to_s("%I").should eq("03")
+    expect(t.to_s("%I")).to eq("03")
+    expect(t2.to_s("%I")).to eq("03")
 
-    t.to_s("%l").should eq(" 3")
-    t2.to_s("%l").should eq(" 3")
+    expect(t.to_s("%l")).to eq(" 3")
+    expect(t2.to_s("%l")).to eq(" 3")
 
     # Note: we purposely match %p to am/pm and %P to AM/PM (makes more sense)
-    t.to_s("%p").should eq("am")
-    t2.to_s("%p").should eq("pm")
+    expect(t.to_s("%p")).to eq("am")
+    expect(t2.to_s("%p")).to eq("pm")
 
-    t.to_s("%P").should eq("AM")
-    t2.to_s("%P").should eq("PM")
+    expect(t.to_s("%P")).to eq("AM")
+    expect(t2.to_s("%P")).to eq("PM")
 
-    t.to_s("%M").to_s.should eq("04")
-    t.to_s("%S").to_s.should eq("05")
-    t.to_s("%L").to_s.should eq("006")
+    expect(t.to_s("%M").to_s).to eq("04")
+    expect(t.to_s("%S").to_s).to eq("05")
+    expect(t.to_s("%L").to_s).to eq("006")
 
     # TODO %N
     # TODO %z
     # TODO %Z
 
-    t.to_s("%A").to_s.should eq("Thursday")
-    t.to_s("%^A").to_s.should eq("THURSDAY")
-    t.to_s("%a").to_s.should eq("Thu")
-    t.to_s("%^a").to_s.should eq("THU")
-    t.to_s("%u").to_s.should eq("4")
-    t.to_s("%w").to_s.should eq("4")
+    expect(t.to_s("%A").to_s).to eq("Thursday")
+    expect(t.to_s("%^A").to_s).to eq("THURSDAY")
+    expect(t.to_s("%a").to_s).to eq("Thu")
+    expect(t.to_s("%^a").to_s).to eq("THU")
+    expect(t.to_s("%u").to_s).to eq("4")
+    expect(t.to_s("%w").to_s).to eq("4")
 
     t3 = Time.new 2014, 1, 5 # A Sunday
-    t3.to_s("%u").to_s.should eq("7")
-    t3.to_s("%w").to_s.should eq("0")
+    expect(t3.to_s("%u").to_s).to eq("7")
+    expect(t3.to_s("%w").to_s).to eq("0")
 
     # TODO %G
     # TODO %g
@@ -312,60 +312,60 @@ describe Time do
     # TODO %t
     # TODO %%
 
-    t.to_s("%%").should eq("%")
-    t.to_s("%c").should eq(t.to_s("%a %b %e %T %Y"))
-    t.to_s("%D").should eq(t.to_s("%m/%d/%y"))
-    t.to_s("%F").should eq(t.to_s("%Y-%m-%d"))
+    expect(t.to_s("%%")).to eq("%")
+    expect(t.to_s("%c")).to eq(t.to_s("%a %b %e %T %Y"))
+    expect(t.to_s("%D")).to eq(t.to_s("%m/%d/%y"))
+    expect(t.to_s("%F")).to eq(t.to_s("%Y-%m-%d"))
     # TODO %v
-    t.to_s("%x").should eq(t.to_s("%D"))
-    t.to_s("%X").should eq(t.to_s("%T"))
-    t.to_s("%r").should eq(t.to_s("%I:%M:%S %P"))
-    t.to_s("%R").should eq(t.to_s("%H:%M"))
-    t.to_s("%T").should eq(t.to_s("%H:%M:%S"))
+    expect(t.to_s("%x")).to eq(t.to_s("%D"))
+    expect(t.to_s("%X")).to eq(t.to_s("%T"))
+    expect(t.to_s("%r")).to eq(t.to_s("%I:%M:%S %P"))
+    expect(t.to_s("%R")).to eq(t.to_s("%H:%M"))
+    expect(t.to_s("%T")).to eq(t.to_s("%H:%M:%S"))
 
-    t.to_s("%Y-%m-hello").should eq("2014-01-hello")
+    expect(t.to_s("%Y-%m-hello")).to eq("2014-01-hello")
   end
 
   it "parses with format" do
     t = Time.parse("", "")
-    t.year.should eq(1)
-    t.month.should eq(1)
-    t.day.should eq(1)
-    t.hour.should eq(0)
-    t.minute.should eq(0)
-    t.second.should eq(0)
-    t.millisecond.should eq(0)
+    expect(t.year).to eq(1)
+    expect(t.month).to eq(1)
+    expect(t.day).to eq(1)
+    expect(t.hour).to eq(0)
+    expect(t.minute).to eq(0)
+    expect(t.second).to eq(0)
+    expect(t.millisecond).to eq(0)
 
-    Time.parse("2014", "%Y").year.should eq(2014)
-    Time.parse("19", "%C").year.should eq(1900)
-    Time.parse("14", "%y").year.should eq(2014)
-    Time.parse("09", "%m").month.should eq(9)
-    Time.parse(" 9", "%_m").month.should eq(9)
-    Time.parse("9", "%-m").month.should eq(9)
-    Time.parse("February", "%B").month.should eq(2)
-    Time.parse("March", "%B").month.should eq(3)
-    Time.parse("MaRcH", "%B").month.should eq(3)
-    Time.parse("MaR", "%B").month.should eq(3)
-    Time.parse("MARCH", "%^B").month.should eq(3)
-    Time.parse("Mar", "%b").month.should eq(3)
-    Time.parse("Mar", "%^b").month.should eq(3)
-    Time.parse("MAR", "%^b").month.should eq(3)
-    Time.parse("MAR", "%h").month.should eq(3)
-    Time.parse("MAR", "%^h").month.should eq(3)
-    Time.parse("2", "%d").day.should eq(2)
-    Time.parse("02", "%d").day.should eq(2)
-    Time.parse("02", "%-d").day.should eq(2)
-    Time.parse(" 2", "%e").day.should eq(2)
-    Time.parse("0123", "%j").year.should eq(123)
-    Time.parse("9", "%H").hour.should eq(9)
-    Time.parse(" 9", "%k").hour.should eq(9)
-    Time.parse("09", "%I").hour.should eq(9)
-    Time.parse(" 9", "%l").hour.should eq(9)
-    Time.parse("9pm", "%l%p").hour.should eq(21)
-    Time.parse("9PM", "%l%P").hour.should eq(21)
-    Time.parse("09", "%M").minute.should eq(9)
-    Time.parse("09", "%S").second.should eq(9)
-    Time.parse("123", "%L").millisecond.should eq(123)
+    expect(Time.parse("2014", "%Y").year).to eq(2014)
+    expect(Time.parse("19", "%C").year).to eq(1900)
+    expect(Time.parse("14", "%y").year).to eq(2014)
+    expect(Time.parse("09", "%m").month).to eq(9)
+    expect(Time.parse(" 9", "%_m").month).to eq(9)
+    expect(Time.parse("9", "%-m").month).to eq(9)
+    expect(Time.parse("February", "%B").month).to eq(2)
+    expect(Time.parse("March", "%B").month).to eq(3)
+    expect(Time.parse("MaRcH", "%B").month).to eq(3)
+    expect(Time.parse("MaR", "%B").month).to eq(3)
+    expect(Time.parse("MARCH", "%^B").month).to eq(3)
+    expect(Time.parse("Mar", "%b").month).to eq(3)
+    expect(Time.parse("Mar", "%^b").month).to eq(3)
+    expect(Time.parse("MAR", "%^b").month).to eq(3)
+    expect(Time.parse("MAR", "%h").month).to eq(3)
+    expect(Time.parse("MAR", "%^h").month).to eq(3)
+    expect(Time.parse("2", "%d").day).to eq(2)
+    expect(Time.parse("02", "%d").day).to eq(2)
+    expect(Time.parse("02", "%-d").day).to eq(2)
+    expect(Time.parse(" 2", "%e").day).to eq(2)
+    expect(Time.parse("0123", "%j").year).to eq(123)
+    expect(Time.parse("9", "%H").hour).to eq(9)
+    expect(Time.parse(" 9", "%k").hour).to eq(9)
+    expect(Time.parse("09", "%I").hour).to eq(9)
+    expect(Time.parse(" 9", "%l").hour).to eq(9)
+    expect(Time.parse("9pm", "%l%p").hour).to eq(21)
+    expect(Time.parse("9PM", "%l%P").hour).to eq(21)
+    expect(Time.parse("09", "%M").minute).to eq(9)
+    expect(Time.parse("09", "%S").second).to eq(9)
+    expect(Time.parse("123", "%L").millisecond).to eq(123)
 
     # TODO %N
     # TODO %z
@@ -381,110 +381,110 @@ describe Time do
     # TODO %t
     # TODO %%
 
-    Time.parse("Fri Oct 31 23:00:24 2014", "%c").to_s.should eq("2014-10-31 23:00:24")
-    Time.parse("10/31/14", "%D").to_s.should eq("2014-10-31 00:00:00")
-    Time.parse("10/31/69", "%D").to_s.should eq("1969-10-31 00:00:00")
-    Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00")
-    Time.parse("2014-10-31", "%F").to_s.should eq("2014-10-31 00:00:00")
+    expect(Time.parse("Fri Oct 31 23:00:24 2014", "%c").to_s).to eq("2014-10-31 23:00:24")
+    expect(Time.parse("10/31/14", "%D").to_s).to eq("2014-10-31 00:00:00")
+    expect(Time.parse("10/31/69", "%D").to_s).to eq("1969-10-31 00:00:00")
+    expect(Time.parse("2014-10-31", "%F").to_s).to eq("2014-10-31 00:00:00")
+    expect(Time.parse("2014-10-31", "%F").to_s).to eq("2014-10-31 00:00:00")
     # TODO %v
-    Time.parse("10/31/14", "%x").to_s.should eq("2014-10-31 00:00:00")
-    Time.parse("10:11:12", "%X").to_s.should eq("0001-01-01 10:11:12")
-    Time.parse("11:14:01 PM", "%r").to_s.should eq("0001-01-01 23:14:01")
-    Time.parse("11:14", "%R").to_s.should eq("0001-01-01 11:14:00")
-    Time.parse("11:12:13", "%T").to_s.should eq("0001-01-01 11:12:13")
+    expect(Time.parse("10/31/14", "%x").to_s).to eq("2014-10-31 00:00:00")
+    expect(Time.parse("10:11:12", "%X").to_s).to eq("0001-01-01 10:11:12")
+    expect(Time.parse("11:14:01 PM", "%r").to_s).to eq("0001-01-01 23:14:01")
+    expect(Time.parse("11:14", "%R").to_s).to eq("0001-01-01 11:14:00")
+    expect(Time.parse("11:12:13", "%T").to_s).to eq("0001-01-01 11:12:13")
 
-    Time.parse("This was done on Friday, October 31, 2014", "This was done on %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00")
-    Time.parse("今は Friday, October 31, 2014", "今は %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00")
+    expect(Time.parse("This was done on Friday, October 31, 2014", "This was done on %A, %B %d, %Y").to_s).to eq("2014-10-31 00:00:00")
+    expect(Time.parse("今は Friday, October 31, 2014", "今は %A, %B %d, %Y").to_s).to eq("2014-10-31 00:00:00")
   end
 
   it "at" do
     t1 = Time.new 2014, 11, 25, 10, 11, 12, 13
     t2 = Time.new 2014, 6, 25, 10, 11, 12, 13
 
-    t1.at_beginning_of_year.to_s.should eq("2014-01-01 00:00:00")
+    expect(t1.at_beginning_of_year.to_s).to eq("2014-01-01 00:00:00")
 
     1.upto(3) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s.should eq("2014-01-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s.should eq("2014-03-31 23:59:59")
+      expect(Time.new(2014, i, 10).at_beginning_of_quarter.to_s).to eq("2014-01-01 00:00:00")
+      expect(Time.new(2014, i, 10).at_end_of_quarter.to_s).to eq("2014-03-31 23:59:59")
     end
     4.upto(6) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s.should eq("2014-04-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s.should eq("2014-06-30 23:59:59")
+      expect(Time.new(2014, i, 10).at_beginning_of_quarter.to_s).to eq("2014-04-01 00:00:00")
+      expect(Time.new(2014, i, 10).at_end_of_quarter.to_s).to eq("2014-06-30 23:59:59")
     end
     7.upto(9) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s.should eq("2014-07-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s.should eq("2014-09-30 23:59:59")
+      expect(Time.new(2014, i, 10).at_beginning_of_quarter.to_s).to eq("2014-07-01 00:00:00")
+      expect(Time.new(2014, i, 10).at_end_of_quarter.to_s).to eq("2014-09-30 23:59:59")
     end
     10.upto(12) do |i|
-      Time.new(2014, i, 10).at_beginning_of_quarter.to_s.should eq("2014-10-01 00:00:00")
-      Time.new(2014, i, 10).at_end_of_quarter.to_s.should eq("2014-12-31 23:59:59")
+      expect(Time.new(2014, i, 10).at_beginning_of_quarter.to_s).to eq("2014-10-01 00:00:00")
+      expect(Time.new(2014, i, 10).at_end_of_quarter.to_s).to eq("2014-12-31 23:59:59")
     end
 
-    t1.at_beginning_of_quarter.to_s.should eq("2014-10-01 00:00:00")
-    t1.at_beginning_of_month.to_s.should eq("2014-11-01 00:00:00")
+    expect(t1.at_beginning_of_quarter.to_s).to eq("2014-10-01 00:00:00")
+    expect(t1.at_beginning_of_month.to_s).to eq("2014-11-01 00:00:00")
 
     3.upto(9) do |i|
-      Time.new(2014, 11, i).at_beginning_of_week.to_s.should eq("2014-11-03 00:00:00")
+      expect(Time.new(2014, 11, i).at_beginning_of_week.to_s).to eq("2014-11-03 00:00:00")
     end
 
-    t1.at_beginning_of_day.to_s.should eq("2014-11-25 00:00:00")
-    t1.at_beginning_of_hour.to_s.should eq("2014-11-25 10:00:00")
-    t1.at_beginning_of_minute.to_s.should eq("2014-11-25 10:11:00")
+    expect(t1.at_beginning_of_day.to_s).to eq("2014-11-25 00:00:00")
+    expect(t1.at_beginning_of_hour.to_s).to eq("2014-11-25 10:00:00")
+    expect(t1.at_beginning_of_minute.to_s).to eq("2014-11-25 10:11:00")
 
-    t1.at_end_of_year.to_s.should eq("2014-12-31 23:59:59")
+    expect(t1.at_end_of_year.to_s).to eq("2014-12-31 23:59:59")
 
-    t1.at_end_of_quarter.to_s.should eq("2014-12-31 23:59:59")
-    t2.at_end_of_quarter.to_s.should eq("2014-06-30 23:59:59")
+    expect(t1.at_end_of_quarter.to_s).to eq("2014-12-31 23:59:59")
+    expect(t2.at_end_of_quarter.to_s).to eq("2014-06-30 23:59:59")
 
-    t1.at_end_of_month.to_s.should eq("2014-11-30 23:59:59")
-    t1.at_end_of_week.to_s.should eq("2014-11-30 23:59:59")
+    expect(t1.at_end_of_month.to_s).to eq("2014-11-30 23:59:59")
+    expect(t1.at_end_of_week.to_s).to eq("2014-11-30 23:59:59")
 
-    Time.new(2014, 11, 2).at_end_of_week.to_s.should eq("2014-11-02 23:59:59")
+    expect(Time.new(2014, 11, 2).at_end_of_week.to_s).to eq("2014-11-02 23:59:59")
     3.upto(9) do |i|
-      Time.new(2014, 11, i).at_end_of_week.to_s.should eq("2014-11-09 23:59:59")
+      expect(Time.new(2014, 11, i).at_end_of_week.to_s).to eq("2014-11-09 23:59:59")
     end
 
-    t1.at_end_of_day.to_s.should eq("2014-11-25 23:59:59")
-    t1.at_end_of_hour.to_s.should eq("2014-11-25 10:59:59")
-    t1.at_end_of_minute.to_s.should eq("2014-11-25 10:11:59")
+    expect(t1.at_end_of_day.to_s).to eq("2014-11-25 23:59:59")
+    expect(t1.at_end_of_hour.to_s).to eq("2014-11-25 10:59:59")
+    expect(t1.at_end_of_minute.to_s).to eq("2014-11-25 10:11:59")
 
-    t1.at_midday.to_s.should eq("2014-11-25 12:00:00")
+    expect(t1.at_midday.to_s).to eq("2014-11-25 12:00:00")
 
-    t1.at_beginning_of_semester.to_s.should eq("2014-07-01 00:00:00")
-    t2.at_beginning_of_semester.to_s.should eq("2014-01-01 00:00:00")
+    expect(t1.at_beginning_of_semester.to_s).to eq("2014-07-01 00:00:00")
+    expect(t2.at_beginning_of_semester.to_s).to eq("2014-01-01 00:00:00")
 
-    t1.at_end_of_semester.to_s.should eq("2014-12-31 23:59:59")
-    t2.at_end_of_semester.to_s.should eq("2014-06-30 23:59:59")
+    expect(t1.at_end_of_semester.to_s).to eq("2014-12-31 23:59:59")
+    expect(t2.at_end_of_semester.to_s).to eq("2014-06-30 23:59:59")
   end
 
   it "does time span units" do
-    1.millisecond.ticks.should eq(TimeSpan::TicksPerMillisecond)
-    1.milliseconds.ticks.should eq(TimeSpan::TicksPerMillisecond)
-    1.second.ticks.should eq(TimeSpan::TicksPerSecond)
-    1.seconds.ticks.should eq(TimeSpan::TicksPerSecond)
-    1.minute.ticks.should eq(TimeSpan::TicksPerMinute)
-    1.minutes.ticks.should eq(TimeSpan::TicksPerMinute)
-    1.hour.ticks.should eq(TimeSpan::TicksPerHour)
-    1.hours.ticks.should eq(TimeSpan::TicksPerHour)
+    expect(1.millisecond.ticks).to eq(TimeSpan::TicksPerMillisecond)
+    expect(1.milliseconds.ticks).to eq(TimeSpan::TicksPerMillisecond)
+    expect(1.second.ticks).to eq(TimeSpan::TicksPerSecond)
+    expect(1.seconds.ticks).to eq(TimeSpan::TicksPerSecond)
+    expect(1.minute.ticks).to eq(TimeSpan::TicksPerMinute)
+    expect(1.minutes.ticks).to eq(TimeSpan::TicksPerMinute)
+    expect(1.hour.ticks).to eq(TimeSpan::TicksPerHour)
+    expect(1.hours.ticks).to eq(TimeSpan::TicksPerHour)
   end
 
   it "preserves kind when adding" do
     time = Time.utc_now
-    time.kind.should eq(Time::Kind::Utc)
+    expect(time.kind).to eq(Time::Kind::Utc)
 
-    (time + 5.minutes).kind.should eq(Time::Kind::Utc)
+    expect((time + 5.minutes).kind).to eq(Time::Kind::Utc)
   end
 
   it "asks for day name" do
     7.times do |i|
       time = Time.new(2015, 2, 15 + i)
-      time.sunday?.should eq(i == 0)
-      time.monday?.should eq(i == 1)
-      time.tuesday?.should eq(i == 2)
-      time.wednesday?.should eq(i == 3)
-      time.thursday?.should eq(i == 4)
-      time.friday?.should eq(i == 5)
-      time.saturday?.should eq(i == 6)
+      expect(time.sunday?).to eq(i == 0)
+      expect(time.monday?).to eq(i == 1)
+      expect(time.tuesday?).to eq(i == 2)
+      expect(time.wednesday?).to eq(i == 3)
+      expect(time.thursday?).to eq(i == 4)
+      expect(time.friday?).to eq(i == 5)
+      expect(time.saturday?).to eq(i == 6)
     end
   end
 

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -13,15 +13,15 @@ end
 
 describe "Tuple" do
   it "does length" do
-    {1, 2, 1, 2}.length.should eq(4)
+    expect({1, 2, 1, 2}.length).to eq(4)
   end
 
   it "does []" do
     a = {1, 2.5}
     i = 0
-    a[i].should eq(1)
+    expect(a[i]).to eq(1)
     i = 1
-    a[i].should eq(2.5)
+    expect(a[i]).to eq(2.5)
   end
 
   it "does [] raises index out of bounds" do
@@ -34,17 +34,17 @@ describe "Tuple" do
 
   it "does []?" do
     a = {1, 2}
-    a[1]?.should eq(2)
-    a[2]?.should be_nil
+    expect(a[1]?).to eq(2)
+    expect(a[2]?).to be_nil
   end
 
   it "does at" do
     a = {1, 2}
-    a.at(1).should eq(2)
+    expect(a.at(1)).to eq(2)
 
     expect_raises(IndexOutOfBounds) { a.at(2) }
 
-    a.at(2) { 3 }.should eq(3)
+    expect(a.at(2) { 3 }).to eq(3)
   end
 
   it "does ==" do
@@ -53,19 +53,19 @@ describe "Tuple" do
     c = {1, 2, 3}
     d = {1}
     e = {1, 2}
-    a.should eq(a)
-    a.should eq(e)
-    a.should_not eq(b)
-    a.should_not eq(c)
-    a.should_not eq(d)
+    expect(a).to eq(a)
+    expect(a).to eq(e)
+    expect(a).to_not eq(b)
+    expect(a).to_not eq(c)
+    expect(a).to_not eq(d)
   end
 
   it "does == with differnt types but same length" do
-    {1, 2}.should eq({1.0, 2.0})
+    expect({1, 2}).to eq({1.0, 2.0})
   end
 
   it "does == with another type" do
-    {1, 2}.should_not eq(1)
+    expect({1, 2}).to_not eq(1)
   end
 
   it "does compare" do
@@ -74,8 +74,8 @@ describe "Tuple" do
     c = {1, 6}
     d = {3, 5}
     e = {0, 8}
-    [a, b, c, d, e].sort.should eq([e, a, c, b, d])
-    [a, b, c, d, e].min.should eq(e)
+    expect([a, b, c, d, e].sort).to eq([e, a, c, b, d])
+    expect([a, b, c, d, e].min).to eq(e)
   end
 
   it "does compare with different lengths" do
@@ -84,12 +84,12 @@ describe "Tuple" do
     c = {1, 2}
     d = {1, 1}
     e = {1, 1, 3}
-    [a, b, c, d, e].sort.should eq([d, e, c, b, a])
-    [a, b, c, d, e].min.should eq(d)
+    expect([a, b, c, d, e].sort).to eq([d, e, c, b, a])
+    expect([a, b, c, d, e].min).to eq(d)
   end
 
   it "does to_s" do
-    {1, 2, 3}.to_s.should eq("{1, 2, 3}")
+    expect({1, 2, 3}.to_s).to eq("{1, 2, 3}")
   end
 
   it "does each" do
@@ -97,34 +97,34 @@ describe "Tuple" do
     {1, 2, 3}.each do |i|
       a += i
     end
-    a.should eq(6)
+    expect(a).to eq(6)
   end
 
   it "does dup" do
     r1, r2 = TupleSpecObj.new(10), TupleSpecObj.new(20)
     t = {r1, r2}
     u = t.dup
-    u.length.should eq(2)
-    u[0].should be(r1)
-    u[1].should be(r2)
+    expect(u.length).to eq(2)
+    expect(u[0]).to be(r1)
+    expect(u[1]).to be(r2)
   end
 
   it "does clone" do
     r1, r2 = TupleSpecObj.new(10), TupleSpecObj.new(20)
     t = {r1, r2}
     u = t.clone
-    u.length.should eq(2)
-    u[0].x.should eq(r1.x)
-    u[0].should_not be(r1)
-    u[1].x.should eq(r2.x)
-    u[1].should_not be(r2)
+    expect(u.length).to eq(2)
+    expect(u[0].x).to eq(r1.x)
+    expect(u[0]).to_not be(r1)
+    expect(u[1].x).to eq(r2.x)
+    expect(u[1]).to_not be(r2)
   end
 
   it "does Tuple#new" do
-    Tuple.new(1, 2, 3).should eq({1, 2, 3})
+    expect(Tuple.new(1, 2, 3)).to eq({1, 2, 3})
   end
 
   it "clones empty tuple" do
-    Tuple.new.clone.should eq(Tuple.new)
+    expect(Tuple.new.clone).to eq(Tuple.new)
   end
 end

--- a/spec/std/uint_spec.cr
+++ b/spec/std/uint_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 
 describe "UInt" do
   it "compares with <=>" do
-    (1_u32 <=> 0_u32).should eq(1)
-    (0_u32 <=> 0_u32).should eq(0)
-    (0_u32 <=> 1_u32).should eq(-1)
+    expect((1_u32 <=> 0_u32)).to eq(1)
+    expect((0_u32 <=> 0_u32)).to eq(0)
+    expect((0_u32 <=> 1_u32)).to eq(-1)
   end
 end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -4,11 +4,11 @@ require "uri"
 private def assert_uri(string, scheme = nil, host = nil, port = nil, path = nil, query = nil)
   it "parse #{string}" do
     uri = URI.parse(string)
-    uri.scheme.should eq(scheme)
-    uri.host.should eq(host)
-    uri.port.should eq(port)
-    uri.path.should eq(path)
-    uri.query.should eq(query)
+    expect(uri.scheme).to eq(scheme)
+    expect(uri.host).to eq(host)
+    expect(uri.port).to eq(port)
+    expect(uri.path).to eq(path)
+    expect(uri.query).to eq(query)
   end
 end
 
@@ -23,18 +23,18 @@ describe "URI" do
   assert_uri("/foo", path: "/foo")
   assert_uri("/foo?q=1", path: "/foo", query: "q=1")
 
-  assert { URI.parse("http://www.google.com/foo").full_path.should eq("/foo") }
-  assert { URI.parse("http://www.google.com").full_path.should eq("/") }
-  assert { URI.parse("http://www.google.com/foo?q=1").full_path.should eq("/foo?q=1") }
-  assert { URI.parse("http://www.google.com/?q=1").full_path.should eq("/?q=1") }
-  assert { URI.parse("http://www.google.com?q=1").full_path.should eq("/?q=1") }
+  assert { expect(URI.parse("http://www.google.com/foo").full_path).to eq("/foo") }
+  assert { expect(URI.parse("http://www.google.com").full_path).to eq("/") }
+  assert { expect(URI.parse("http://www.google.com/foo?q=1").full_path).to eq("/foo?q=1") }
+  assert { expect(URI.parse("http://www.google.com/?q=1").full_path).to eq("/?q=1") }
+  assert { expect(URI.parse("http://www.google.com?q=1").full_path).to eq("/?q=1") }
 
   describe "to_s" do
-    assert { URI.new("http", "www.google.com").to_s.should eq("http://www.google.com") }
-    assert { URI.new("http", "www.google.com", 80).to_s.should eq("http://www.google.com") }
-    assert { URI.new("http", "www.google.com", 1234).to_s.should eq("http://www.google.com:1234") }
-    assert { URI.new("http", "www.google.com", 80, "/hello").to_s.should eq("http://www.google.com/hello") }
-    assert { URI.new("http", "www.google.com", 80, "/hello", "a=1").to_s.should eq("http://www.google.com/hello?a=1") }
+    assert { expect(URI.new("http", "www.google.com").to_s).to eq("http://www.google.com") }
+    assert { expect(URI.new("http", "www.google.com", 80).to_s).to eq("http://www.google.com") }
+    assert { expect(URI.new("http", "www.google.com", 1234).to_s).to eq("http://www.google.com:1234") }
+    assert { expect(URI.new("http", "www.google.com", 80, "/hello").to_s).to eq("http://www.google.com/hello") }
+    assert { expect(URI.new("http", "www.google.com", 80, "/hello", "a=1").to_s).to eq("http://www.google.com/hello?a=1") }
   end
 end
 

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -11,67 +11,67 @@ describe XML do
         </person>
       </people>
       ))
-    doc.document.should eq(doc)
-    doc.name.should eq("document")
-    doc.attributes.empty?.should be_true
+    expect(doc.document).to eq(doc)
+    expect(doc.name).to eq("document")
+    expect(doc.attributes.empty?).to be_true
 
     people = doc.root.not_nil!
-    people.name.should eq("people")
-    people.type.should eq(XML::Type::ELEMENT_NODE)
+    expect(people.name).to eq("people")
+    expect(people.type).to eq(XML::Type::ELEMENT_NODE)
 
-    people.attributes.empty?.should be_true
+    expect(people.attributes.empty?).to be_true
 
     children = doc.children
-    children.length.should eq(1)
-    children.empty?.should be_false
+    expect(children.length).to eq(1)
+    expect(children.empty?).to be_false
 
     people = children[0]
-    people.name.should eq("people")
+    expect(people.name).to eq("people")
 
-    people.document.should eq(doc)
+    expect(people.document).to eq(doc)
 
     children = people.children
-    children.length.should eq(3)
+    expect(children.length).to eq(3)
 
     text = children[0]
-    text.name.should eq("text")
-    text.content.should eq("\n        ")
+    expect(text.name).to eq("text")
+    expect(text.content).to eq("\n        ")
 
     person = children[1]
-    person.name.should eq("person")
+    expect(person.name).to eq("person")
 
     text = children[2]
-    text.content.should eq("\n      ")
+    expect(text.content).to eq("\n      ")
 
     attrs = person.attributes
-    attrs.empty?.should be_false
-    attrs.length.should eq(2)
+    expect(attrs.empty?).to be_false
+    expect(attrs.length).to eq(2)
 
     attr = attrs[0]
-    attr.name.should eq("id")
-    attr.content.should eq("1")
-    attr.text.should eq("1")
-    attr.inner_text.should eq("1")
+    expect(attr.name).to eq("id")
+    expect(attr.content).to eq("1")
+    expect(attr.text).to eq("1")
+    expect(attr.inner_text).to eq("1")
 
     attr = attrs[1]
-    attr.name.should eq("id2")
-    attr.content.should eq("2")
+    expect(attr.name).to eq("id2")
+    expect(attr.content).to eq("2")
 
-    attrs["id"].content.should eq("1")
-    attrs["id2"].content.should eq("2")
+    expect(attrs["id"].content).to eq("1")
+    expect(attrs["id2"].content).to eq("2")
 
-    attrs["id3"]?.should be_nil
+    expect(attrs["id3"]?).to be_nil
     expect_raises(MissingKey) { attrs["id3"] }
 
-    person["id"].should eq("1")
-    person["id2"].should eq("2")
-    person["id3"]?.should be_nil
+    expect(person["id"]).to eq("1")
+    expect(person["id2"]).to eq("2")
+    expect(person["id3"]?).to be_nil
     expect_raises(MissingKey) { person["id3"] }
 
     name = person.children.find { |node| node.name == "name" }.not_nil!
-    name.content.should eq("John")
+    expect(name.content).to eq("John")
 
-    name.parent.should eq(person)
+    expect(name.parent).to eq(person)
   end
 
   it "parses from io" do
@@ -85,12 +85,12 @@ describe XML do
       ))
 
     doc = XML.parse(io)
-    doc.document.should eq(doc)
-    doc.name.should eq("document")
+    expect(doc.document).to eq(doc)
+    expect(doc.name).to eq("document")
 
     people = doc.children.find { |node| node.name == "people" }.not_nil!
     person = people.children.find { |node| node.name == "person" }.not_nil!
-    person["id"].should eq("1")
+    expect(person["id"]).to eq("1")
   end
 
   it "does to_s" do
@@ -104,7 +104,7 @@ describe XML do
       )
 
     doc = XML.parse(string)
-    doc.to_s.strip.should eq(<<-XML
+    expect(doc.to_s.strip).to eq(<<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <people>
   <person id="1" id2="2">
@@ -125,26 +125,26 @@ XML
       ))
 
     people = doc.first_element_child.not_nil!
-    people.name.should eq("people")
+    expect(people.name).to eq("people")
 
     person = people.first_element_child.not_nil!
-    person.name.should eq("person")
-    person["id"].should eq("1")
+    expect(person.name).to eq("person")
+    expect(person["id"]).to eq("1")
 
     text = person.next.not_nil!
-    text.content.should eq("\n        ")
+    expect(text.content).to eq("\n        ")
 
-    text.previous.should eq(person)
-    text.previous_sibling.should eq(person)
+    expect(text.previous).to eq(person)
+    expect(text.previous_sibling).to eq(person)
 
-    person.next_sibling.should eq(text)
+    expect(person.next_sibling).to eq(text)
 
     person2 = text.next.not_nil!
-    person2.name.should eq("person")
-    person2["id"].should eq("2")
+    expect(person2.name).to eq("person")
+    expect(person2["id"]).to eq("2")
 
-    person.next_element.should eq(person2)
-    person2.previous_element.should eq(person)
+    expect(person.next_element).to eq(person2)
+    expect(person2.previous_element).to eq(person)
   end
 
   it "handles errors" do
@@ -163,11 +163,11 @@ XML
       ))
     namespaces = doc.root.not_nil!.namespace_scopes
 
-    namespaces.length.should eq(2)
-    namespaces[0].href.should eq("http://www.w3.org/2005/Atom")
-    namespaces[0].prefix.should be_nil
-    namespaces[1].href.should eq("http://a9.com/-/spec/opensearchrss/1.0/")
-    namespaces[1].prefix.should eq("openSearch")
+    expect(namespaces.length).to eq(2)
+    expect(namespaces[0].href).to eq("http://www.w3.org/2005/Atom")
+    expect(namespaces[0].prefix).to be_nil
+    expect(namespaces[1].href).to eq("http://a9.com/-/spec/opensearchrss/1.0/")
+    expect(namespaces[1].prefix).to eq("openSearch")
   end
 
   it "gets root namespaces as hash" do
@@ -177,7 +177,7 @@ XML
       </feed>
       ))
     namespaces = doc.root.not_nil!.namespaces
-    namespaces.should eq({
+    expect(namespaces).to eq({
       "xmlns" => "http://www.w3.org/2005/Atom",
       "xmlns:openSearch": "http://a9.com/-/spec/opensearchrss/1.0/",
     })

--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -21,46 +21,46 @@ module XML
       doc = doc()
 
       nodes = doc.xpath("//people/person") as NodeSet
-      nodes.length.should eq(2)
+      expect(nodes.length).to eq(2)
 
-      nodes[0].name.should eq("person")
-      nodes[0]["id"].should eq("1")
+      expect(nodes[0].name).to eq("person")
+      expect(nodes[0]["id"]).to eq("1")
 
-      nodes[1].name.should eq("person")
-      nodes[1]["id"].should eq("2")
+      expect(nodes[1].name).to eq("person")
+      expect(nodes[1]["id"]).to eq("2")
 
       nodes = doc.xpath_nodes("//people/person")
-      nodes.length.should eq(2)
+      expect(nodes.length).to eq(2)
     end
 
     it "finds string" do
       doc = doc()
 
       id = doc.xpath("string(//people/person[1]/@id)") as String
-      id.should eq("1")
+      expect(id).to eq("1")
 
       id = doc.xpath_string("string(//people/person[1]/@id)")
-      id.should eq("1")
+      expect(id).to eq("1")
     end
 
     it "finds number" do
       doc = doc()
 
       count = doc.xpath("count(//people/person)") as Float64
-      count.should eq(2)
+      expect(count).to eq(2)
 
       count = doc.xpath_float("count(//people/person)")
-      count.should eq(2)
+      expect(count).to eq(2)
     end
 
     it "finds boolean" do
       doc = doc()
 
       id = doc.xpath("boolean(//people/person[1]/@id)") as Bool
-      id.should be_true
+      expect(id).to be_true
 
       id = doc.xpath_bool("boolean(//people/person[1]/@id)")
-      id.should be_true
+      expect(id).to be_true
     end
 
     it "raises on invalid xpath" do
@@ -76,11 +76,11 @@ module XML
         </feed>
         ))
       nodes = doc.xpath("//atom:feed", namespaces: {"atom": "http://www.w3.org/2005/Atom"}) as NodeSet
-      nodes.length.should eq(1)
-      nodes[0].name.should eq("feed")
+      expect(nodes.length).to eq(1)
+      expect(nodes[0].name).to eq("feed")
       ns = nodes[0].namespace.not_nil!
-      ns.href.should eq("http://www.w3.org/2005/Atom")
-      ns.prefix.should be_nil
+      expect(ns.href).to eq("http://www.w3.org/2005/Atom")
+      expect(ns.prefix).to be_nil
     end
 
     it "finds with root namespaces" do
@@ -90,11 +90,11 @@ module XML
         </feed>
         ))
       nodes = doc.xpath("//xmlns:feed", namespaces: doc.root.not_nil!.namespaces) as NodeSet
-      nodes.length.should eq(1)
-      nodes[0].name.should eq("feed")
+      expect(nodes.length).to eq(1)
+      expect(nodes[0].name).to eq("feed")
       ns = nodes[0].namespace.not_nil!
-      ns.href.should eq("http://www.w3.org/2005/Atom")
-      ns.prefix.should be_nil
+      expect(ns.href).to eq("http://www.w3.org/2005/Atom")
+      expect(ns.prefix).to be_nil
     end
 
     it "finds with variable binding" do
@@ -106,8 +106,8 @@ module XML
         </feed>
         ))
       nodes = doc.xpath("//feed/person[@id=$value]", variables: {"value": 2}) as NodeSet
-      nodes.length.should eq(1)
-      nodes[0]["id"].should eq("2")
+      expect(nodes.length).to eq(1)
+      expect(nodes[0]["id"]).to eq("2")
     end
   end
 end

--- a/spec/std/yaml_spec.cr
+++ b/spec/std/yaml_spec.cr
@@ -3,22 +3,22 @@ require "yaml"
 
 describe "YAML" do
   describe "parser" do
-    assert { YAML.load("foo").should eq("foo") }
-    assert { YAML.load("- foo\n- bar").should eq(["foo", "bar"]) }
-    assert { YAML.load_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
-    assert { YAML.load("foo: bar").should eq({"foo" => "bar"}) }
-    assert { YAML.load("--- []\n").should eq([] of YAML::Type) }
-    assert { YAML.load("---\n...").should eq("") }
+    assert { expect(YAML.load("foo")).to eq("foo") }
+    assert { expect(YAML.load("- foo\n- bar")).to eq(["foo", "bar"]) }
+    assert { expect(YAML.load_all("---\nfoo\n---\nbar\n")).to eq(["foo", "bar"]) }
+    assert { expect(YAML.load("foo: bar")).to eq({"foo" => "bar"}) }
+    assert { expect(YAML.load("--- []\n")).to eq([] of YAML::Type) }
+    assert { expect(YAML.load("---\n...")).to eq("") }
 
     it "parses recursive sequence" do
       doc = YAML.load("--- &foo\n- *foo\n") as Array
-      doc[0].object_id.should eq(doc.object_id)
+      expect(doc[0].object_id).to eq(doc.object_id)
     end
 
     it "parses alias to scalar" do
       doc = YAML.load("---\n- &x foo\n- *x\n") as Array
-      doc.should eq(["foo", "foo"])
-      doc[0].object_id.should eq(doc[1].object_id)
+      expect(doc).to eq(["foo", "foo"])
+      expect(doc[0].object_id).to eq(doc[1].object_id)
     end
   end
 end

--- a/src/compiler/crystal/tools/init/template/example_spec.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example_spec.cr.ecr
@@ -4,6 +4,6 @@ describe <%= module_name %> do
   # TODO: Write tests
 
   it "works" do
-    false.should eq(true)
+    expect(false).to eq(true)
   end
 end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -1,4 +1,25 @@
 module Spec
+  class Expectation(T)
+    getter target
+
+    def initialize(@target : T)
+    end
+
+    def to(expectation, file = __FILE__, line = __LINE__)
+      unless expectation.match(target)
+        fail(expectation.failure_message, file, line)
+      end
+    end
+
+    def to_not(expectation, file = __FILE__, line = __LINE__)
+      if expectation.match(target)
+        fail(expectation.negative_failure_message, file, line)
+      end
+    end
+
+    alias_method not_to, to_not
+  end
+
   class EqualExpectation(T)
     def initialize(@value : T)
     end
@@ -281,16 +302,22 @@ macro expect_raises(klass, message)
   end
 end
 
-class Object
-  def should(expectation, file = __FILE__, line = __LINE__)
-    unless expectation.match self
-      fail(expectation.failure_message, file, line)
+macro spec_enable_should
+  class Object
+    def should(expectation, file = __FILE__, line = __LINE__)
+      unless expectation.match self
+        fail(expectation.failure_message, file, line)
+      end
     end
-  end
 
-  def should_not(expectation, file = __FILE__, line = __LINE__)
-    if expectation.match self
-      fail(expectation.negative_failure_message, file, line)
+    def should_not(expectation, file = __FILE__, line = __LINE__)
+      if expectation.match self
+        fail(expectation.negative_failure_message, file, line)
+      end
     end
   end
+end
+
+def expect(target)
+  Spec::Expectation.new(target)
 end


### PR DESCRIPTION
Adds `expect(...).to matcher`. Removes `Object#should` and `Object#should_not`. But leaves possibility to re-enable them with `spec_enable_should` macro.

Commits are made in a fashion to make them easier to read:

- https://github.com/waterlink/crystal/commit/b9356aa6045c5315ac362647fd80c763880585eb - adds `expect` method and `spec_enable_should` macro.
- https://github.com/waterlink/crystal/commit/aa5df1ecf258b4fad904942ca9d487d6398a7a43 - fixes all specs to use `expect(...).to matcher` (~ +5000/-5000, probably kills browser, so read from git directly)
- https://github.com/waterlink/crystal/commit/0ec2ab6289de385ff0da5c60b075537e5cb01263 - a bunch of TODOs. I have encountered bunch of specs that are commented out, but seems like they want to be pending.
- https://github.com/waterlink/crystal/commit/ab3caeb0a86e5d6acd3e7a5f8248c074fadd2225 - fixes template for `crystal init` to generate `example_spec.cr` with `expect(...).to matcher` style.

---

So, unexpectedly, doesn't change a thing about performance:

Before:

```
compile: 1:36 mins and 1.4GB of RAM
suite run: 3:04 mins and 1.6GB of RAM
```

After:
```
compile: 1:48 mins and 1.4 GB of RAM
suite run: 2:50 mins and 1.6 GB of RAM
```

Both compile steps were peaking for 1-2 seconds to 2 GB and then back to 1.4GB