### PR TITLE
Use commit_subject for Travis IRC notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ notifications:
     use_notice: true
     skip_join: true
     template:
-      - "%{repository_slug}#%{commit} (%{branch} - %{commit_message}): %{message} %{build_url}"
+      - "%{repository_slug}#%{commit} (%{branch} - %{commit_subject}): %{message} %{build_url}"
   slack:
     secure: Ng3nTqGWY+9p1pS6yjGqDhmRvdgbIZgTNpMWbO/ngwpCyicmD3jafZkShqqXbULZTJJr3OxIGzi6GHGusT0Ic/Pi9JCM3X3v/xuBruKIR+EnNyPo7IL4ZYAlwnXyJHlCHHDBq0gSHGvGJwsXn6IgZBPRfeIq+CCyQHVPyvc9EHE=
 branches:


### PR DESCRIPTION
commit_message breaks the notification with multiline commit messages, commit_subject picks only the first line