### PR TITLE
Fix LibC types

### DIFF
--- a/src/fiber/fiber.cr
+++ b/src/fiber/fiber.cr
@@ -19,7 +19,7 @@ class Fiber
   protected property :prev_fiber
 
   def initialize(&@proc)
-    @stack = @@stack_pool.pop? || LibC.malloc(STACK_SIZE.to_u32)
+    @stack = @@stack_pool.pop? || LibC.malloc(LibC::SizeT.cast(STACK_SIZE))
     @stack_top = @stack_bottom = @stack + STACK_SIZE
     @cr = LibPcl.co_create(->(fiber) { (fiber as Fiber).run }, self as Void*, @stack, STACK_SIZE)
     LibPcl.co_set_data(@cr, self as Void*)

--- a/src/libc.cr
+++ b/src/libc.cr
@@ -1,29 +1,32 @@
 lib LibC
+  ifdef x86_64
+    alias SizeT = UInt64
+    alias SSizeT = Int64
+  else
+    alias SizeT = UInt32
+    alias SSizeT = Int32
+  end
+
+  #ifdef windows
+  #alias LongT = Int32
+  #else
+  alias LongT = SSizeT
+  #end
+
+  alias PtrDiffT = SSizeT
+
+  alias TimeT = Int64
+
   ifdef darwin
     alias ModeT = UInt16
   elsif linux
     alias ModeT = UInt32
   end
 
-  ifdef x86_64
-    alias IntT = Int64
-    alias UIntT = UInt64
-    alias LongT = Int64
-  else
-    alias IntT = Int32
-    alias UIntT = UInt32
-    alias LongT = Int32
-  end
-
-  alias PtrDiffT = IntT
-  alias SizeT = UIntT
-  alias SSizeT = IntT
-  alias TimeT = IntT
-
-  fun malloc(size : UInt32) : Void*
-  fun realloc(ptr : Void*, size : UInt32) : Void*
+  fun malloc(size : SizeT) : Void*
+  fun realloc(ptr : Void*, size : SizeT) : Void*
   fun free(ptr : Void*)
-  fun time(t : Int64) : Int64
+  fun time(t : TimeT*) : TimeT
   fun free(ptr : Void*)
-  fun memcmp(p1 : Void*, p2 : Void*, size : LibC::SizeT) : Int32
+  fun memcmp(p1 : Void*, p2 : Void*, size : SizeT) : Int32
 end


### PR DESCRIPTION
Current definitions of some C types and functions are wrong.

A lot of confusion comes from the use of the meaningless type `IntT`, which does not map to C `int`. Looking back at it, the situation wasn't as dire as I thought (first I saw that the `int` type is wrong, then I saw it used wrongly, but I misunderstood this)

An important thing to understand is the C standard never defines the exact sizes of numeric types. Even char can be more than 1 byte (and there were precedents). We can't use Crystal's `IntXX` types in C bindings, because that works only by coincidence with the current **de-facto** standards.

But let's leave that for another day. For now I just want to fix the current definitions in *libc*.

http://stackoverflow.com/a/589685

https://msdn.microsoft.com/en-us/library/1f4c8f33.aspx

http://stackoverflow.com/a/25473026
