### PR TITLE
Change spec description (grammar/clarity)

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -77,7 +77,7 @@ describe "Spec matchers" do
     end
   end
 
-  context "should work as describe" do
+  context "should work like describe" do
     it "is true" do
       true.should be_truthy
     end


### PR DESCRIPTION
Just stumbled upon this, I'm not a native speaker but I believe that as is only used in different contexts (with an adjective or something, like... "as big as") - seemed weird to me so I put in like.

Maybe I'm wrong  :sweat_smile: