### PR TITLE
Fix crystal deps behavior with path dependencies that have no git commits

### DIFF
--- a/src/crystal/project/path_dependency.cr
+++ b/src/crystal/project/path_dependency.cr
@@ -31,7 +31,8 @@ module Crystal
     end
 
     def current_version
-      exec("([ -d \"#{@path}/.git\" ] && git -C #{@path} rev-parse HEAD) || echo -n 'local'")
+      ref = `git -C #{@path} rev-parse HEAD 2>/dev/null`.chomp
+      ref == "" || ref == "HEAD" ? "local" : ref
     end
 
     private def exec(cmd)


### PR DESCRIPTION
Given three local path dependencies:
```
deps do
  path "../git-commit" # has one git commit
  path "../git-empty" # has git init but no commits
  path "../not-git" # not in git
end
```

Prior to this PR, `.deps.lock` would look like this:
```
{
  "git-commit": "309c2df912898d32f3a0593e84bb0d41baae48ff\n",
  "git-empty": "HEAD\n-n local\n",
  "not-git": "-n local\n"
}
```
In addition, you'd get a nasty fatal error since the rev-parse would fail.

After this PR, `.deps.lock` looks like:
```
{
  "git-commit": "309c2df912898d32f3a0593e84bb0d41baae48ff",
  "git-empty": "local",
  "not-git": "local"
}
```

And no fatal error. :boom: 