### PR TITLE
Fix HTTP::Request#keep_alive? method

### DIFF
--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -26,6 +26,8 @@ class HTTP::Request
       return true
     when "close"
       return false
+    when "upgrade"
+    	return false
     end
 
     case @version


### PR DESCRIPTION
Add "upgrade" type of connection to fix Websocket hand shake, that expects "Connection" header to be "Upgrade".