### PR TITLE
Non-matching captures return nil instead of empty string 

### DIFF
--- a/spec/std/regexp_spec.cr
+++ b/spec/std/regexp_spec.cr
@@ -49,9 +49,16 @@ describe "Regex" do
       $~["g2"].should eq("ba")
     end
 
-    it "capture empty group" do
-      ("foo" =~ /(?<g1>.*)foo/).should eq(0)
+    it "captures empty group" do
+      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
+      $~[1].should eq("")
       $~["g1"].should eq("")
+    end
+
+    it "raises exception on optional empty group" do
+      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
+      expect_raises(Exception) { $~[1] }
+      expect_raises(Exception) { $~["g1"] }
     end
 
     it "raises exception when named group doesn't exist" do
@@ -73,8 +80,15 @@ describe "Regex" do
     end
 
     it "capture empty group" do
-      ("foo" =~ /(?<g1>.*)foo/).should eq(0)
+      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
+      $~[1]?.should eq("")
       $~["g1"]?.should eq("")
+    end
+
+    it "capture optional empty group" do
+      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
+      $~[1]?.should be_nil
+      $~["g1"]?.should be_nil
     end
 
     it "returns nil exception when named group doesn't exist" do
@@ -101,6 +115,7 @@ describe "Regex" do
     /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" lettero:"o" letterx:"x">))
     /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
     /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    /f(o)(x)?/.match("the fort").inspect.should eq(%(#<MatchData "fo" 1:"o" 2:nil>))
     /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))
   end
 

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -7,7 +7,7 @@ lib LibPCRE
   fun exec = pcre_exec(code : Pcre, extra : PcreExtra, subject : UInt8*, length : Int32, offset : Int32, options : Int32,
                 ovector : Int32*, ovecsize : Int32) : Int32
   fun full_info = pcre_fullinfo(code : Pcre, extra : PcreExtra, what : Int32, where : Int32*) : Int32
-  fun get_named_substring = pcre_get_named_substring(code : Pcre, subject : UInt8*, ovector : Int32*, string_count : Int32, string_name : UInt8*, string_ptr : UInt8**) : Int32
+  fun get_stringnumber = pcre_get_stringnumber(code : Pcre, string_name : UInt8*) : Int32
 
   INFO_CAPTURECOUNT  = 2
   INFO_NAMEENTRYSIZE = 7

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -29,6 +29,7 @@ class MatchData
 
     start = @ovector[n * 2]
     finish = @ovector[n * 2 + 1]
+    return if start < 0
     @string.byte_slice(start, finish - start)
   end
 
@@ -39,9 +40,9 @@ class MatchData
   end
 
   def []?(group_name : String)
-    ret = LibPCRE.get_named_substring(@code, @string, @ovector, @length + 1, group_name, out value)
+    ret = LibPCRE.get_stringnumber(@code, group_name)
     return if ret < 0
-    String.new(value)
+    self[ret]?
   end
 
   def [](group_name : String)
@@ -67,7 +68,7 @@ class MatchData
         io << " " if i > 0
         io << name_table.fetch(i + 1) { i + 1 }
         io << ":"
-        self[i + 1].inspect(io)
+        self[i + 1]?.inspect(io)
       end
     end
     io << ">"

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -39,11 +39,12 @@ class URI
   def self.parse(string : String)
     case string
     when /\A(?<scheme>.*):\/\/(?<host>[^:\/\?]*)(:(?<port>\d*))?(?<path>\/[^?]*)?(\?(?<qs>.*))?\Z/
-      scheme = $1
-      host = $2
-      port = $4.empty? ? nil : $4.to_i
-      path = $5.empty? ? nil : $5
-      query = $7.empty? ? nil : $7
+      m = $~
+      scheme = m[1]
+      host = m[2]
+      port = m[4]?.try(&.to_i)
+      path = m[5]?
+      query = m[7]?
     else
       if question_index = string.index '?'
         path = string[0 ... question_index]


### PR DESCRIPTION
This is a breaking change, but brings the API in line with similar regular expression APIs.

Before:

    /f(o)(x?)/.match("the fort") #=> #<MatchData "fo" 1:"o" 2:"">
    /f(o)(x)?/.match("the fort") #=> #<MatchData "fo" 1:"o" 2:"">

After:

    /f(o)(x?)/.match("the fort") #=> #<MatchData "fo" 1:"o" 2:"">
    /f(o)(x)?/.match("the fort") #=> #<MatchData "fo" 1:"o" 2:nil>