### PR TITLE
Allow for spaces before the closing tag of a heredoc

### DIFF
--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -147,7 +147,7 @@ describe "Lexer string" do
   end
 
   it "lexes heredoc" do
-    string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK.\n  HERE\nHERESY"
+    string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK.\n  HERESY"
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE")
     tester = LexerObjects::Strings.new(lexer)
 
@@ -163,17 +163,25 @@ describe "Lexer string" do
     tester.should_have_reached_eof
   end
 
+  it "lexes heredoc with spaces before close tag" do
+    lexer = Lexer.new("<<-XML\nfoo\n   XML")
+    tester = LexerObjects::Strings.new(lexer)
+
+    tester.next_token_should_be(:STRING, "foo")
+    tester.should_have_reached_eof
+  end
+
   it "assigns correct location after heredoc (#346)" do
-    string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK.\n  HERE"
+    string = "Hello, mom! I am HERE.\nHER dress is beatiful.\nHE is OK."
     lexer = Lexer.new("<<-HERE\n#{string}\nHERE\n1")
     tester = LexerObjects::Strings.new(lexer)
 
     tester.next_token_should_be(:STRING, string)
     tester.token_should_be_at(line: 1, column: 1)
     tester.next_token_should_be(:NEWLINE)
-    tester.token_should_be_at(line: 6, column: 5)
+    tester.token_should_be_at(line: 5, column: 5)
     tester.next_token_should_be(:NUMBER)
-    tester.token_should_be_at(line: 7, column: 1)
+    tester.token_should_be_at(line: 6, column: 1)
     tester.should_have_reached_eof
   end
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -155,6 +155,14 @@ module Crystal
 
                 here_end = current_pos
                 is_here  = false
+                while true
+                  char = peek_next_char
+                  if char != ' '
+                    break
+                  else
+                    next_char
+                  end
+                end
                 here.each_char do |c|
                   char = next_char
                   unless char == c


### PR DESCRIPTION
This allows you to write heredocs that look better, especially when you
don't care about spaces in the begging of the lines, for example:

```crystal
def some_method
  here = <<-HTML
    <div>
      <h1>Text</h1>
    </div>
  HTML
end
```

It also makes heredocs in Crystal behave the same way as in Ruby,
leading to less surprises to people coming from that community.