### PR TITLE
Enumerable#each_cons(n)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -221,6 +221,20 @@ describe "Enumerable" do
     end
   end
 
+  describe "each_cons" do
+    it "returns running pairs" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
+      array.should eq([[1, 2], [2, 3], [3, 4]])
+    end
+
+    it "returns running triples" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
+      array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    end
+  end
+
   it "gets each_with_index iterator" do
     iter = [1, 2].each_with_index
     iter.next.should eq({1, 0})

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -59,6 +59,18 @@ module Enumerable(T)
     each.slice(count)
   end
 
+  def each_cons(count : Int)
+    cons = Array(T).new(count)
+    each do |elem|
+      cons << elem
+      cons.shift if cons.size > count
+      if cons.size == count
+        yield cons.dup
+      end
+    end
+    nil
+  end
+
   def each_with_index(offset = 0)
     i = offset
     each do |elem|


### PR DESCRIPTION
This PR adds `Enumerable#each_cons(n)` to iterate over a list in pairs/triples/etc. Example:

```crystal
(1..8).each_cons(3) do |triple|
  pp triple
end
```

Output:

```
triple = [1, 2, 3]
triple = [2, 3, 4]
triple = [3, 4, 5]
triple = [4, 5, 6]
triple = [5, 6, 7]
triple = [6, 7, 8]
```

A couple of lateral considerations:

* It would probably make sense to implement it for `Iterator` (like slices are), but I struggled a bit on doing so. I will try harder, but on a separate PR :wink: 
* Related to this last point, while having a look to `Enumerable#each_slice` and `Iterator#slice` for *inspiration* and realized that the implementation is *duplicated* ([here](https://github.com/manastech/crystal/blob/21206c74c86be6d27b90db05043b4c060e6721b1/src/enumerable.cr#L45-56) and [here](https://github.com/manastech/crystal/blob/21206c74c86be6d27b90db05043b4c060e6721b1/src/iterator.cr#L363-391)). Would it make sense replacing the block implementation in `Enumerable` with:

```crystal
def each_slice(count : Int)
  each.slice(count).each do |slice|
    yield slice
  end
end
```

(and use the same strategy with `each_cons`)? Specs pass with that implementation, but I don't know if there is a different reason for that duplication (maybe performance?).