### PR TITLE
Add named groups in MatchData#to_s

### DIFF
--- a/spec/std/regexp_spec.cr
+++ b/spec/std/regexp_spec.cr
@@ -26,6 +26,17 @@ describe "Regex" do
     expect_raises(IndexOutOfBounds) { $1 }
   end
 
+  describe "name_table" do
+    it "is a map of capture group number to name" do
+      table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table
+      table[1].should eq("date")
+      table[2].should eq("year")
+      table[3]?.should be_nil
+      table[4].should eq("month")
+      table[5].should eq("day")
+    end
+  end
+
   describe "MatchData#[]" do
     it "raises if outside match range with []" do
       "foo" =~ /foo/

--- a/spec/std/regexp_spec.cr
+++ b/spec/std/regexp_spec.cr
@@ -98,6 +98,7 @@ describe "Regex" do
     /foo/imx.to_s.should eq("/foo/imx")
 
     /f(o)(x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" lettero:"o" letterx:"x">))
     /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
     /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
     /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -6,10 +6,13 @@ lib LibPCRE
   fun study = pcre_study(code : Pcre, options : Int32, errptr : UInt8**) : PcreExtra
   fun exec = pcre_exec(code : Pcre, extra : PcreExtra, subject : UInt8*, length : Int32, offset : Int32, options : Int32,
                 ovector : Int32*, ovecsize : Int32) : Int32
-  fun full_info = pcre_fullinfo(code : Pcre, extra : Void*, what : Int32, where : Int32*) : Int32
+  fun full_info = pcre_fullinfo(code : Pcre, extra : PcreExtra, what : Int32, where : Int32*) : Int32
   fun get_named_substring = pcre_get_named_substring(code : Pcre, subject : UInt8*, ovector : Int32*, string_count : Int32, string_name : UInt8*, string_ptr : UInt8**) : Int32
 
-  INFO_CAPTURECOUNT = 2
+  INFO_CAPTURECOUNT  = 2
+  INFO_NAMEENTRYSIZE = 7
+  INFO_NAMECOUNT     = 8
+  INFO_NAMETABLE     = 9
 
   $pcre_malloc : (UInt32 -> Void*)
   $pcre_free : (Void* ->)

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -57,13 +57,16 @@ class MatchData
   end
 
   def to_s(io : IO)
+    name_table = @regex.name_table
+
     io << "#<MatchData "
     self[0].inspect(io)
     if length > 0
       io << " "
       length.times do |i|
         io << " " if i > 0
-        io << (i + 1) << ":"
+        io << name_table.fetch(i + 1) { i + 1 }
+        io << ":"
         self[i + 1].inspect(io)
       end
     end

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -29,6 +29,28 @@ class Regex
     new source, Options.new(options)
   end
 
+  def name_table
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMECOUNT,     out name_count)
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMEENTRYSIZE, out name_entry_size)
+    table_pointer = Pointer(UInt8).null
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMETABLE, pointerof(table_pointer) as Pointer(Int32))
+    name_table = table_pointer.to_slice(name_entry_size*name_count)
+
+    lookup = Hash(UInt16,String).new
+
+    name_count.times do |i|
+      capture_offset = i * name_entry_size
+      capture_number = (name_table[capture_offset].to_u16 << 8) | name_table[capture_offset+1].to_u16
+
+      name_offset = capture_offset + 2
+      name = String.new( (name_table + name_offset).pointer(name_entry_size-3) )
+
+      lookup[capture_number] = name
+    end
+
+    lookup
+  end
+
   def options
     @options
   end


### PR DESCRIPTION
I was finding it difficult to debug a large regular expression that had named groups. This patch will hopefully help with that.

given 
``` crystal
reg = /(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x
p reg.match "1919-12-14"
```

current: 
`#<MatchData "1919-12-14" 1:"1919-12-14" 2:"1919" 3:"19" 4:"12" 5:"14">`

with patch:
`#<MatchData "1919-12-14" date:"1919-12-14" year:"1919" 3:"19" month:"12" day:"14">`
