### PR TITLE
Allow Time.parse to return UTC times

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -397,6 +397,11 @@ describe Time do
     Time.parse("今は Friday, October 31, 2014", "今は %A, %B %d, %Y").to_s.should eq("2014-10-31 00:00:00")
   end
 
+  it "can parse in UTC" do
+    time = Time.parse("2014-10-31 11:12:13", "%F %T", Time::Kind::Utc)
+    time.kind.should eq(Time::Kind::Utc)
+  end
+
   it "at" do
     t1 = Time.new 2014, 11, 25, 10, 11, 12, 13
     t2 = Time.new 2014, 6, 25, 10, 11, 12, 13

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -259,8 +259,8 @@ struct Time
     TimeFormat.new(format).format(self, io)
   end
 
-  def self.parse(time, pattern)
-    TimeFormat.new(pattern).parse(time)
+  def self.parse(time, pattern, kind=Time::Kind::Unspecified)
+    TimeFormat.new(pattern).parse(time, kind)
   end
 
   # Returns the number of seconds since the Epoch

--- a/src/time/time_format.cr
+++ b/src/time/time_format.cr
@@ -9,10 +9,10 @@ struct TimeFormat
   def initialize(@pattern : String)
   end
 
-  def parse(string)
+  def parse(string, kind = Time::Kind::Unspecified)
     parser = Parser.new(string)
     parser.visit(pattern)
-    parser.time
+    parser.time(kind)
   end
 
   def format(time : Time)

--- a/src/time/time_format/parser.cr
+++ b/src/time/time_format/parser.cr
@@ -14,9 +14,9 @@ struct TimeFormat
       @pm = false
     end
 
-    def time
+    def time(kind = Time::Kind::Unspecified)
       @hour += 12 if @pm
-      Time.new @year, @month, @day, @hour, @minute, @second, @millisecond
+      Time.new @year, @month, @day, @hour, @minute, @second, @millisecond, kind
     end
 
     def year


### PR DESCRIPTION
Unless I'm misinterpreting what the meaning `Time::Kind` I think it'd be useful to be able to get a utc time out of `Time.parse`

I ran into this being missing when adding support for timestamps in github.com/will/crystal-pg . In addition to this, I also discovered that there wasn't a way to parse out msec or offsets, so I'm instead just using `StringScanner` which is alright.