### PR TITLE
Enable IO#puts to take several arguments

### DIFF
--- a/spec/std/io/string_io_spec.cr
+++ b/spec/std/io/string_io_spec.cr
@@ -50,6 +50,17 @@ describe "StringIO" do
     io.to_s.should eq("foo\n")
   end
 
+  it "puts several arguments" do
+    io = StringIO.new
+    io.puts(1, "aaa", "\n")
+    lines = io.each_line
+
+    lines.next.should eq("1\n")
+    lines.next.should eq("aaa\n")
+    lines.next.should eq("\n")
+    chars.next.should be_a(Iterator::Stop)
+  end
+
   it "print" do
     io = StringIO.new
     io.print "foo"

--- a/spec/std/io/string_io_spec.cr
+++ b/spec/std/io/string_io_spec.cr
@@ -48,6 +48,10 @@ describe "StringIO" do
     io = StringIO.new
     io.puts "foo"
     io.to_s.should eq("foo\n")
+
+    io = StringIO.new
+    io.puts
+    io.to_s.should eq("\n")
   end
 
   it "puts several arguments" do
@@ -58,7 +62,7 @@ describe "StringIO" do
     lines.next.should eq("1\n")
     lines.next.should eq("aaa\n")
     lines.next.should eq("\n")
-    chars.next.should be_a(Iterator::Stop)
+    lines.next.should be_a(Iterator::Stop)
   end
 
   it "print" do
@@ -135,12 +139,6 @@ describe "StringIO" do
     io.gets.should eq("foobar")
   end
 
-  it "does puts" do
-    io = StringIO.new
-    io.puts
-    io.to_s.should eq("\n")
-  end
-
   it "read chars from UTF-8 string" do
     io = StringIO.new("há日本語")
     io.read_char.should eq('h')
@@ -168,7 +166,7 @@ describe "StringIO" do
     counter.should eq(3)
   end
 
-  it "writes an array of btyes" do
+  it "writes an array of bytes" do
     str = String.build do |io|
       bytes = ['a'.ord.to_u8, 'b'.ord.to_u8]
       io.write bytes

--- a/src/io.cr
+++ b/src/io.cr
@@ -203,6 +203,13 @@ module IO
     write_byte '\n'.ord.to_u8
   end
 
+  def puts(*objects)
+    objects.each do |obj|
+      puts obj
+    end
+    nil
+  end
+
   def printf(format_string, *args)
     printf format_string, args
   end


### PR DESCRIPTION
`Kernel#puts` can take several arguments but `IO#puts` doesn't.

It means that `puts(1, 2, 3)` is OK but `STDOUT.puts(1, 2, 3)` is not OK.  This behavior looks odd to me.  Ruby's `IO#puts` can take several arguments and I think Crystal should follow it.