### PR TITLE
Implement Time.from_ms and Time#to_ms

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -56,6 +56,13 @@ describe Time do
     typeof(from_at).should eq(Time)
   end
 
+  it "initialize with .from_ms" do
+    ms = Time.now.to_i * 1000
+    from_ms = Time.from_ms(ms)
+    from_ms.to_ms.should eq(ms)
+    typeof(from_ms).should eq(Time)
+  end
+
   it "fields" do
     Time::MaxValue.ticks.should eq(3155378975999999999)
     Time::MinValue.ticks.should eq(0)
@@ -248,6 +255,17 @@ describe Time do
 
     t = Time.new 2014, 10, 30, 21, 18, 1
     t.to_s.should eq("2014-10-30 21:18:01")
+  end
+
+  it "to_i" do
+    t = Time.new 2014, 10, 30, 21, 18, 13
+    t.to_i.should eq(1414703893)
+    t.to_i.should eq(t.to_seconds)
+  end
+
+  it "to_ms" do
+    t = Time.new 2014, 10, 30, 21, 18, 13
+    t.to_ms.should eq(1414703893000)
   end
 
   it "formats" do

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -96,6 +96,10 @@ struct Time
     new(UnixEpoch + seconds.to_i64 * TimeSpan::TicksPerSecond, kind)
   end
 
+  def self.from_ms(ms : Int, kind = Kind::Utc)
+    new(UnixEpoch + ms.to_i64 * TimeSpan::TicksPerMillisecond, kind)
+  end
+
   def +(other : TimeSpan)
     add_ticks other.ticks
   end
@@ -268,8 +272,14 @@ struct Time
   end
 
   # Returns the number of seconds since the Epoch
-  def to_i
+  def to_seconds
     (ticks - UnixEpoch) / TimeSpan::TicksPerSecond
+  end
+
+  alias_method to_i, to_seconds
+
+  def to_ms
+    (ticks - UnixEpoch) / TimeSpan::TicksPerMillisecond
   end
 
   def to_f


### PR DESCRIPTION
I'm very open to changing the names for these methods or changing how they're implemented.

I know this doesn't exactly follow what Ruby does, but Ruby works with seconds mostly. I need these methods to work with BSON which allows for milliseconds precision (which is nice).

I also added `Time#to_seconds` and aliased `Time#to_i` to it.