### PR TITLE
Implement Enumerable#drop

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -1,6 +1,17 @@
 require "spec"
 
 describe "Enumerable" do
+
+  describe "drop" do
+    it "returns an array without the dropped elements" do
+      [1, 2, 3, 4, 5, 6].drop(3).should eq [4, 5, 6]
+    end
+
+    it "returns an empty array when dropping more elements than array size" do
+      [1, 2].drop(3).should eq [] of Int32
+    end
+  end
+
   describe "find" do
     it "finds" do
       [1, 2, 3].find { |x| x > 2 }.should eq(3)

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -119,6 +119,21 @@ module Enumerable(T)
     n.times { each { |x| yield x } }
   end
 
+  # Returns an array with the first *count* elements removed from the original collection.
+  #
+  # If *count* is bigger than the number of elements in the collection, returns an empty array.
+  #
+  #     [1, 2, 3, 4, 5, 6].drop(3)  #=> [4, 5, 6]
+  def drop(count : Int)
+    array_size = size - count
+    array_size = 0 if size < 0
+    array = Array(T).new(array_size)
+    each_with_index do |e, i|
+      array << e if i >= count
+    end
+    array
+  end
+
   # Iterates over the collection in slices of size *count*, and runs the block for each of those.
   #
   #     [1, 2, 3, 4, 5].each_slice(2) do |slice|

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -125,9 +125,7 @@ module Enumerable(T)
   #
   #     [1, 2, 3, 4, 5, 6].drop(3)  #=> [4, 5, 6]
   def drop(count : Int)
-    array_size = size - count
-    array_size = 0 if size < 0
-    array = Array(T).new(array_size)
+    array = Array(T).new
     each_with_index do |e, i|
       array << e if i >= count
     end


### PR DESCRIPTION
I just went through ruby's enumerable and looked what was missing and decided to give `drop` a go.

I put it at the top of the spec file as I think it'd be nice to have an alphabetical order there, sort of how `enumerable.cr` itself tries to be alphabetic :) 