### PR TITLE
Fix generating the document of VirtualType

### DIFF
--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -573,6 +573,11 @@ class Crystal::Doc::Type
     io << ')'
   end
 
+  def type_to_html(type : Crystal::VirtualType, io, text = nil)
+    type_to_html type.base_type, io, text
+    io << '+'
+  end
+
   def type_to_html(type : Crystal::Type, io, text = nil)
     type_to_html @generator.type(type), io, text
   end


### PR DESCRIPTION
Current compiler is missing generating process for `Crystal::VirtualType`, so we get an error by generating such a code:

```crystal
alias O = Object+
```

and an error message and stack trace is:

```
fatal: Not a git repository (or any of the parent directories): .git
Unhandled type in `name`: Object+
*raise<String>:NoReturn +70 [0]
*Crystal::Doc::Type#name<Crystal::Doc::Type>:String +526 [0]
*Crystal::Doc::Type#full_name_without_type_vars<Crystal::Doc::Type, String::Builder>:String::Builder +53 [0]
*Crystal::Doc::Type#full_name<Crystal::Doc::Type, String::Builder>:String::Builder? +30 [0]
*Crystal::Doc::Type#type_to_html<Crystal::Doc::Type, Crystal::Type+, String::Builder>:(Nil | String::Builder | Array(Crystal::Type+)) +127 [0]
*Crystal::Doc::TypeTemplate#to_s<Crystal::Doc::TypeTemplate, File>:File +1851 [0]
*Crystal::Doc::Generator#generate_types_docs<Crystal::Doc::Generator, Array(Crystal::Doc::Type), String>:Array(Crystal::Doc::Type) +444 [0]
*Crystal::Command::run<Array(String)>:(Nil | Bool | FileDescriptorIO+ | Crystal::Compiler::Result | Array(Crystal::Init::View+:Class)) +21281 [0]
main +17080 [0]
__libc_start_main +245 [0]
_start +41 [0]

Error: you've found a bug in the Crystal compiler. Please open an issue: https://github.com/manastech/crystal/issues
```

So, I fixed it.