### PR TITLE
Fixed quoted cell not appending comma if cell is first in row.

### DIFF
--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -21,23 +21,30 @@ class CSV::Builder
     row values
   end
 
-  def cell
-    @io << "," unless @first_cell_in_row
-    yield @io
+  def append_cell(io, block)
+    io << "," unless @first_cell_in_row
+    block.call(io)
     @first_cell_in_row = false
   end
 
+  def cell(io, &block)
+    append_cell(@io, block)
+  end
+
   def quote_cell(value)
-    @io << '"'
-    value.each_byte do |byte|
-      case byte
-      when '"'.ord
-        @io << %("")
-      else
-        @io.write_byte byte
+    block = ->(io : IO) {
+      io << '"'
+      value.each_byte do |byte|
+        case byte
+        when '"'.ord
+          @io << %("")
+        else
+          io.write_byte byte
+        end
       end
-    end
-    @io << '"'
+      io << '"'
+    }
+    append_cell(@io, block)
   end
 
   struct Row


### PR DESCRIPTION
I encountered a bug where a cell with a comma would be correctly quoted but the delimiter comma was omitted if it was the first cell in the row. I wrote a fix and it appears to be working but it needs a review. I saw the specs but wasn't familiar with them enough to add anything (are they the unit tests/equivalent?). I can add the tests I had to them if required.