### PR TITLE
version of llvm should not be hardcoded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,15 @@ SPEC_SOURCES := $(shell find spec -name '*.cr')
 FLAGS := $(if $(release),--release )$(if $(stats),--stats )$(if $(threads),--threads $(threads) )
 EXPORTS := $(if $(release),,CRYSTAL_CONFIG_PATH=`pwd`/src)
 ifeq (Darwin,$(shell uname))
-	BUILD_PATH := PATH=`brew --prefix llvm36`/bin:$$PATH LIBRARY_PATH=`brew --prefix crystal`/embedded/lib
+	# try llvm36, then llvm35, finally llvm
+	LLVM_PATH := $(shell brew --prefix llvm36)
+	ifneq ("",$(wildcard $(LLVM_PATH)))
+		LLVM_PATH := $(shell brew --prefix llvm35)
+	endif
+	ifneq ("",$(wildcard $(LLVM_PATH)))
+		LLVM_PATH := $(shell brew --prefix llvm)
+	endif
+	BUILD_PATH := PATH=$(LLVM_PATH)/bin:$$PATH LIBRARY_PATH=`brew --prefix crystal`/embedded/lib
 endif
 
 all: crystal


### PR DESCRIPTION
- The "from sources" directions mention `brew install --with-llvm` which
  installs `llvm` as `llvm`, not with a version suffix
- So lets try all the options until we find a working `llvm`