### PR TITLE
Add Iterator#flatten.

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -228,6 +228,59 @@ describe Iterator do
     iter.to_a.should eq([1, 2, 'a', 'b'])
   end
 
+  describe "flatten" do
+    it "flattens an iterator of mixed-type iterators" do
+      iter = [(1..2).each, ('a'..'b').each].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+      iter.next.should eq('b')
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a', 'b'])
+    end
+
+    it "flattens an iterator of mixed-type elements and iterators" do
+      iter = [(1..2).each, 'a'].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a'])
+    end
+
+    it "flattens an iterator of mixed-type elements and iterators and iterators of iterators" do
+      iter = [(1..2).each, [['a', 'b'].each].each, "foo"].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+      iter.next.should eq('b')
+      iter.next.should eq("foo")
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a', 'b', "foo"])
+    end
+  end
+
   it "taps" do
     a = 0
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -167,6 +167,10 @@ module Iterator(T)
     Chain(typeof(self), typeof(other), T, U).new(self, other)
   end
 
+  def flatten
+    Flatten(typeof(first.first)).new(self)
+  end
+
   def tap(&block : T ->)
     Tap(typeof(self), T).new(self, block)
   end
@@ -534,6 +538,38 @@ module Iterator(T)
       @iter1.rewind
       @iter2.rewind
       @iter1_consumed = false
+    end
+  end
+
+  # :nodoc:
+  class Flatten(T)
+    include Iterator(T)
+
+    def initialize(@iter : Iterator(Iterator(T)))
+      @current = @iter.next
+    end
+
+    def next
+      current = @current
+      if current.is_a?(Stop)
+        stop
+      else
+        v = current.next
+        if v.is_a?(Stop)
+          @current = @iter.next
+          self.next
+        else
+          v
+        end
+      end
+    end
+
+    def rewind
+      @iter.rewind
+      @iter.each { |i| i.rewind }
+      @iter.rewind
+
+      @current = @iter.next
     end
   end
 


### PR DESCRIPTION
Hi! This currently doesn't actually work for Iterators of union types.

I'm not sure why. The problem seems to be that in the test, `[(1..2).each, ('a'..'b').each].each.flatten` has the type `Flatten(Char)`, instead of `Flatten(Int32 | Char)`.

I figured I'd push the code I had, in any case. =)