### PR TITLE
Add `abstract def to_s_with_source` to `Crystal::Exception`

### DIFF
--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -10,6 +10,8 @@ module Crystal
       to_s_with_source(nil, io)
     end
 
+    abstract def to_s_with_source(source, io)
+
     def to_s_with_source(source)
       String.build do |io|
         to_s_with_source source, io


### PR DESCRIPTION
`Crystal::Exception` is abstract class and this class needs
`to_s_with_source(source, io)` to be implemented,
so add this method as abstract def.