### PR TITLE
Raise JSON::ParseException in json_mapping

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -104,8 +104,14 @@ describe "JSON mapping" do
   end
 
   it "parses strict person with unknown attributes" do
-    expect_raises Exception, "unknown json attribute: foo" do
+    expect_raises JSON::ParseException, "unknown json attribute: foo" do
       StrictJSONPerson.from_json(%({"name": "John", "age": 30, "foo": "bar"}))
+    end
+  end
+
+  it "raises if non-nilable attribute is nil" do
+    expect_raises JSON::ParseException, "missing json attribute: name" do
+      JSONPerson.from_json(%({"age": 30}))
     end
   end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -36,7 +36,7 @@ class Object
         {% end %}
         else
           {% if strict %}
-            raise "unknown json attribute: #{_key}"
+            raise JSON::ParseException.new("unknown json attribute: #{_key}", 0, 0)
           {% else %}
             _pull.skip
           {% end %}
@@ -46,7 +46,7 @@ class Object
       {% for key, value in properties %}
         {% unless value[:nilable] %}
           if _{{key.id}}.is_a?(Nil)
-            raise "missing json attribute: {{(value[:key] || key).id}}"
+            raise JSON::ParseException.new("missing json attribute: {{(value[:key] || key).id}}", 0, 0)
           end
         {% end %}
       {% end %}


### PR DESCRIPTION
Raising Exception makes it unnecessary hard to handle
differently from other errors.