### PR TITLE
Use only 1 line on travis irc messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ notifications:
       - "irc.freenode.net#crystal-lang"
     use_notice: true
     skip_join: true
+    template:
+      - "%{repository_slug}#%{commit} (%{branch} - %{commit_message}): %{message} %{build_url}"
   slack:
     secure: Ng3nTqGWY+9p1pS6yjGqDhmRvdgbIZgTNpMWbO/ngwpCyicmD3jafZkShqqXbULZTJJr3OxIGzi6GHGusT0Ic/Pi9JCM3X3v/xuBruKIR+EnNyPo7IL4ZYAlwnXyJHlCHHDBq0gSHGvGJwsXn6IgZBPRfeIq+CCyQHVPyvc9EHE=
 branches:


### PR DESCRIPTION
This should make it go from
```
9:32 AM <travis-ci> manastech/crystal#2589 (master - e0062b6 : Ary Borenszweig): The build passed.
9:32 AM <travis-ci> Change view : https://github.com/manastech/crystal/compare/c2aa416594ba...e0062b658596
9:32 AM <travis-ci> Build details : https://travis-ci.org/manastech/crystal/builds/68613131
```
to
```
9:32 AM <travis-ci> manastech/crystal#e0062b6 (master - Merge pull request #886 from yui-knk/test/bool_ban): The build passed. https://travis-ci.org/manastech/crystal/builds/68613131
```
