### PR TITLE
more correct regex for github repo validation

### DIFF
--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -6,7 +6,7 @@ module Crystal
     getter target_dir
 
     def initialize(repo, name = nil : String?, ssh = false, branch = nil : String?)
-      unless repo =~ /^([^\/]*)\/([^\/]*)$/
+      unless repo =~ /(\A[^\s\/]+)\/([^\s\/]+\z)/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end
 

--- a/src/crystal/project/github_dependency.cr
+++ b/src/crystal/project/github_dependency.cr
@@ -6,7 +6,7 @@ module Crystal
     getter target_dir
 
     def initialize(repo, name = nil : String?, ssh = false, branch = nil : String?)
-      unless repo =~ /(.*)\/(.*)/
+      unless repo =~ /^([^\/]*)\/([^\/]*)$/
         raise ProjectError.new("Invalid GitHub repository definition: #{repo}")
       end
 


### PR DESCRIPTION
the old regex would recognize foo/bar/baz as valid repository as
slashes are arbitrary characters in the sense of the dot-symbol.
this new regex allows only one slash in the repo-string.
additionally i limited the regex to match line begin and ending,
otherwise foo/bar/baz would still pass as the regex matches the
foo/bar-portion of the string.