### PR TITLE
add support for octal numbers with the 0o prefix

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -188,8 +188,9 @@ describe "Lexer" do
   it_lexes_number :u64, ["0xFFFF_u64", "65535"]
 
   it_lexes_i32 [["0123", "83"], ["-0123", "-83"], ["+0123", "+83"]]
+  it_lexes_i32 [["0o123", "83"], ["-0o123", "-83"], ["+0o123", "+83"]]
   it_lexes_f64 [["0.5", "0.5"], ["+0.5", "+0.5"], ["-0.5", "-0.5"]]
-  it_lexes_i64 [["0123_i64", "83"], ["0x1_i64", "1"], ["0b1_i64", "1"]]
+  it_lexes_i64 [["0123_i64", "83"], ["0o123_i64", "83"], ["0x1_i64", "1"], ["0b1_i64", "1"]]
 
   it_lexes_i64 ["2147483648", "-2147483649", "-9223372036854775808"]
   it_lexes_i64 [["2147483648.foo", "2147483648"]]
@@ -263,6 +264,7 @@ describe "Lexer" do
 
   assert_syntax_error "0xFF_i8", "255 doesn't fit in an Int8"
   assert_syntax_error "0200_i8", "128 doesn't fit in an Int8"
+  assert_syntax_error "0o200_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "0b10000000_i8", "128 doesn't fit in an Int8"
 
   it "lexes not instance var" do

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1316,6 +1316,9 @@ module Crystal
       case peek_next_char
       when 'x'
         scan_hex_number(start, negative)
+      when 'o'
+        next_char
+        scan_octal_number(start, negative)
       when 'b'
         scan_bin_number(start, negative)
       when '.'

--- a/src/int.cr
+++ b/src/int.cr
@@ -43,10 +43,10 @@
 # 0b1101 # == 13
 # ```
 #
-# Octal numbers start with a zero:
+# Octal numbers start with `0o`:
 #
 # ```text
-# 0123 # == 83
+# 0o123 # == 83
 # ```
 #
 # Hexadecimal numbers start with `0x`:


### PR DESCRIPTION
As discussed in issue #740. Right now octal constants are prefixed with `0`.
This commit allows them to be prefixed with `0o` which is consistent with hex
`0x` and binary `0b`. A future commit could remove support for the `0` prefix.