### PR TITLE
Init handles dashes in project names

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -23,7 +23,12 @@ module Crystal
 
     run_init_project("lib", "example", "tmp/example", "John Smith")
     run_init_project("app", "example_app", "tmp/example_app", "John Smith")
+    run_init_project("lib", "example-lib", "tmp/example-lib", "John Smith")
 
+    describe_file "example-lib/src/example-lib.cr" do |file|
+      file.should contain("Example::Lib")
+    end
+    
     describe_file "example/.gitignore" do |gitignore|
       gitignore.should contain("/.deps/")
       gitignore.should contain("/.deps.lock")

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -107,7 +107,7 @@ DIR  - directory where project will be generated,
       end
 
       def module_name
-        config.name.camelcase
+        config.name.camelcase.split("-").map(&.capitalize).join("::")
       end
 
       abstract def full_path


### PR DESCRIPTION
Otherwise init creates module names that are invalid like `Example-lib`.