### PR TITLE
String#camelcase handles -es

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 require "spec"
 
 describe "String" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "spec"
 
 describe "String" do
@@ -764,6 +765,7 @@ describe "String" do
   it "does camelcase" do
     "foo".camelcase.should eq("Foo")
     "foo_bar".camelcase.should eq("FooBar")
+    "foo-bar".camelcase.should eq("Foo::Bar")
   end
 
   it "answers ascii_only?" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 lib LibC
   fun atoi(str : UInt8*) : Int32
   fun atoll(str : UInt8*) : Int64
@@ -1185,6 +1186,10 @@ class String
       each_char do |char|
         if first
           str << char.upcase
+        elsif char == '-'
+          last_is_underscore = true
+          str << ':'
+          str << ':'
         elsif char == '_'
           last_is_underscore = true
         elsif last_is_underscore

--- a/src/string.cr
+++ b/src/string.cr
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 lib LibC
   fun atoi(str : UInt8*) : Int32
   fun atoll(str : UInt8*) : Int64
@@ -1180,21 +1179,21 @@ class String
 
   def camelcase
     first = true
-    last_is_underscore = false
+    last_is_seperator = false
 
     String.build(bytesize) do |str|
       each_char do |char|
         if first
           str << char.upcase
         elsif char == '-'
-          last_is_underscore = true
+          last_is_seperator = true
           str << ':'
           str << ':'
         elsif char == '_'
-          last_is_underscore = true
-        elsif last_is_underscore
+          last_is_seperator = true
+        elsif last_is_seperator
           str << char.upcase
-          last_is_underscore = false
+          last_is_seperator = false
         else
           str << char
         end


### PR DESCRIPTION
I hit this when I tried to init a new project with a name like
nifty-project. I ended up with:

```crystal
module Nifty-project

end
```

Not *positive* it makes sense to handle it in String#camelcase... but
really not sure there's a case where you would ever want a camelcased
string that looks like 'Nifty-project'. If so, maybe we can write a
String#constantize method or somethign similar.