### PR TITLE
Slice to string

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -989,6 +989,22 @@ describe "String" do
     s.bytesize.should eq(3)
   end
 
+  it "from a slice, it stops at the first zero or full length, whichever is shorter" do
+    sl = Slice(UInt8).new(3)
+    sl[0] = 'a'.ord.to_u8
+    sl[1] = '\0'.ord.to_u8
+    sl[2] = 'c'.ord.to_u8
+
+    st = String.new(sl)
+    st.should eq("a")
+    st.bytesize.should eq(1)
+
+    sl[1] = 'b'.ord.to_u8
+    st = String.new(sl)
+    st.should eq("abc")
+    st.bytesize.should eq(3)
+  end
+
   it "tr" do
     "bla".tr("a", "h").should eq("blh")
     "bla".tr("a", "⊙").should eq("bl⊙")

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -42,7 +42,7 @@ class Regex
       capture_number = (name_table[capture_offset].to_u16 << 8) | name_table[capture_offset+1].to_u16
 
       name_offset = capture_offset + 2
-      name = String.new( (name_table + name_offset).pointer(name_entry_size-3) )
+      name = String.new( (name_table + name_offset) )
 
       lookup[capture_number] = name
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -112,7 +112,8 @@ class String
 
   include Comparable(self)
 
-  # Creates a String form the given slice. Bytes will be copied from the slice.
+  # Creates a String form the given slice. Bytes will be copied from the slice
+  # until the first \0 or the full length of the slice, whichever comes first.
   #
   # This method is always safe to call, and the resulting string will have
   # the contents and length of the slice.
@@ -125,7 +126,12 @@ class String
   # Note: if the slice doesn't denote a valid UTF-8 sequence, this method still succeeds.
   # However, when iterating it or indexing it, an `InvalidByteSequenceError` will be raised.
   def self.new(slice : Slice(UInt8))
-    new(slice.pointer(slice.length), slice.length)
+    length = 0
+    slice.each do |byte|
+      break if byte == 0_u8
+      length += 1
+    end
+    new(slice.pointer(length), length)
   end
 
   # Creates a String from a pointer. Bytes will be copied from the pointer.


### PR DESCRIPTION
I noticed this first when doing the regex work, then again yesterday in irc where someone wanted to use a different C function

``` crystal
lib Unistd
  fun readlink(pathname : UInt8*, buf : UInt8*, bufsiz : Int32) : Int32
end

a = Slice(UInt8).new(100)
p Unistd.readlink("two", a.pointer(a.length), a.length)
p String.new(a.pointer(a.length))
``` 

is required currently unless you want all zeros at the end, whereas with this, you could just do 

``` crystal
p String.new(a)
```

which is also safer. 

If people want the old behavior, `String.new( :Pointer, :Int)  still can make strings with nulls in the middle.