### PR TITLE
Fix error messages of undefined macro method exception

### DIFF
--- a/spec/compiler/type_inference/hooks_spec.cr
+++ b/spec/compiler/type_inference/hooks_spec.cr
@@ -116,6 +116,6 @@ describe "Type inference: hooks" do
         include Doable
       end
       ),
-      "undefined macro method 'StringLiteral#unknown'"
+      "undefined macro method 'MacroId#unknown'"
   end
 end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -371,4 +371,7 @@ module Crystal
 
   class FrozenTypeException < TypeException
   end
+
+  class UndefinedMacroMethodError < TypeException
+  end
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -21,7 +21,7 @@ module Crystal
       when "!"
         BoolLiteral.new(!truthy?)
       else
-        raise "undefined macro method '#{class_desc}##{method}'"
+        raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
       end
     end
 
@@ -659,6 +659,8 @@ module Crystal
       value = StringLiteral.new(@value).interpret(method, args, block, interpreter)
       value = MacroId.new(value.value) if value.is_a?(StringLiteral)
       value
+    rescue UndefinedMacroMethodError
+      raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
     end
 
     def interpret_compare(other : MacroId | StringLiteral)
@@ -676,6 +678,8 @@ module Crystal
       value = StringLiteral.new(@value).interpret(method, args, block, interpreter)
       value = SymbolLiteral.new(value.value) if value.is_a?(StringLiteral)
       value
+    rescue UndefinedMacroMethodError
+      raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
     end
   end
 


### PR DESCRIPTION
When undefined macro method for SymbolLiteral or MacroId
is called, error message is tweaked:

```
{{:smy.unknown}}
```

shows
`undefined macro method 'StringLiteral#unknown'`.
This commit fixs error message.