### PR TITLE
Macro methods: Def#visibility and ArrayLiteral #push and #unshift

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -585,6 +585,14 @@ describe "MacroExpander" do
     it "executes uniq" do
       assert_macro "", %({{[1, 1, 1, 2, 3, 1, 2, 3, 4].uniq}}), [] of ASTNode, %([1, 2, 3, 4])
     end
+
+    it "executes unshift" do
+      assert_macro "", %({% x = [1]; x.unshift(2); %}{{x}}), [] of ASTNode, %([2, 1])
+    end
+
+    it "executes push" do
+      assert_macro "", %({% x = [1]; x.push(2); x << 3 %}{{x}}), [] of ASTNode, %([1, 2, 3])
+    end
   end
 
   describe "hash methods" do

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -748,6 +748,11 @@ describe "MacroExpander" do
     it "executes receiver" do
       assert_macro "x", %({{x.receiver}}), [Def.new("some_def", receiver: Var.new("self"))] of ASTNode, "self"
     end
+
+    it "executes visibility" do
+      assert_macro "x", %({{x.visibility}}), [Def.new("some_def")] of ASTNode, "nil"
+      assert_macro "x", %({{x.visibility}}), [Def.new("some_def").tap { |d| d.visibility = :private }] of ASTNode, ":private"
+    end
   end
 
   describe "call methods" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -628,6 +628,8 @@ module Crystal
         ArrayLiteral.map(self.args) { |arg| arg }
       when "receiver"
         receiver || Nop.new
+      when "visibility"
+        visibility ? SymbolLiteral.new(visibility.to_s) : NilLiteral.new
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -453,6 +453,22 @@ module Crystal
         else
           raise "wrong number of arguments for [] (#{args.length} for 1)"
         end
+      when "unshift"
+        case args.length
+        when 1
+          elements.unshift(args.first)
+          self
+        else
+          raise "wrong number of arguments for push (#{args.length} for 1)"
+        end
+      when "push", "<<"
+        case args.length
+        when 1
+          elements << args.first
+          self
+        else
+          raise "wrong number of arguments for push (#{args.length} for 1)"
+        end
       else
         super
       end


### PR DESCRIPTION
1. Exposes the visibility of methods as per #953 : returns either `nil`, `:protected` or `:private`. Public methods of a class may be selected with:

  ```crystal
  {% public_methods = @type.methods.select { |m| !m.visibility } %}
  ```

2. Enables mutability of ArrayLiteral collections with #push and #unshift methods. A use case is to push data to a constant from different macros and eventually use it at runtime or at compile time from another macro (eg: `inherited`, `method_missing`, ...).