### PR TITLE
Int#to_s performance

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -62,7 +62,10 @@ describe "Int" do
     assert { -1234.to_s(16, upcase: true).should eq("-4D2") }
     assert { 1234.to_s(36, upcase: true).should eq("YA") }
     assert { -1234.to_s(36, upcase: true).should eq("-YA") }
+    assert { 0.to_s(2).should eq("0") }
     assert { 0.to_s(16).should eq("0") }
+    assert { 1.to_s(2).should eq("1") }
+    assert { 1.to_s(16).should eq("1") }
 
     it "raises on base 1" do
       expect_raises { 123.to_s(1) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -225,12 +225,18 @@ struct Int
       init = 0
     end
 
-    # bit-shifting, performance optimized for base 2
-    if base == 2
+    # bit-shifting, performance optimized for base 2 and base 16
+    if base == 2 || base == 16
+      mask = (base-1)
+      shift = (base == 2) ? 1 : 4
       while num > 0
-        digit = num & 1
-        str.write_byte (zero + digit).to_u8
-        num = num >> 1
+        digit = num & mask
+        if digit >= 10
+          str.write_byte (letter_a + digit).to_u8
+        else
+          str.write_byte (zero + digit).to_u8
+        end
+        num = num >> shift
       end
     end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -214,6 +214,9 @@ struct Int
     str = StringIO.new
     num = self
 
+    letter_a = (upcase ? 'A' : 'a').ord - 10
+    zero = '0'.ord
+
     if num < 0
       str.write_byte '-'.ord.to_u8
       num = num.abs
@@ -222,12 +225,21 @@ struct Int
       init = 0
     end
 
+    # bit-shifting, performance optimized for base 2
+    if base == 2
+      while num > 0
+        digit = num & 1
+        str.write_byte (zero + digit).to_u8
+        num = num >> 1
+      end
+    end
+
     while num > 0
       digit = num % base
       if digit >= 10
-        str.write_byte ((upcase ? 'A' : 'a').ord + digit - 10).to_u8
+        str.write_byte (letter_a + digit).to_u8
       else
-        str.write_byte ('0'.ord + digit).to_u8
+        str.write_byte (zero + digit).to_u8
       end
       num /= base
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -206,8 +206,8 @@ struct Int
   def to_s(base : Int, io : IO, upcase = false : Bool)
     raise "Invalid base #{base}" unless 2 <= base <= 36
 
-    if self == 0
-      io << "0"
+    if self == 0 || self == 1
+      io << self == 0 ? "0" : "1"
       return
     end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -225,10 +225,11 @@ struct Int
       init = 0
     end
 
-    # bit-shifting, performance optimized for base 2 and base 16
-    if base == 2 || base == 16
-      mask = (base-1)
-      shift = (base == 2) ? 1 : 4
+    # bit-shift - performance optimized for bases 2, 4, 8, and 16
+    if base % 2 == 0 && base <= 16
+      mask = base - 1
+      # shift = { 2 => 1, 4 => 2, 8 => 3, 16 => 4 }[base] # slow
+      shift = (base == 16) ? 4 : ((base == 2) ? 1 : (( base == 8 ) ? 3 : 2))
       while num > 0
         digit = num & mask
         if digit >= 10


### PR DESCRIPTION
- if speed (and memory allocation) is the reason we're doing this seems
  we should do it for both 0 and 1