### PR TITLE
[ci skip] Fix/test desc

### DIFF
--- a/spec/compiler/type_inference/abstract_def_spec.cr
+++ b/spec/compiler/type_inference/abstract_def_spec.cr
@@ -53,7 +53,7 @@ describe "Type inference: abstract def" do
       ) { int32 }
   end
 
-  it "doesn't error on abstract def on sub-subclass (bug)" do
+  it "works on abstract def on sub-subclass" do
     assert_type(%(
       abstract class Foo
         abstract def foo


### PR DESCRIPTION
Class `Baz` inherits class `Bar` and `Bar` implements `foo` method,
so we can call `Baz#foo`.