### PR TITLE
reduce the excessive number of newlines (<br/>) and do not display attributes

### DIFF
--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -142,8 +142,9 @@ module Crystal
         node.expressions.each do |exp|
           unless exp.nop?
             append_indent
-            exp.accept self
-            newline
+            unless exp.accept(self) == false
+              newline
+            end
           end
         end
       end

--- a/src/compiler/crystal/tools/browser.cr
+++ b/src/compiler/crystal/tools/browser.cr
@@ -137,9 +137,9 @@ class Crystal::Browser
           }
         </style>
       </head>
-      <body>
+      <body><code>
         #{yield}
-      </body>
+      </code></body>
     </html>
     )
   end
@@ -168,6 +168,10 @@ class Crystal::Browser
     end
 
     def visit(node : ModuleDef)
+      false
+    end
+
+    def visit(node : Attribute)
       false
     end
 


### PR DESCRIPTION
reduce the excessive number of newlines (<br/>) and do not display attributes

also wrap the new code into <code>...</code> to use proportional fonts