### PR TITLE
Add values_at

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -147,6 +147,22 @@ describe "Array" do
     end
   end
 
+  describe "values_at" do
+    it "returns the given indexes" do
+      ["a", "b", "c", "d"].values_at(1, 0, 2).should eq({"b", "a", "c"})
+    end
+
+    it "raises when passed an invalid index" do
+      expect_raises IndexOutOfBounds do
+        ["a"].values_at(10)
+      end
+    end
+
+    it "works with mixed types" do
+      [1, "a", 1.0, :a].values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
+    end
+  end
+
   it "does clear" do
     a = [1, 2, 3]
     a.clear

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -131,6 +131,23 @@ describe "Hash" do
     end
   end
 
+  describe "values_at" do
+    it "returns the given keys" do
+      {"a": 1, "b": 2, "c": 3, "d": 4}.values_at("b", "a", "c").should eq({2, 1, 3})
+    end
+
+    it "raises when passed an invalid key" do
+      expect_raises MissingKey do
+        {"a": 1}.values_at("b")
+      end
+    end
+
+    it "works with mixed types" do
+      {1 => :a, "a" => 1, 1.0 => "a", :a => 1.0}.values_at(1, "a", 1.0, :a).should eq({:a, 1, "a", 1.0})
+    end
+  end
+
+
   describe "has_key?" do
     it "doesn't have key" do
       a = {1 => 2}

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -45,6 +45,18 @@ describe "StaticArray" do
     a[2].should eq(2)
   end
 
+  describe "values_at" do
+    it "returns the given indexes" do
+      StaticArray(Int32, 4).new { |i| i + 1 }.values_at(1, 0, 2).should eq({2, 1, 3})
+    end
+
+    it "raises when passed an invalid index" do
+      expect_raises IndexOutOfBounds do
+        StaticArray(Int32, 1).new { |i| i + 1 }.values_at(10)
+      end
+    end
+  end
+
   it "does to_s" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.to_s.should eq("[1, 2, 3]")

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -47,6 +47,22 @@ describe "Tuple" do
     a.at(2) { 3 }.should eq(3)
   end
 
+  describe "values_at" do
+    it "returns the given indexes" do
+      {"a", "b", "c", "d"}.values_at(1, 0, 2).should eq({"b", "a", "c"})
+    end
+
+    it "raises when passed an invalid index" do
+      expect_raises IndexOutOfBounds do
+        {"a"}.values_at(10)
+      end
+    end
+
+    it "works with mixed types" do
+      {1, "a", 1.0, :a}.values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
+    end
+  end
+
   it "does ==" do
     a = {1, 2}
     b = {3, 4}

--- a/src/array.cr
+++ b/src/array.cr
@@ -285,6 +285,16 @@ class Array(T)
     end
   end
 
+  # Returns a tuple populated with the elements at the given indexes.
+  # Raises if any index is invalid.
+  #
+  # ```
+  # ["a", "b", "c", "d"].values_at(0, 2) #=> {"a", "c"}
+  # ```
+  def values_at(*indexes : Int)
+    indexes.map {|index| self[index] }
+  end
+
   def buffer
     @buffer
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -98,6 +98,16 @@ class Hash(K, V)
     entry ? entry.value : yield key
   end
 
+  # Returns a tuple populated with the elements at the given indexes.
+  # Raises if any index is invalid.
+  #
+  # ```
+  # {"a": 1, "b": 2, "c": 3, "d": 4}.values_at("a", "c") #=> {1, 3}
+  # ```
+  def values_at(*indexes : K)
+    indexes.map {|index| self[index] }
+  end
+
   def delete(key)
     index = bucket_index(key)
     entry = @buckets[index]

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -41,6 +41,17 @@ struct StaticArray(T, N)
     buffer[index] = value
   end
 
+  # Returns a tuple populated with the elements at the given indexes.
+  # Raises if any index is invalid.
+  #
+  # ```
+  # a = StaticArray(Int32, 4).new { |i| i + 1 }
+  # a.values_at(0, 2) #=> {1, 3}
+  # ```
+  def values_at(*indexes : Int)
+    indexes.map {|index| self[index] }
+  end
+
   def update(index : Int)
     index = check_index_out_of_bounds index
     buffer[index] = yield buffer[index]

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -133,6 +133,16 @@ struct Tuple
     yield
   end
 
+  # Returns a tuple populated with the elements at the given indexes.
+  # Raises if any index is invalid.
+  #
+  # ```
+  # {"a", "b", "c", "d"}.values_at(0, 2) #=> {"a", "c"}
+  # ```
+  def values_at(*indexes : Int)
+    indexes.map {|index| self[index] }
+  end
+
   # Yields each of the elements in this tuple.
   #
   # ```


### PR DESCRIPTION
Besides the standard usecases from Ruby, given #683 was accepted, this can return a tuple and thus be used as a splat:

```ruby
def add(a, b)
  a + b
end

data = [1, 2, 3, 4]
add(*data.values_at(0, 3)) #=> 5
add(*data.values_at(3, 1)) #=> 6
