### PR TITLE
Fix bad assumption in TCPSocket.new test

### DIFF
--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -89,7 +89,7 @@ describe "TCPSocket" do
   end
 
   it "fails when host doesn't exist" do
-    expect_raises(SocketError, /^getaddrinfo: .+ not known$/) do
+    expect_raises(SocketError, /^getaddrinfo: (.+ not known|no address .+)$/i) do
       TCPSocket.new("localhostttttt", 12345)
     end
   end


### PR DESCRIPTION
The test assumes that the error message contains the string "not known"
but on my x86_64 FC21 box, the message is ""getaddrinfo: No address
associated with hostname".  Update the test accordingly.