### PR TITLE
Raise in Enumerable#take if a negative count is used

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -119,6 +119,12 @@ describe "Enumerable" do
   describe "take" do
     assert { [-1, -2, -3].take(1).should eq([-1]) }
     assert { [-1, -2, -3].take(4).should eq([-1, -2, -3]) }
+
+    it "raises if count is negative" do
+      expect_raises(ArgumentError) do
+        [1, 2].take(-1)
+      end
+    end
   end
 
   describe "first" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -711,6 +711,8 @@ module Enumerable(T)
   # If *count* is bigger than the number of elements in the collection, returns as many as possible. This
   # include the case of calling it over an empty collection, in which case it returns an empty array.
   def take(count : Int)
+    raise ArgumentError.new("attempt to take negative size") if count < 0
+
     ary = Array(T).new(count)
     each_with_index do |e, i|
       break if i == count


### PR DESCRIPTION
* same behavior as Enumerable#drop

(as @asterite added it to `#drop` I figured it is probably desirable for take as well)