### PR TITLE
Improve performance of File#each_line iterator.

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -221,6 +221,10 @@ class File < FileDescriptorIO
     end
   end
 
+  def each_line
+    IO::LineIterator.new(BufferedIO.new(self))
+  end
+
   def self.read_lines(filename)
     lines = [] of String
     each_line(filename) do |line|


### PR DESCRIPTION
Improve performance of File#each_line iterator by using BufferedIO.

Using this example.cr:

```crystal
puts File.open("/usr/share/dict/words").each_line.max_by{|w| w.length}
```

Old version which delegates to IO#each_line:

```
crystal example.cr  1.26s user 1.42s system 101% cpu 2.636 total
```

New version:

```
crystal example.cr  0.61s user 0.19s system 160% cpu 0.495 total
```