### PR TITLE
Fix a bug skiping too many character after a link

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -89,4 +89,6 @@ describe Markdown do
   assert_render "  *  *  *  ", "<hr/>"
 
   assert_render "hello < world", "<p>hello &lt; world</p>"
+
+  assert_render "Hello __[World](http://foo.com)__!", %(<p>Hello <strong><a href="http://foo.com">World</a></strong>!</p>)
 end

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -313,8 +313,8 @@ class Markdown::Parser
           @renderer.end_link
 
           paren_idx = (str + pos + 1).to_slice(bytesize - pos - 1).index(')'.ord).not_nil!
-          pos += paren_idx + 2
-          cursor = pos
+          pos += paren_idx + 1
+          cursor = pos + 1
           in_link = false
         end
       end


### PR DESCRIPTION
Now, Markdown parser has a bug.  For example, such Markdown text is parsed and is converted to such HTML.

```markdown
__[Crystal](https://crystal-lang.org)__
```

```html
<p><strong><a href="https://crystal-lang.org">Crystal</a>__</p>
```

So, I corrected it.

```html
<p><strong><a href="https://crystal-lang.org">Crystal</a></strong></p>
```