### PR TITLE
Corrected name of command "build" in usage

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -93,7 +93,7 @@ USAGE
   end
 
   private def self.build(options)
-    config = create_compiler "run", options
+    config = create_compiler "build", options
     config.compile
   end
 


### PR DESCRIPTION
That was causing a typo in command description:

```sh
$ crystal build
Usage: crystal run [options] [programfile] [--] [arguments]

Options:
    --cross-compile flags            cross-compile
    -d, --debug                      Add symbolic debug info
   ...
```