### PR TITLE
SIGPIPE, non-blocking fds passed to other procs, and the os x travis failures

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -148,12 +148,12 @@ module IO
   def flush
   end
 
-  def self.pipe
+  def self.pipe(read_blocking=false, write_blocking=false)
     if LibC.pipe(out pipe_fds) != 0
       raise Errno.new("Could not create pipe")
     end
 
-    {FileDescriptorIO.new(pipe_fds[0]), FileDescriptorIO.new(pipe_fds[1])}
+    {FileDescriptorIO.new(pipe_fds[0], read_blocking), FileDescriptorIO.new(pipe_fds[1], write_blocking)}
   end
 
   def self.pipe

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -12,11 +12,11 @@ def Process.run(command, args = nil, output = nil : IO | Bool, input = nil : Str
   argv << Pointer(UInt8).null
 
   if output
-    process_output, fork_output = IO.pipe
+    process_output, fork_output = IO.pipe(write_blocking: true)
   end
 
   if input
-    fork_input, process_input = IO.pipe
+    fork_input, process_input = IO.pipe(read_blocking: true)
   end
 
   pid = fork do

--- a/src/spec/spec.cr
+++ b/src/spec/spec.cr
@@ -163,6 +163,7 @@ OptionParser.parse! do |opts|
 end
 
 Signal.trap(Signal::INT) { Spec.abort! }
+Signal.trap(Signal::PIPE, Signal::IGNORE)
 
 redefine_main do |main|
   time = Time.now


### PR DESCRIPTION
## reproducing
I was able to reproduce the #607 travis failures by using this program:

``` crystal
require "spec"
10000.times do
  it "send input from IO" do
    #begin
      File.open(__FILE__, "r") do |file|
        Process.run("/bin/cat", input: file, output: true).output.should eq(File.read(__FILE__))
        #Process.run("/usr/local/bin/pv", args: ["-q"], input: file, output: true).output.should eq(File.read(__FILE__))
      end
    #rescue
    #  puts "Errno!: #{LibC.errno}"
    #end
  end
end
```
out of the 10k runs, about 0.1% would fail. If the system is loaded (with `dd` for example), the error rate would increase. 

Running `lldb` showed that it was a SIGPIPE failure: https://gist.github.com/will/b5ed5d5b46f0ccd3f8bd

## specs

The first patch here cafe21f73ab85731f83eabc59c8eda2684fabdcc, ignores SIGPIPE in specs, which allows an exception to propagate rather than killing the process, and ending the specs. With this, the commented out exception tracking in the example above gets hit instead.

## file descriptors shared with other processes

@fdr had experience with exactly this problem with [wal-e](github.com/wal-e/wal-e) and was able to help narrow down the issue quickly. 

You'll notice the commented out code we tried `pv` instead of `cat`. Pipe viewer can correctly deal with non-blocking file descriptors, and when it is swapped in, there are no SIGPIPEs. `cat` however, cannot deal with non-blocking fds all of the time.

With that confirmation, we were able to patch `Process.run` to not modify the fds passed to other programs in patch cafec2ae2b11a6e128918629136b7fca996f0ba1.

In general other process should not be expected to deal with non-blocking file descriptors. This isn't just an os x problem, and I believe that it would happen eventually on linux. In fact, the wal-e problem was found on linux. There is for sure some other factor that makes it more common on os x, and particularly on travis.