### PR TITLE
Add Int[index] syntax.

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -115,6 +115,22 @@ describe "Int" do
     assert { 5.bit(3).should eq(0) }
   end
 
+  describe "[index : Int]" do
+    assert { 0b01[0].should eq(1) }
+  end
+
+  describe "[index : Range(Int, Int)]" do
+    it "returns an array of bits for range indicies" do
+      a   = -15_i8
+      arr = a[0...8]
+      arr.should eq([1, 1, 1, 1, 0, 0, 0, 1])
+    end
+
+    it "raises on a negative range" do
+      expect_raises { 1[-1..1] }
+    end
+  end
+
   describe "divmod" do
     assert { 5.divmod(3).should eq({1, 2}) }
   end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -115,10 +115,6 @@ describe "Int" do
     assert { 5.bit(3).should eq(0) }
   end
 
-  describe "[index : Int]" do
-    assert { 0b01[0].should eq(1) }
-  end
-
   describe "[index : Range(Int, Int)]" do
     it "returns an array of bits for range indicies" do
       a   = -15_i8

--- a/src/int.cr
+++ b/src/int.cr
@@ -83,10 +83,6 @@ struct Int
     end
   end
 
-  def [](index : Int)
-    bit(index)
-  end
-
   # Returns an array containing the bits of this integer
   # corresponding to the indicies of the range given.
   #
@@ -99,7 +95,7 @@ struct Int
       raise ArgumentError.new "Invalid range: #{range}"
     end
 
-    range.map { |i| self[i] }.reverse
+    range.map { |i| bit(i) }.reverse
   end
 
   def remainder(other : Int)

--- a/src/int.cr
+++ b/src/int.cr
@@ -83,6 +83,25 @@ struct Int
     end
   end
 
+  def [](index : Int)
+    bit(index)
+  end
+
+  # Returns an array containing the bits of this integer
+  # corresponding to the indicies of the range given.
+  #
+  # ```
+  # bits = 14[0...8] #=> [0, 0, 0, 0, 1, 1, 1, 0]
+  # bits = 14[0...4] #=> [1, 1, 1, 0]
+  # ```
+  def [](range : Range(Int, Int))
+    if range.begin < 0
+      raise ArgumentError.new "Invalid range: #{range}"
+    end
+
+    range.map { |i| self[i] }.reverse
+  end
+
   def remainder(other : Int)
     if other == 0
       raise DivisionByZero.new


### PR DESCRIPTION
The ability to index directly into a Fixnum to retrieve a bit is one of my favourite "hidden gems" in Ruby.

This pull request adds the `Int[index : Int]` operation that allows for retrieval of a single bit as such:

```crystal
0x01[0] #=> 1
```

as well as the ability to grab an array of bits from a supplied range:

```crystal
num = -15
num[0...8] #=> [1, 1, 1, 1, 0, 0, 0, 1]
```