### PR TITLE
pass flags when building the spec target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all_spec: $(O)/all_spec
 
 $(O)/all_spec: $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
-	$(BUILD_PATH) ./bin/crystal build -o $@ spec/all_spec.cr
+	$(BUILD_PATH) ./bin/crystal build $(FLAGS) -o $@ spec/all_spec.cr
 
 $(O)/crystal: $(SOURCES)
 	@mkdir -p $(O)


### PR DESCRIPTION
Previously, flags such as `--stats` would not be passed to the crystal
compiler when building spec with e.g. `make stats=1 spec`. This commit fixes
that. You can also easily build a version of `all_spec` in release mode, but
bc+obj codegen has taken 45 minutes (and is still going).