### PR TITLE
LibC::TimeVal#tv_sec is TimeT

### DIFF
--- a/src/event/event.cr
+++ b/src/event/event.cr
@@ -52,7 +52,7 @@ module Event
 
     private def to_timeval(time : Int)
       t :: LibC::TimeVal
-      t.tv_sec = time.to_i64
+      t.tv_sec  = typeof(t.tv_sec).cast(time)
       t.tv_usec = typeof(t.tv_usec).cast(0)
       t
     end
@@ -60,10 +60,10 @@ module Event
     private def to_timeval(time : Float)
       t :: LibC::TimeVal
 
-      seconds = time.to_i64
+      seconds  = typeof(tv.tv_sec).cast(time)
       useconds = typeof(t.tv_usec).cast((time - seconds) * 1e6)
 
-      t.tv_sec = seconds.to_i64
+      t.tv_sec  = seconds
       t.tv_usec = useconds
       t
     end


### PR DESCRIPTION
That means it's architecture dependent

This fixes sleep on 32bit platforms, probably among
a host of other stuff.