### PR TITLE
Remove superfluous spec

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -282,7 +282,6 @@ describe "Array" do
   describe "empty" do
     it "is empty" do
       ([] of Int32).empty?.should be_true
-      [1].empty?.should be_false
     end
 
     it "is not empty" do


### PR DESCRIPTION
Case is exactly repeated in a separate spec just below

I believe keeping them separate for it is empty/it is not empty
is also beneficial and easier to spot if something breaks :)