### PR TITLE
Make .crystal directory location configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install: |
   esac
   export PATH=/tmp/llvm-3.5.0-1/bin:$PATH
   export CRYSTAL_CONFIG_VERSION=ci
+  export CRYSTAL_CACHE_DIR=/tmp/crystal
 script:
   - make crystal spec
   - find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-build

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -1,7 +1,7 @@
 module Crystal
   def self.tempfile(basename)
-    Dir.mkdir_p ".crystal"
-    ".crystal/crystal-run-#{basename}.tmp"
+    Dir.mkdir_p Config.cache_dir
+    File.join(Config.cache_dir, "crystal-run-#{basename}.tmp")
   end
 end
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -143,7 +143,7 @@ module Crystal
       if @cross_compile_flags
         output_dir = "."
       else
-        output_dir = ".crystal/#{sources.first.filename}"
+        output_dir = File.join(Config.cache_dir, sources.first.filename)
       end
 
       Dir.mkdir_p(output_dir)

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -2,5 +2,10 @@ module Crystal
   module Config
     PATH = {{ env("CRYSTAL_CONFIG_PATH") || "" }}
     VERSION = {{ env("CRYSTAL_CONFIG_VERSION") || `(git describe --tags --long 2>/dev/null)`.stringify.chomp }}
+    CACHE_DIR = ENV["CRYSTAL_CACHE_DIR"]? || ".crystal"
+
+    def self.cache_dir
+      @@cache_dir ||= File.expand_path(CACHE_DIR)
+    end
   end
 end


### PR DESCRIPTION
* Default behaviour unchanged
* Allows to not clutter stuff up with .crystal directories wherever you happen to run `crystal eval`
* No conflicts, generated files are already namespaced by their full path
* Potential reusage of temporary files after changing the current working directory and compiling the same file again
* *Slight* speedup by setting the location to somewhere in /tmp
* If we later decide to put the default location into /tmp/crystal, ~/.crystal or whatever, if available, there's now a central place to implement that logic.