### PR TITLE
Fix Regex 'm' modifier mistakenly mapped to PCRE_DOTALL

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -144,4 +144,9 @@ describe "Regex" do
     Regex.new("foo").should eq(Regex.new("foo"))
     Regex.new("foo").should_not eq(Regex.new("bar"))
   end
+
+  it "matches lines beginnings on ^ in multiline mode" do
+    ("foo\nbar" =~ /^bar/).should be_nil
+    ("foo\nbar" =~ /^bar/m).should eq(4)
+  end
 end

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -4,7 +4,13 @@ class Regex
   @[Flags]
   enum Options
     IGNORE_CASE = 1
-    MULTILINE = 4
+    # PCRE native PCRE_MULTILINE flag is 2, and PCRE_DOTALL is 4 ;
+    # - PCRE_DOTALL changes the "." meaning,
+    # - PCRE_MULTILINE changes "^" and "$" meanings)
+    # Ruby modifies this meaning to have essentially one unique "m"
+    # flag that activates both behviours, so here we do the same by
+    # mapping MULTILINE to PCRE_MULTILINE | PCRE_DOTALL
+    MULTILINE = 6
     EXTENDED = 8
     # :nodoc:
     ANCHORED      = 16


### PR DESCRIPTION
This PR modifies the `m` Regex modifier so it better matches Ruby's behaviour. Previously the `m` flag was mapped to the "PCRE_DOTALL" flag in the PCRE library, which I think is wrong.

Ruby essentially sets DOTALL and MULTILINE as synonyms (I think it happens [here](https://github.com/ruby/ruby/blob/trunk/include/ruby/oniguruma.h#L356)). Note that Ruby also has a weird/unique behaviour among other languages, which is `^` always match beginning of lines, even without the `m` modifier.

Other PCRE implementations and Perl differentiate DOTALL (`s`) and MULTILINE (`m`).

I'd love to read some thoughts about all this and what behaviour should be adopted for Crystal. I think this little change already is an improvement, but I can rework the PR in any direction you think is better.

For what is worth, here's the pretty common use-case that make me see the problem:
```
a = "a\nmultiline\nstring"
a.gsub(/^/, "### ")
# => "### a\nmultiline\nstring"
a.gsub(/^/m, "### ")
# => "### a\nmultiline\nstring"
```
Ruby replaces beginnings of lines with "###" in both cases, crystal current stable in first only. With the proposed modification the second case replaces all.

What do you think?

(edit: reword last sentence)