### PR TITLE
Added more functionality to openssl

### DIFF
--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -6,6 +6,13 @@ lib LibSSL
   type SSLContext = Void*
   type SSL = Void*
 
+  OP_NO_SSLv2 = 16777216
+  OP_NO_SSLv3 = 33554432
+  OP_NO_TLSv1 = 67108864
+  OP_NO_TLSv1_1 = 268435456
+  OP_NO_TLSv1_2 = 134217728
+  SSL_CTRL_OPTIONS = 32
+
   enum SSLFileType
     PEM = 1
     ASN1 = 2
@@ -38,5 +45,8 @@ lib LibSSL
   fun ssl_free = SSL_free(handle : SSL)
   fun ssl_ctx_use_certificate_chain_file = SSL_CTX_use_certificate_chain_file(ctx : SSLContext, file : UInt8*) : Int32
   fun ssl_ctx_use_privatekey_file = SSL_CTX_use_PrivateKey_file(ctx : SSLContext, file : UInt8*, filetype : SSLFileType) : Int32
+  fun ssl_ctx_set_options = SSL_CTX_ctrl(context : SSLContext, command : Int32, long_arg : Int32, pointer_arg : Void*) : Int32
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  fun ssl_set_cipher_list = SSL_set_cipher_list(handle : SSL, text : UInt8*) : Int32
+
 end

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -20,6 +20,7 @@ lib LibSSL
 
   fun ssl_load_error_strings = SSL_load_error_strings()
   fun ssl_library_init = SSL_library_init()
+  fun ssl_v3_server_method = SSLv3_server_method() : SSLMethod
   fun sslv23_method  = SSLv23_method() : SSLMethod
   fun ssl_ctx_new = SSL_CTX_new(method : SSLMethod) : SSLContext
   fun ssl_ctx_free = SSL_CTX_free(context : SSLContext)

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -19,6 +19,10 @@ class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_use_privatekey_file(@handle, file_path, LibSSL::SSLFileType::PEM)
   end
 
+  def set_options(ctx_options)
+    LibSSL.ssl_ctx_set_options(@handle, LibSSL::SSL_CTRL_OPTIONS, ctx_options, nil)
+  end
+
   def to_unsafe
     @handle
   end

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -4,7 +4,7 @@ class OpenSSL::SSL::Context
   end
 
   def initialize
-    @handle = LibSSL.ssl_ctx_new(LibSSL.sslv23_method)
+    @handle = LibSSL.ssl_ctx_new(LibSSL.ssl_v3_server_method)
   end
 
   def finalize

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -17,6 +17,10 @@ class OpenSSL::SSL::Socket
     LibSSL.ssl_free(@ssl)
   end
 
+  def set_cipher_list(ciphers)
+    LibSSL.ssl_set_cipher_list(@ssl, ciphers)
+  end
+
   def read(slice : Slice(UInt8), count)
     LibSSL.ssl_read(@ssl, slice.pointer(count), count)
   end


### PR DESCRIPTION
Added: 
1) ssl_set_cipher_list
2) ssl_ctx_set_options

Should be used like this: 

```ruby
require "openssl"
require "socket"

begin
  tcp_server = TCPServer.new(55555)
rescue e : Exception
  puts "Error in socket: #{e}"
end

if tcp_server
  context = OpenSSL::SSL::Context.default
  context.private_key = ("key.pem")
  context.certificate_chain = ("cert.pem")
  # OP_NO_* should be OR'd with each other 
  context.set_options(LibSSL::OP_NO_SSLv2 | LibSSL::OP_NO_SSLv3)
  begin
    loop do
      client = tcp_server.accept
      ssl_server = OpenSSL::SSL::Socket.new(client, :server, context)
      # Passed as a string, or a single cipher
      ssl_server.set_cipher_list("HIGH:!aNULL:!kRSA:!PSK:!SRP!MD5:!RC4")
    end
  rescue e : Exception
    puts "Error in SSL socket: #{e.message}\r\nlog: #{e.backtrace}"
  end
end
```