### PR TITLE
Flush STDERR when calling exit()

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -102,6 +102,7 @@ end
 def exit(status = 0)
   AtExitHandlers.run
   STDOUT.flush
+  STDERR.flush
   Process.exit(status)
 end
 


### PR DESCRIPTION
As of today only STDOUT is flushed, hence messages sent on STDERR may be
lost when calling exit(), which is a common pattern, for instance:

    def usage
      STDERR.puts "Usage: #{PROGRAM_NAME} <args>"
      exit 1
    end

In such a case chances are you won't see the error message in current
versions of crystal.