### PR TITLE
Add `class_name` macro method

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -208,6 +208,10 @@ describe "MacroExpander" do
       end
 
       it "executes class_name" do
+        assert_macro "x", "{{x.class_name}}", [MacroId.new("hello")] of ASTNode, "\"MacroId\""
+      end
+
+      it "executes class_name" do
         assert_macro "x", "{{x.class_name}}", [StringLiteral.new("hello")] of ASTNode, "\"StringLiteral\""
       end
 

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -201,6 +201,28 @@ describe "MacroExpander" do
     it "executes == on symbols (false) (#240)" do
       assert_macro "", "{{:foo == :bar}}", [] of ASTNode, "false"
     end
+
+    describe "class_name" do
+      it "executes class_name" do
+        assert_macro "", "{{:foo.class_name}}", [] of ASTNode, "\"SymbolLiteral\""
+      end
+
+      it "executes class_name" do
+        assert_macro "x", "{{x.class_name}}", [StringLiteral.new("hello")] of ASTNode, "\"StringLiteral\""
+      end
+
+      it "executes class_name" do
+        assert_macro "x", "{{x.class_name}}", [SymbolLiteral.new("hello")] of ASTNode, "\"SymbolLiteral\""
+      end
+
+      it "executes class_name" do
+        assert_macro "x", "{{x.class_name}}", [NumberLiteral.new(1)] of ASTNode, "\"NumberLiteral\""
+      end
+
+      it "executes class_name" do
+        assert_macro "x", "{{x.class_name}}", [ArrayLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "\"ArrayLiteral\""
+      end
+    end
   end
 
   describe "number methods" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -14,6 +14,8 @@ module Crystal
         interpret_argless_method("id", args) { MacroId.new(to_macro_id) }
       when "stringify"
         interpret_argless_method("stringify", args) { stringify }
+      when "class_name"
+        interpret_argless_method("class_name", args) { class_name }
       when "=="
         BoolLiteral.new(self == args.first)
       when "!="
@@ -52,6 +54,10 @@ module Crystal
 
     def stringify
       StringLiteral.new(to_s)
+    end
+
+    def class_name
+      StringLiteral.new(class_desc)
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -658,7 +658,7 @@ module Crystal
   class MacroId
     def interpret(method, args, block, interpreter)
       case method
-      when "==", "!=", "stringify"
+      when "==", "!=", "stringify", "class_name"
         return super
       end
 
@@ -675,7 +675,7 @@ module Crystal
   class SymbolLiteral
     def interpret(method, args, block, interpreter)
       case method
-      when "==", "!=", "stringify"
+      when "==", "!=", "stringify", "class_name"
         return super
       end
 


### PR DESCRIPTION
In crystal some Literal objects have few macro method, and others
have many macro method.
For example BoolLiteral has few macro method
(`id`, `stringify`), NumberLiteral has many macro method (`>`, `+` etc).

So I think `class_name` macro method which returns the name of Literal
is usefull and implement it.