### PR TITLE
Change it to use postfix '_spec.cr' for spec files

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -165,12 +165,12 @@ USAGE
           options << "-l" << target_line
         end
       elsif File.directory?(target_filename)
-        target_filename = "#{target_filename}/**"
+        target_filename = "#{target_filename}/**_spec.cr"
       else
         error "'#{target_filename}' is not a file"
       end
     else
-      target_filename = "spec/**"
+      target_filename = "spec/**_spec.cr"
     end
 
     sources = [Compiler::Source.new("spec", %(require "./#{target_filename}"))]


### PR DESCRIPTION
Many people name it `foo_spec.cr` for spec files what is put in `spec` directory, and another name is used for misc (helper) files.

But, current implementation of `crystal spec` selects `./**` as spec files, so misc file is loaded by this behavior and it makes an error in some case.  For example, I put such a file as `spec/foo_spec.cr`:

```crystal
require "spec"

{{ run "./spec_generator.cr", "Foo!"}}
```

and put such a file as `spec/spec_generator.cr`:

```crystal
puts %(
require "spec"

describe #{ARGV[0].inspect} do
  it #{ARGV[0].inspect} do
    true.should be_false
  end
end)
```

In this case, I run `crystal spec` and it raise such an error (First character `F` is spec failure (above `true.should be_false`) and another is the error of running `spec_generator.cr`):

```
FIndex out of bounds (IndexOutOfBounds)
*Exception@Exception#initialize<IndexOutOfBounds, String>:Array(String) +46 [0]
*IndexOutOfBounds#initialize<IndexOutOfBounds, String>:Array(String) +6 [0]
*IndexOutOfBounds::new<String>:IndexOutOfBounds +97 [0]
*IndexOutOfBounds::new:IndexOutOfBounds +16 [0]
*Array(String)@Array(T)#at<Array(String), Int32>:String +114 [0]
*Array(String)@Array(T)#[]<Array(String), Int32>:String +6 [0]
__crystal_main +25493 [0]
main +108 [0]
__libc_start_main +245 [0]
_start +41 [0]
 +41 [0]
Program terminated abnormally with error code: 256
```

So, I fix it by changing default parameter into `./**_spec.cr`.  