### PR TITLE
Improve `expect_raises(klass, message)`

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -260,6 +260,7 @@ module Spec
     macro expect_raises(klass, message)
       begin
         {{yield}}
+        fail "expected to raise {{klass.id}}"
       rescue %ex : {{klass.id}}
         %msg = {{message}}
         %ex_to_s = %ex.to_s

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -260,7 +260,6 @@ module Spec
     macro expect_raises(klass, message)
       begin
         {{yield}}
-        fail "expected to raise {{klass.id}}"
       rescue %ex : {{klass.id}}
         %msg = {{message}}
         %ex_to_s = %ex.to_s
@@ -274,6 +273,8 @@ module Spec
             fail "expected {{klass.id}}'s message to include #{ %msg.inspect }, but was #{ %ex_to_s.inspect }"
           end
         end
+      rescue
+        fail "expected to raise {{klass.id}}"
       end
     end
   end


### PR DESCRIPTION
Before this commit, if expected exception is not raised,
exception's backtrace is show.
This commit fix it to show "expected to raise {{klass.id}}".