### PR TITLE
Add ordered list for Markdown

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -74,6 +74,11 @@ describe Markdown do
   assert_render "* Hello\nWorld", "<ul><li>Hello</li></ul>\n\n<p>World</p>"
   assert_render "Params:\n  * Foo\n  * Bar", "<p>Params:</p>\n\n<ul><li>Foo</li><li>Bar</li></ul>"
 
+  assert_render "1. Hello", "<ol><li>Hello</li></ol>"
+  assert_render "2. Hello", "<ol><li>Hello</li></ol>"
+  assert_render "01. Hello\n02. World", "<ol><li>Hello</li><li>World</li></ol>"
+  assert_render "Params:\n  1. Foo\n  2. Bar", "<p>Params:</p>\n\n<ol><li>Foo</li><li>Bar</li></ol>"
+
   assert_render "Hello [world](http://foo.com)", %(<p>Hello <a href="http://foo.com">world</a></p>)
   assert_render "Hello [world](http://foo.com)!", %(<p>Hello <a href="http://foo.com">world</a>!</p>)
   assert_render "Hello [world **2**](http://foo.com)!", %(<p>Hello <a href="http://foo.com">world <strong>2</strong></a>!</p>)

--- a/src/markdown/html_renderer.cr
+++ b/src/markdown/html_renderer.cr
@@ -62,6 +62,14 @@ class Markdown::HTMLRenderer
     @io << "</ul>"
   end
 
+  def begin_ordered_list
+    @io << "<ol>"
+  end
+
+  def end_ordered_list
+    @io << "</ol>"
+  end
+
   def begin_list_item
     @io << "<li>"
   end


### PR DESCRIPTION
Crystal's Markdown parser did not support ordered list,

```markdown
1. Hello
2. World
```

So, I added it.

__This PR makes it possible to display Crystal's [README.md](https://github.com/manastech/crystal/blob/master/README.md) exactly__.