### PR TITLE
Fix typos in docs

### DIFF
--- a/_gitbook/syntax_and_semantics/blocks_and_procs.md
+++ b/_gitbook/syntax_and_semantics/blocks_and_procs.md
@@ -216,7 +216,7 @@ end
 value #:: Int32 | String
 ```
 
-If a `break` receives many arguments, they are automaticaly transformed to a [Tuple](http://crystal-lang.org/api/Tuple.html):
+If a `break` receives many arguments, they are automatically transformed to a [Tuple](http://crystal-lang.org/api/Tuple.html):
 
 ```ruby
 values = twice { break 1, 2 }
@@ -232,7 +232,7 @@ value #=> nil
 
 ## next
 
-The `next` expression inside a block exists early from the block (not the method). For example:
+The `next` expression inside a block exits early from the block (not the method). For example:
 
 ```ruby
 def twice

--- a/_gitbook/syntax_and_semantics/constants.md
+++ b/_gitbook/syntax_and_semantics/constants.md
@@ -29,4 +29,4 @@ end
 TEN #=> 10
 ```
 
-If a constant is not used its initializer is never included in the final executable.
+If a constant is not used, its initializer is never included in the final executable.

--- a/_gitbook/syntax_and_semantics/generics.md
+++ b/_gitbook/syntax_and_semantics/generics.md
@@ -1,6 +1,6 @@
 # Generics
 
-Instance variables' types are inferred from the values assigned to them, like it was explained in [instance varaibles type inference](instance_variables_type_inference.html):
+Instance variables' types are inferred from the values assigned to them, like it was explained in [instance variables type inference](instance_variables_type_inference.html):
 
 ```ruby
 class MyBox

--- a/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
+++ b/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
@@ -28,7 +28,7 @@ one.name #=> 1
 one.name + 2 #=> 3
 ```
 
-If you compile the previous programs with `--hierarchy`, the compiler will show you a hierarchy graph with the types it inferred. In the first case:
+If you compile the previous programs with the `hierarchy` command, the compiler will show you a hierarchy graph with the types it inferred. In the first case:
 
 ```
 - class Object
@@ -59,7 +59,7 @@ john = Person.new "John"
 one = Person.new 1
 ```
 
-Inovking the compiler with `--hierarchy` we get:
+Invoking the compiler with the `hierarchy` command we get:
 
 ```
 - class Object

--- a/_gitbook/syntax_and_semantics/is_a.md
+++ b/_gitbook/syntax_and_semantics/is_a.md
@@ -1,6 +1,6 @@
 # is_a?
 
-The pseudo-method `is_a?` determines wether a type inherits or includes another type. For example:
+The pseudo-method `is_a?` determines whether a type inherits or includes another type. For example:
 
 ```ruby
 a = 1
@@ -10,4 +10,4 @@ a.is_a?(Number)         #=> true
 a.is_a?(Int32 | String) #=> true
 ```
 
-It is a pseudo-method because the compiler knows about it and it can affect type information, as explained in [if var.is_a?(...)](if_varis_a.html). Also, it acceps a [type](type_grammar.html) that must be known at compile-time as its argument.
+It is a pseudo-method because the compiler knows about it and it can affect type information, as explained in [if var.is_a?(...)](if_varis_a.html). Also, it accepts a [type](type_grammar.html) that must be known at compile-time as its argument.

--- a/_gitbook/syntax_and_semantics/literals/string.md
+++ b/_gitbook/syntax_and_semantics/literals/string.md
@@ -60,7 +60,7 @@ by joining multiple literals with a backslash:
 "no newlines" # same as "hello world, no newlines"
 ```
 
-Alterantively, a backlash followed by a newline can be inserted inside the string literal:
+Alternatively, a backlash followed by a newline can be inserted inside the string literal:
 
 ```ruby
 "hello \

--- a/_gitbook/syntax_and_semantics/responds_to.md
+++ b/_gitbook/syntax_and_semantics/responds_to.md
@@ -1,6 +1,6 @@
 # responds_to?
 
-The pseudo-method `responds_to?` determines wether a type has a method with the given name. For example:
+The pseudo-method `responds_to?` determines whether a type has a method with the given name. For example:
 
 ```ruby
 a = 1

--- a/_gitbook/syntax_and_semantics/type_restrictions.md
+++ b/_gitbook/syntax_and_semantics/type_restrictions.md
@@ -72,7 +72,7 @@ In the previous example `self` is the same as writing `Person`. But, in general,
 
 As a side note, since `Person` inherits `Reference` the second definition of `==` is not needed, since it's already defined in `Reference`.
 
-Note that `self` always represents a match against and instance type, even in class methods:
+Note that `self` always represents a match against an instance type, even in class methods:
 
 ``` ruby
 class Person

--- a/_gitbook/syntax_and_semantics/virtual_and_abstract_types.md
+++ b/_gitbook/syntax_and_semantics/virtual_and_abstract_types.md
@@ -29,7 +29,7 @@ john = Person.new "John", Dog.new
 peter = Person.new "Peter", Cat.new
 ```
 
-If you compile the above program with `--hierarchy` you will see this for `Person`:
+If you compile the above program with the `hierarchy` command you will see this for `Person`:
 
 ```
 - class Object

--- a/_gitbook/syntax_and_semantics/visibility.md
+++ b/_gitbook/syntax_and_semantics/visibility.md
@@ -94,4 +94,4 @@ require "./one"
 greet # undefined local variable or method 'greet'
 ```
 
-This allows you to define helper methods in a file that will only be konwn in that file.
+This allows you to define helper methods in a file that will only be known in that file.


### PR DESCRIPTION
---

The second one is a typo right? Unless I misunderstood something.

PS - I did `rake build`, but that ended up additionally changing all the timestamps of the generated book, which I'm pretty sure you don't want? So I'm assuming you will have to rebuild the book yourself?