### PR TITLE
Add Array#transpose

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1023,8 +1023,8 @@ describe "Array" do
     end
 
     it "raises IndexError error when length of element is invalid" do
-      expect_raises(IndexError){ [[1], [1, 2]].transpose }
-      expect_raises(IndexError){ [[1, 2], [1]].transpose }
+      expect_raises(IndexOutOfBounds){ [[1], [1, 2]].transpose }
+      expect_raises(IndexOutOfBounds){ [[1, 2], [1]].transpose }
     end
   end
 end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1015,6 +1015,15 @@ describe "Array" do
       [[:a]].transpose.should eq([[:a]])
     end
 
+    it "transposes union of arrays" do
+      [[1, 2], [1.0, 2.0]].transpose.should eq([[1, 1.0], [2, 2.0]])
+      [[1, 2.0], [1, 2.0]].transpose.should eq([[1, 1], [2.0, 2.0]])
+      [[1, 1.0], ['a', "aaa"]].transpose.should eq([[1, 'a'], [1.0, "aaa"]])
+
+      typeof([[1.0], [1]].transpose).should eq(Array(Array(Int32 | Float64)))
+      typeof([[1, 1.0], ['a', "aaa"]].transpose).should eq(Array(Array(String | Int32 | Float64 | Char)))
+    end
+
     it "transposes empty array" do
       e = [] of Array(Int32)
       e.transpose.empty?.should be_true

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1007,4 +1007,24 @@ describe "Array" do
       [1, 2, 3].cycle(2).to_a.should eq([1, 2, 3, 1, 2, 3])
     end
   end
+
+  describe "transpose" do
+    it "transeposes elements" do
+      [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])
+      [[:a, :c, :e], [:b, :d, :f]].transpose.should eq([[:a, :b], [:c, :d], [:e, :f]])
+      [[:a]].transpose.should eq([[:a]])
+    end
+
+    it "transposes empty array" do
+      e = [] of Array(Int32)
+      e.transpose.empty?.should be_true
+      [e].transpose.empty?.should be_true
+      [e, e, e].transpose.empty?.should be_true
+    end
+
+    it "raises IndexError error when length of element is invalid" do
+      expect_raises(IndexError){ [[1], [1, 2]].transpose }
+      expect_raises(IndexError){ [[1, 2], [1]].transpose }
+    end
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -908,7 +908,7 @@ class Array(T)
     len = at(0).length
     (1...@length).each do |i|
       l = at(i).length
-      raise IndexError.new(l, len) if len != l
+      raise IndexOutOfBounds.new if len != l
     end
 
     Array(T).new(len) do |i|

--- a/src/array.cr
+++ b/src/array.cr
@@ -895,6 +895,29 @@ class Array(T)
     @buffer
   end
 
+  # Assumes that `self` is an array of array and transposes the rows and columns.
+  #
+  # ```
+  # a = [[:a, :b], [:c, :d], [:e, :f]]
+  # a.transpose   # => [[:a, :c, :e], [:b, :d, :f]]
+  # a             # => [[:a, :b], [:c, :d], [:e, :f]]
+  # ```
+  def transpose
+    return Array(T).new if empty?
+
+    len = at(0).length
+    (1...@length).each do |i|
+      l = at(i).length
+      raise IndexError.new(l, len) if len != l
+    end
+
+    Array(T).new(len) do |i|
+      a = T.new(@length) do |j|
+        at(j).at(i)
+      end
+    end
+  end
+
   # Returns a new array by removing duplicate values in `self`.
   #
   # ```

--- a/src/array.cr
+++ b/src/array.cr
@@ -903,7 +903,7 @@ class Array(T)
   # a             # => [[:a, :b], [:c, :d], [:e, :f]]
   # ```
   def transpose
-    return Array(T).new if empty?
+    return Array(Array(typeof(first.first))).new if empty?
 
     len = at(0).length
     (1...@length).each do |i|
@@ -911,8 +911,8 @@ class Array(T)
       raise IndexOutOfBounds.new if len != l
     end
 
-    Array(T).new(len) do |i|
-      a = T.new(@length) do |j|
+    Array(Array(typeof(first.first))).new(len) do |i|
+      Array(typeof(first.first)).new(@length) do |j|
         at(j).at(i)
       end
     end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -146,9 +146,3 @@ class DivisionByZero < Exception
     super(message)
   end
 end
-
-class IndexError < Exception
-  def initialize(n, m)
-    super("Element size differs (#{n} should be #{m})")
-  end
-end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -146,3 +146,9 @@ class DivisionByZero < Exception
     super(message)
   end
 end
+
+class IndexError < Exception
+  def initialize(n, m)
+    super("Element size differs (#{n} should be #{m})")
+  end
+end


### PR DESCRIPTION
It assumes that `self` is an array of array and transposes the rows and columns.

```crystal
  a = [[:a, :b], [:c, :d], [:e, :f]]
  a.transpose   # => [[:a, :c, :e], [:b, :d, :f]]
  a             # => [[:a, :b], [:c, :d], [:e, :f]]
```

I have some questions for this implementation.

1. Should I use an exception which already exists?  I created new exception `IndexError` only for this method following Ruby's `Array#transpose` implementation.
2. Is there any way to check the element is an `Array` at compile time?  Current implementation outputs bad error message when this method is invoked with array of non-array element.

I tested all test cases and they passed with Crystal 0.7.4 on OS X 10.9.5.