### PR TITLE
Add `target` attr into "defined in" link of types

### DIFF
--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -41,7 +41,7 @@
   <h2>Defined in:</h2>
   <% locations.each do |location| %>
     <% if url = location.url %>
-      <a href="<%= url %>"><%= location.filename %></a>
+      <a href="<%= url %>" target="_blank"><%= location.filename %></a>
     <% else %>
       <%= location.filename %>
     <% end %>


### PR DESCRIPTION
GitHub's response includes `X-Frame-Options: deny`.

`defined in` links are not working now.