### PR TITLE
Switch to 0o as the one true octal constant prefix (needs a 0.7.4 release)

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -187,10 +187,9 @@ describe "Lexer" do
 
   it_lexes_number :u64, ["0xFFFF_u64", "65535"]
 
-  it_lexes_i32 [["0123", "83"], ["-0123", "-83"], ["+0123", "+83"]]
   it_lexes_i32 [["0o123", "83"], ["-0o123", "-83"], ["+0o123", "+83"]]
   it_lexes_f64 [["0.5", "0.5"], ["+0.5", "+0.5"], ["-0.5", "-0.5"]]
-  it_lexes_i64 [["0123_i64", "83"], ["0o123_i64", "83"], ["0x1_i64", "1"], ["0b1_i64", "1"]]
+  it_lexes_i64 [["0o123_i64", "83"], ["0x1_i64", "1"], ["0b1_i64", "1"]]
 
   it_lexes_i64 ["2147483648", "-2147483649", "-9223372036854775808"]
   it_lexes_i64 [["2147483648.foo", "2147483648"]]
@@ -201,6 +200,10 @@ describe "Lexer" do
 
   it_lexes_number :i32, ["+0", "+0"]
   it_lexes_number :i32, ["-0", "-0"]
+
+  it_lexes_number :i32, ["0", "0"]
+  it_lexes_number :i32, ["0_i32", "0"]
+  it_lexes_number :i8, ["0i8", "0"]
 
   it_lexes_char "'a'", 'a'
   it_lexes_char "'\\b'", 8.chr
@@ -263,9 +266,12 @@ describe "Lexer" do
   assert_syntax_error "18446744073709551616", "18446744073709551616 doesn't fit in an UInt64"
 
   assert_syntax_error "0xFF_i8", "255 doesn't fit in an Int8"
-  assert_syntax_error "0200_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "0o200_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "0b10000000_i8", "128 doesn't fit in an Int8"
+
+  assert_syntax_error "0123", "octal constants should be prefixed with 0o"
+  assert_syntax_error "00", "octal constants should be prefixed with 0o"
+  assert_syntax_error "01_i64", "octal constants should be prefixed with 0o"
 
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -15,7 +15,7 @@ describe "Dir" do
 
   it "tests mkdir and rmdir with a new path" do
     path = "/tmp/crystal_mkdir_test_#{Process.pid}/"
-    Dir.mkdir(path, 0700).should eq(0)
+    Dir.mkdir(path, 0o700).should eq(0)
     Dir.exists?(path).should be_true
     Dir.rmdir(path).should eq(0)
     Dir.exists?(path).should be_false
@@ -23,7 +23,7 @@ describe "Dir" do
 
   it "tests mkdir with an existing path" do
     expect_raises Errno do
-      Dir.mkdir(__DIR__, 0700)
+      Dir.mkdir(__DIR__, 0o700)
     end
   end
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1317,7 +1317,6 @@ module Crystal
       when 'x'
         scan_hex_number(start, negative)
       when 'o'
-        next_char
         scan_octal_number(start, negative)
       when 'b'
         scan_bin_number(start, negative)
@@ -1359,7 +1358,11 @@ module Crystal
           scan_number(start)
         end
       else
-        scan_octal_number(start, negative)
+        if next_char.digit?
+          raise "octal constants should be prefixed with 0o"
+        else
+          finish_scan_prefixed_number 0_u64, false, start
+        end
       end
     end
 
@@ -1384,6 +1387,8 @@ module Crystal
     end
 
     def scan_octal_number(start, negative)
+      next_char
+
       num = 0_u64
 
       while true

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -275,14 +275,14 @@ class Dir
     File::Stat.new(stat).directory?
   end
 
-  def self.mkdir(path, mode=0777)
+  def self.mkdir(path, mode=0o777)
     if LibC.mkdir(path, LibC::ModeT.cast(mode)) == -1
       raise Errno.new("Unable to create directory '#{path}'")
     end
     0
   end
 
-  def self.mkdir_p(path, mode=0777)
+  def self.mkdir_p(path, mode=0o777)
     return 0 if Dir.exists?(path)
 
     components = path.split(File::SEPARATOR)

--- a/src/file/stat.cr
+++ b/src/file/stat.cr
@@ -66,17 +66,17 @@ lib LibC
     end
   end
 
-  S_ISVTX  = 0001000
-  S_ISGID  = 0002000
-  S_ISUID  = 0004000
-  S_IFIFO  = 0010000
-  S_IFCHR  = 0020000
-  S_IFDIR  = 0040000
-  S_IFBLK  = 0060000
-  S_IFREG  = 0100000
-  S_IFLNK  = 0120000
-  S_IFSOCK = 0140000
-  S_IFMT   = 0170000
+  S_ISVTX  = 0o001000
+  S_ISGID  = 0o002000
+  S_ISUID  = 0o004000
+  S_IFIFO  = 0o010000
+  S_IFCHR  = 0o020000
+  S_IFDIR  = 0o040000
+  S_IFBLK  = 0o060000
+  S_IFREG  = 0o100000
+  S_IFLNK  = 0o120000
+  S_IFSOCK = 0o140000
+  S_IFMT   = 0o170000
 
   fun stat(path : UInt8*, stat : Stat*) : Int32
   fun lstat(path : UInt8*, stat : Stat *) : Int32

--- a/src/io.cr
+++ b/src/io.cr
@@ -7,13 +7,13 @@ lib LibC
   end
 
   ifdef linux
-    O_RDONLY   = 00000000
-    O_WRONLY   = 00000001
-    O_RDWR     = 00000002
-    O_APPEND   = 00002000
-    O_CREAT    = 00000100
-    O_TRUNC    = 00001000
-    O_NONBLOCK = 00004000
+    O_RDONLY   = 0o0000000
+    O_WRONLY   = 0o0000001
+    O_RDWR     = 0o0000002
+    O_APPEND   = 0o0002000
+    O_CREAT    = 0o0000100
+    O_TRUNC    = 0o0001000
+    O_NONBLOCK = 0o0004000
   elsif darwin
     O_RDONLY   = 0x0000
     O_WRONLY   = 0x0001
@@ -24,18 +24,18 @@ lib LibC
     O_NONBLOCK = 0x0004
   end
 
-  S_IRWXU    = 0000700         # RWX mask for owner
-  S_IRUSR    = 0000400         # R for owner
-  S_IWUSR    = 0000200         # W for owner
-  S_IXUSR    = 0000100         # X for owner
-  S_IRWXG    = 0000070         # RWX mask for group
-  S_IRGRP    = 0000040         # R for group
-  S_IWGRP    = 0000020         # W for group
-  S_IXGRP    = 0000010         # X for group
-  S_IRWXO    = 0000007         # RWX mask for other
-  S_IROTH    = 0000004         # R for other
-  S_IWOTH    = 0000002         # W for other
-  S_IXOTH    = 0000001         # X for other
+  S_IRWXU    = 0o000700         # RWX mask for owner
+  S_IRUSR    = 0o000400         # R for owner
+  S_IWUSR    = 0o000200         # W for owner
+  S_IXUSR    = 0o000100         # X for owner
+  S_IRWXG    = 0o000070         # RWX mask for group
+  S_IRGRP    = 0o000040         # R for group
+  S_IWGRP    = 0o000020         # W for group
+  S_IXGRP    = 0o000010         # X for group
+  S_IRWXO    = 0o000007         # RWX mask for other
+  S_IROTH    = 0o000004         # R for other
+  S_IWOTH    = 0o000002         # W for other
+  S_IXOTH    = 0o000001         # X for other
 
   EWOULDBLOCK = 140
   EAGAIN      = 11

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -21,146 +21,146 @@ lib LibTermios
 
   @[Flags]
   enum IFlag
-#    IGNBRK  = 0000001
-    BRKINT  = 0000002
-#    IGNPAR  = 0000004
-#    PARMRK  = 0000010
-#    INPCK   = 0000020
-    ISTRIP  = 0000040
-#    INLCR   = 0000100
-#    IGNCR   = 0000200
-    ICRNL   = 0000400
-#    IUCLC   = 0001000
-    IXON    = 0002000
-#    IXANY   = 0004000
-#    IXOFF   = 0010000
-#    IMAXBEL = 0020000
-#    IUTF8   = 0040000
+#    IGNBRK  = 0o000001
+    BRKINT  = 0o000002
+#    IGNPAR  = 0o000004
+#    PARMRK  = 0o000010
+#    INPCK   = 0o000020
+    ISTRIP  = 0o000040
+#    INLCR   = 0o000100
+#    IGNCR   = 0o000200
+    ICRNL   = 0o000400
+#    IUCLC   = 0o001000
+    IXON    = 0o002000
+#    IXANY   = 0o004000
+#    IXOFF   = 0o010000
+#    IMAXBEL = 0o020000
+#    IUTF8   = 0o040000
   end
 
   @[Flags]
   enum OFlag
-    OPOST  = 0000001
-#    OLCUC  = 0000002
-#    ONLCR  = 0000004
-#    OCRNL  = 0000010
-#    ONOCR  = 0000020
-#    ONLRET = 0000040
-#    OFILL  = 0000100
-#    OFDEL  = 0000200
+    OPOST  = 0o000001
+#    OLCUC  = 0o000002
+#    ONLCR  = 0o000004
+#    OCRNL  = 0o000010
+#    ONOCR  = 0o000020
+#    ONLRET = 0o000040
+#    OFILL  = 0o000100
+#    OFDEL  = 0o000200
 ##if defined __USE_MISC || defined __USE_XOPEN
-#    NLDLY  = 0000400
-#      NL0  = 0000000
-#      NL1  = 0000400
-#    CRDLY  = 0003000
-#      CR0  = 0000000
-#      CR1  = 0001000
-#      CR2  = 0002000
-#      CR3  = 0003000
-#    TABDLY = 0014000
-#      TAB0 = 0000000
-#      TAB1 = 0004000
-#      TAB2 = 0010000
-#      TAB3 = 0014000
-#    BSDLY  = 0020000
-#      BS0  = 0000000
-#      BS1  = 0020000
-#    FFDLY  = 0100000
-#      FF0  = 0000000
-#      FF1  = 0100000
+#    NLDLY  = 0o000400
+#      NL0  = 0o000000
+#      NL1  = 0o000400
+#    CRDLY  = 0o003000
+#      CR0  = 0o000000
+#      CR1  = 0o001000
+#      CR2  = 0o002000
+#      CR3  = 0o003000
+#    TABDLY = 0o014000
+#      TAB0 = 0o000000
+#      TAB1 = 0o004000
+#      TAB2 = 0o010000
+#      TAB3 = 0o014000
+#    BSDLY  = 0o020000
+#      BS0  = 0o000000
+#      BS1  = 0o020000
+#    FFDLY  = 0o100000
+#      FF0  = 0o000000
+#      FF1  = 0o100000
 ##endif
-#    VTDLY  = 0040000
-#      VT0  = 0000000
-#      VT1  = 0040000
+#    VTDLY  = 0o040000
+#      VT0  = 0o000000
+#      VT1  = 0o040000
 ##ifdef __USE_MISC
-#    XTABS  = 0014000
+#    XTABS  = 0o014000
 ##endif
   end
 
 #  enum CFlag
 ##ifdef __USE_MISC
-#    CBAUD  = 0010017
+#    CBAUD  = 0o010017
 ##endif
-#    B0     = 0000000     # hang up
-#    B50    = 0000001
-#    B75    = 0000002
-#    B110   = 0000003
-#    B134   = 0000004
-#    B150   = 0000005
-#    B200   = 0000006
-#    B300   = 0000007
-#    B600   = 0000010
-#    B1200  = 0000011
-#    B1800  = 0000012
-#    B2400  = 0000013
-#    B4800  = 0000014
-#    B9600  = 0000015
-#    B19200 = 0000016
-#    B38400 = 0000017
+#    B0     = 0o000000     # hang up
+#    B50    = 0o000001
+#    B75    = 0o000002
+#    B110   = 0o000003
+#    B134   = 0o000004
+#    B150   = 0o000005
+#    B200   = 0o000006
+#    B300   = 0o000007
+#    B600   = 0o000010
+#    B1200  = 0o000011
+#    B1800  = 0o000012
+#    B2400  = 0o000013
+#    B4800  = 0o000014
+#    B9600  = 0o000015
+#    B19200 = 0o000016
+#    B38400 = 0o000017
 ##ifdef __USE_MISC
 ## define EXTA B19200
 ## define EXTB B38400
 ##endif
-#    CSIZE    = 0000060
-#    CS5      = 0000000
-#    CS6      = 0000020
-#    CS7      = 0000040
-#    CS8      = 0000060
-#    CSTOPB   = 0000100
-#    CREAD    = 0000200
-#    PARENB   = 0000400
-#    PARODD   = 0001000
-#    HUPCL    = 0002000
-#    CLOCAL   = 0004000
+#    CSIZE    = 0o000060
+#    CS5      = 0o000000
+#    CS6      = 0o000020
+#    CS7      = 0o000040
+#    CS8      = 0o000060
+#    CSTOPB   = 0o000100
+#    CREAD    = 0o000200
+#    PARENB   = 0o000400
+#    PARODD   = 0o001000
+#    HUPCL    = 0o002000
+#    CLOCAL   = 0o004000
 ##ifdef __USE_MISC
-#    CBAUDEX  = 0010000
+#    CBAUDEX  = 0o010000
 ##endif
-#    B57600   = 0010001
-#    B115200  = 0010002
-#    B230400  = 0010003
-#    B460800  = 0010004
-#    B500000  = 0010005
-#    B576000  = 0010006
-#    B921600  = 0010007
-#    B1000000 = 0010010
-#    B1152000 = 0010011
-#    B1500000 = 0010012
-#    B2000000 = 0010013
-#    B2500000 = 0010014
-#    B3000000 = 0010015
-#    B3500000 = 0010016
-#    B4000000 = 0010017
+#    B57600   = 0o010001
+#    B115200  = 0o010002
+#    B230400  = 0o010003
+#    B460800  = 0o010004
+#    B500000  = 0o010005
+#    B576000  = 0o010006
+#    B921600  = 0o010007
+#    B1000000 = 0o010010
+#    B1152000 = 0o010011
+#    B1500000 = 0o010012
+#    B2000000 = 0o010013
+#    B2500000 = 0o010014
+#    B3000000 = 0o010015
+#    B3500000 = 0o010016
+#    B4000000 = 0o010017
 ##define __MAX_BAUD B4000000
 ##ifdef __USE_MISC
-#    CIBAUD   = 002003600000     # input baud rate (not used)
-#    CMSPAR   = 010000000000     # mark or space (stick) parity
-#    CRTSCTS  = 020000000000     # flow control
+#    CIBAUD   = 0o02003600000     # input baud rate (not used)
+#    CMSPAR   = 0o10000000000     # mark or space (stick) parity
+#    CRTSCTS  = 0o20000000000     # flow control
 ##endif
 #  end
 
   @[Flags]
   enum LFlag
-    ISIG    = 0000001
-    ICANON  = 0000002
+    ISIG    = 0o000001
+    ICANON  = 0o000002
 ##if defined __USE_MISC || defined __USE_XOPEN
-#    XCASE   = 0000004
+#    XCASE   = 0o000004
 ##endif
-    ECHO    = 0000010
-    ECHOE   = 0000020
-    ECHOK   = 0000040
-    ECHONL  = 0000100
-#    NOFLSH  = 0000200
-#    TOSTOP  = 0000400
+    ECHO    = 0o000010
+    ECHOE   = 0o000020
+    ECHOK   = 0o000040
+    ECHONL  = 0o000100
+#    NOFLSH  = 0o000200
+#    TOSTOP  = 0o000400
 ##ifdef __USE_MISC
-#    ECHOCTL = 0001000
-#    ECHOPRT = 0002000
-#    ECHOKE  = 0004000
-#    FLUSHO  = 0010000
-#    PENDIN  = 0040000
+#    ECHOCTL = 0o001000
+#    ECHOPRT = 0o002000
+#    ECHOKE  = 0o004000
+#    FLUSHO  = 0o010000
+#    PENDIN  = 0o040000
 ##endif
-    IEXTEN  = 0100000
+    IEXTEN  = 0o100000
 #ifdef __USE_BSD
-    EXTPROC = 0200000
+    EXTPROC = 0o200000
 #endif
 
   end


### PR DESCRIPTION
This PR needs a new release of Crystal before merging (the compiler can be built with current HEAD, but not using 0.7.3).

This PR simply converts all constants in the standard library to use the `0o` octal prefix and causes old `0700` style octal constants to cause an error. It updates the specs appropriately and adds a few new ones to double check the `0` case. Once merged, this should fix issue #740.

[Travis failure is expected, as Travis is not building using current crystal HEAD]