### PR TITLE
Added Hash#size and SimpleHash#size

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -205,6 +205,19 @@ describe "Hash" do
     end
   end
 
+  describe "size" do
+    it "is the same as length" do
+      a = {} of Int32 => Int32
+      a.size.should eq(a.length)
+
+      a = {1 => 2}
+      a.size.should eq(a.length)
+
+      a = {1 => 2, 3 => 4, 5 => 6, 7 => 8}
+      a.size.should eq(a.length)
+    end
+  end
+
   it "maps" do
     hash = {1 => 2, 3 => 4}
     array = hash.map { |k, v| k + v }

--- a/spec/std/simple_hash_spec.cr
+++ b/spec/std/simple_hash_spec.cr
@@ -159,6 +159,19 @@ describe "SimpleHash" do
     end
   end
 
+  describe "size" do
+    it "is the same as #length" do
+      a = SimpleHash(Int32, Int32).new
+      a.size.should eq(a.length)
+
+      a = SimpleHash {1 => 2}
+      a.size.should eq(a.length)
+
+      a = SimpleHash {1 => 2, 3 => 4, 5 => 6, 7 => 8}
+      a.size.should eq(a.length)
+    end
+  end
+
   describe "to_s" do
     it "returns a string representation" do
       a = SimpleHash(Int32, Int32).new

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -301,6 +301,10 @@ class Hash(K, V)
     end
   end
 
+  def size
+    @length
+  end
+
   def clear
     @buckets_length.times do |i|
       @buckets[i] = nil

--- a/src/simple_hash.cr
+++ b/src/simple_hash.cr
@@ -95,6 +95,10 @@ struct SimpleHash(K, V)
     @values.length
   end
 
+  def size
+    length
+  end
+
   def object_id
     @values.object_id
   end


### PR DESCRIPTION
I want `size` method even if `length` method exists because I'm often confused which method `size` or `length` the container has. (And `size` is a bit shorter than `length`)
Note that Ruby has both methods in `Hash` class.

I tested `size` methods with Crystal compiled by Crystal 0.7.2.