### PR TITLE
Declear type of arg hash (Hash#merge!)

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -247,7 +247,7 @@ class Hash(K, V)
     hash
   end
 
-  def merge!(other : Hash)
+  def merge!(other : Hash(K, V))
     other.each do |k, v|
       self[k] = v
     end


### PR DESCRIPTION
This make short error messages.

Ex: if rewrite `spec/std/hash_spec.cr`

```
  it "merges!" do
    h1 = {1 => 2, 3 => 4}
    h2 = {"1 => "5", 2 => 3}
    h3 = h1.merge!(h2)
    h3.object_id.should eq(h1.object_id)
    h3.should eq({1 => 5, 3 => 4, 2 => 3})
  end
```

[Before]

```
Error in ./spec/std/hash_spec.cr:14: instantiating 'describe(String)'

describe "Hash" do
^~~~~~~~

in ./src/spec/dsl.cr:3: instantiating 'Spec::RootContext:Class#describe(String, String, Int32)'

    Spec::RootContext.describe(description.to_s, file, line) do |context|
                      ^~~~~~~~

in ./src/spec/dsl.cr:3: instantiating 'Spec::RootContext:Class#describe(String, String, Int32)'

    Spec::RootContext.describe(description.to_s, file, line) do |context|
                      ^~~~~~~~

in ./spec/std/hash_spec.cr:14: instantiating 'describe(String)'

describe "Hash" do
^~~~~~~~

in ./spec/std/hash_spec.cr:295: instantiating 'it(String)'

  it "merges!" do
  ^~

in ./spec/std/hash_spec.cr:295: instantiating 'it(String)'

  it "merges!" do
  ^~

in ./spec/std/hash_spec.cr:298: instantiating 'Hash(Int32, Int32)#merge!(Hash((String | Int32), (String | Int32)))'

    h3 = h1.merge!(h2)
            ^~~~~~

in ./src/hash.cr:251: instantiating 'Hash((String | Int32), (String | Int32))#each()'

    other.each do |k, v|
          ^~~~

in ./src/hash.cr:251: instantiating 'Hash((String | Int32), (String | Int32))#each()'

    other.each do |k, v|
          ^~~~

in ./src/hash.cr:252: no overload matches 'Hash(Int32, Int32)#[]=' with types (String | Int32), (String | Int32)
Overloads are:
 - Hash(Int32, Int32)#[]=(key : Int32, value : Int32)
Couldn't find overloads for these types:
 - Hash(Int32, Int32)#[]=(key : String, value : String)
 - Hash(Int32, Int32)#[]=(key : String, value : Int32)
 - Hash(Int32, Int32)#[]=(key : Int32, value : String)

      self[k] = v
          ^
```

[After]

```
Error in ./spec/std/hash_spec.cr:14: instantiating 'describe(String)'

describe "Hash" do
^~~~~~~~

in ./src/spec/dsl.cr:3: instantiating 'Spec::RootContext:Class#describe(String, String, Int32)'

    Spec::RootContext.describe(description.to_s, file, line) do |context|
                      ^~~~~~~~

in ./src/spec/dsl.cr:3: instantiating 'Spec::RootContext:Class#describe(String, String, Int32)'

    Spec::RootContext.describe(description.to_s, file, line) do |context|
                      ^~~~~~~~

in ./spec/std/hash_spec.cr:14: instantiating 'describe(String)'

describe "Hash" do
^~~~~~~~

in ./spec/std/hash_spec.cr:295: instantiating 'it(String)'

  it "merges!" do
  ^~

in ./spec/std/hash_spec.cr:295: instantiating 'it(String)'

  it "merges!" do
  ^~

in ./spec/std/hash_spec.cr:298: no overload matches 'Hash(Int32, Int32)#merge!' with types Hash((String | Int32), (String | Int32))
Overloads are:
 - Hash(Int32, Int32)#merge!(other : Hash(K, V))

    h3 = h1.merge!(h2)
```

If we will reimplement `Hash#[]=` to accept other type of key & value, this PR is nonsense.