### PR TITLE
Fix "Installing" docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Status
 Installing
 ----------
 
-[Follow these instructions](http://crystal-lang.org/docs/installation/README.html)
+[Follow these instructions](http://crystal-lang.org/docs/installation/index.html)
 
 Documentation
 ----------


### PR DESCRIPTION
The current link to the "Installing" session in the README throws a 404.

I've changed it to the installation section of the docs in http://cristal-lan.org.