### PR TITLE
Add root option to json_mapping fields

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -69,6 +69,12 @@ class JSONWithAny
   json_mapping({name: String, any: JSON::Any})
 end
 
+class JSONResult
+  json_mapping({
+    result: {type: Array(JSONPerson), root: "heroes"}
+  })
+end
+
 describe "JSON mapping" do
   it "parses person" do
     person = JSONPerson.from_json(%({"name": "John", "age": 30}))
@@ -171,5 +177,13 @@ describe "JSON mapping" do
     json.name.should eq("Hi")
     json.any.should eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
     json.to_json.should eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
+  end
+
+  it "parses with root key" do
+    json = %({"result":{"heroes":[{"name":"Batman"}]}})
+    result = JSONResult.from_json(json)
+    result.result.should be_a(Array(JSONPerson))
+    result.result.first.name.should eq "Batman"
+    result.to_json.should eq(json)
   end
 end

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -23,13 +23,31 @@ class Object
         case _key
         {% for key, value in properties %}
           when {{value[:key] || key.id.stringify}}
-            _{{key.id}} =
+            {% unless value[:root] %} _{{key.id}} = {% end %}
             {% if value[:nilable] == true %} _pull.read_null_or { {% end %}
+
+            {% if value[:root] %}
+              _pull.read_object do |_nested_key|
+                case _nested_key
+                when  {{value[:root]}}
+                  _{{key.id}} =
+            {% end %}
 
             {% if value[:converter] %}
               {{value[:converter]}}.from_json(_pull)
             {% else %}
               {{value[:type]}}.new(_pull)
+            {% end %}
+
+            {% if value[:root] %}
+                else
+                  {% if strict %}
+                    raise JSON::ParseException.new("unknown json attribute: #{_nested_key}", 0, 0)
+                  {% else %}
+                    _pull.skip
+                  {% end %}
+                end
+              end
             {% end %}
 
             {% if value[:nilable] == true %} } {% end %}
@@ -66,6 +84,10 @@ class Object
           {% end %}
 
             json.field({{value[:key] || key.id.stringify}}) do
+              {% if value[:root] %}
+                io.json_object do |json|
+                  json.field({{value[:root]}}) do
+              {% end %}
               {% if value[:converter] %}
                 if _{{key.id}}
                   {{ value[:converter] }}.to_json(_{{key.id}}, io)
@@ -74,6 +96,10 @@ class Object
                 end
               {% else %}
                 _{{key.id}}.to_json(io)
+              {% end %}
+              {% if value[:root] %}
+                  end
+                end
               {% end %}
             end
 


### PR DESCRIPTION
This allows to avoid useless intermediate objects for common json
structures. `{"foo": {"bar": ["baz"]}}` can be parsed with

```cr
class Foo
  json_mapping({foo: {type: Array(Bar), root: "bar"}})
end
```

instead of

```cr
class BarCollection
  json_mapping({bar: Array(Bar)})
end

class Foo
  json_mapping({foo: BarCollection})
end
```