### PR TITLE
Add link to API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site
 .bundle
 _book
+tmp
+.build

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,6 +15,11 @@
           <i class='ic bookmark'></i>
         </a>
       </li>
+      <li>
+        <a href='/api' title='API Reference'>
+          <i class='ic download'></i>
+        </a>
+      </li>
     </ul>
   </nav>
   <!-- %a.ico{:href => "#"} -->


### PR DESCRIPTION
Use the download icon because it's there and not being used as far as I
can tell