### PR TITLE
WIP: added expect syntax to spec

### DIFF
--- a/spec/std/spec_except_spec.cr
+++ b/spec/std/spec_except_spec.cr
@@ -1,0 +1,85 @@
+require "spec"
+
+describe "Spec matchers" do
+  describe "expect to be_truthy" do
+    it "passes for true" do
+      expect(true).to be_truthy
+    end
+
+    it "passes for some non-nil, non-false value" do
+      expect(42).to be_truthy
+    end
+  end
+
+  describe "expect to_not be_truthy" do
+    it "passes for false" do
+      expect(false).to_not be_truthy
+    end
+
+    it "passes for nil" do
+      expect(nil).to_not be_truthy
+    end
+  end
+
+  describe "expect to be_falsey" do
+    it "passes for false" do
+      expect(false).to be_falsey
+    end
+
+    it "passes for nil" do
+      expect(nil).to be_falsey
+    end
+  end
+
+  describe "expect to_not be_falsey" do
+    it "passses for true" do
+      expect(true).to_not be_falsey
+    end
+
+    it "passes for some non-nil, non-false value" do
+      expect(42).to_not be_falsey
+    end
+  end
+
+  describe "expect to contain" do
+    it "passes when string includes? specified substring" do
+      expect("hello world!").to contain("hello")
+    end
+
+    it "works with array" do
+      expect([1, 2, 3, 5, 8]).to contain(5)
+    end
+
+    it "works with set" do
+      expect([1, 2, 3, 5, 8].to_set).to contain(8)
+    end
+
+    it "works with range" do
+      expect(50 .. 55).to contain(53)
+    end
+
+    #it "does not pass when string does not includes? specified substring" do
+    #  expect do
+    #    expect("hello world!").to contain("crystal")
+    #  end.to raise_exception(Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"})
+    #end
+  end
+
+  describe "expect to_not contain" do
+    it "passes when string does not includes? specified substring" do
+      expect("hello world!").to contain("crystal")
+    end
+
+    #it "does not pass when string does not includes? specified substring" do
+    #  expect_raises Spec::AssertionFailed, %{expected: value "hello world!"\nto not include: "world"} do
+    #    expect("hello world!").to_not contain("world")
+    #  end
+    #end
+  end
+
+  context "expect to work as describe" do
+    it "is true" do
+      expect(true).to be_truthy
+    end
+  end
+end

--- a/spec/std/spec_except_spec.cr
+++ b/spec/std/spec_except_spec.cr
@@ -58,11 +58,11 @@ describe "Spec matchers" do
       expect(50 .. 55).to contain(53)
     end
 
-    #it "does not pass when string does not includes? specified substring" do
-    #  expect do
-    #    expect("hello world!").to contain("crystal")
-    #  end.to raise_exception(Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"})
-    #end
+    it "does not pass when string does not includes? specified substring" do
+      expect do
+        expect("hello world!").to contain("crystal")
+      end.to raise_error(Spec::AssertionFailed, %{expected:   "hello world!"\nto include: "crystal"})
+    end
   end
 
   describe "expect to_not contain" do
@@ -70,11 +70,11 @@ describe "Spec matchers" do
       expect("hello world!").to contain("crystal")
     end
 
-    #it "does not pass when string does not includes? specified substring" do
-    #  expect_raises Spec::AssertionFailed, %{expected: value "hello world!"\nto not include: "world"} do
-    #    expect("hello world!").to_not contain("world")
-    #  end
-    #end
+    it "does not pass when string does not includes? specified substring" do
+      expect do
+        expect("hello world!").to contain("crystal")
+      end.to raise_error Spec::AssertionFailed, %{expected: value "hello world!"\nto not include: "world"}
+    end
   end
 
   context "expect to work as describe" do

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -210,7 +210,7 @@ module Spec
 end
 
 def expect(value)
-  Expectation.new(value)
+  Spec::Expectation.new(value)
 end
 
 def eq(value)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -227,8 +227,9 @@ end
 def expect
   begin
     yield
-  rescue Object => e
-    Spec::Expectation.new(e) and return
+  rescue _ex_ : Object
+    Spec::Expectation.new(e)
+    return
   ensure
     Spec::Expectation.new(nil)
   end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -16,6 +16,17 @@ module Spec
     end
   end
 
+  class RaiseErrorExpecation(T)
+    def initialize(@value : T, @message="")
+    end
+
+  def matches(value, message)
+    expect(@value).to eq value
+    unless message.empty?
+      expect(@value.message).to eq message
+    end
+  end
+
   class EqualExpectation(T)
     def initialize(@value : T)
     end
@@ -213,6 +224,16 @@ def expect(value)
   Spec::Expectation.new(value)
 end
 
+def expect
+  begin
+    yield
+  rescue Object => e
+    Spec::Expectation.new(e) and return
+  ensure
+    Spec::Expectation.new(nil)
+  end
+end
+
 def eq(value)
   Spec::EqualExpectation.new value
 end
@@ -247,6 +268,10 @@ end
 
 def be
   Spec::Be
+end
+
+def raise_error(base, message="")
+  RaiseErrorExpecation.new(base, message)
 end
 
 def match(value)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -272,7 +272,7 @@ def be
 end
 
 def raise_error(base, message="")
-  RaiseErrorExpecation.new(base, message)
+  Spec::RaiseErrorExpecation.new(base, message)
 end
 
 def match(value)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -1,4 +1,21 @@
 module Spec
+  class Expectation(T)
+    def initialize(@value : T)
+    end
+
+    def to(matcher, file = __FILE__, line = __LINE__)
+      unless match.match @value
+        fail(matcher.failure_message, file, line)
+      end
+    end
+
+    def to_not(matcher, file = __FILE__, line = __LINE__)
+      if matcher.match @value
+        fail(matcher.negative_failure_message, file, line)
+      end
+    end
+  end
+
   class EqualExpectation(T)
     def initialize(@value : T)
     end
@@ -190,6 +207,10 @@ module Spec
       end
     end
   end
+end
+
+def expect(value)
+  Expectation.new(value)
 end
 
 def eq(value)


### PR DESCRIPTION
this PR is to start the initial conversation of migrating `Object#should` syntax to `expect(instance).to` syntax, is `should` preferred over `expect`, for example