### PR TITLE
add Char#===(:Int8) casting, and vice versa

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -187,4 +187,11 @@ describe "Char" do
   it "does bytes" do
     '\u{FF}'.bytes.should eq([195, 191])
   end
+
+  it "#===(:Int)" do
+    ('c'.ord).should eq(99)
+    ('c' === 99_u8).should be_true
+    ('c' === 99).should be_true
+    ('z' === 99).should be_false
+  end
 end

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -193,5 +193,8 @@ describe "Char" do
     ('c' === 99_u8).should be_true
     ('c' === 99).should be_true
     ('z' === 99).should be_false
+
+    ('酒'.ord).should eq(37202)
+    ('酒' === 37202).should be_true
   end
 end

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -16,9 +16,10 @@ describe "Int" do
   end
 
   describe "#===(:Char)" do
-    assert { (99 === 'c').should    be_true }
-    assert { (99_u8 === 'c').should be_true }
-    assert { (99 === 'z').should    be_false }
+    assert { (99 === 'c').should     be_true }
+    assert { (99_u8 === 'c').should  be_true }
+    assert { (99 === 'z').should     be_false }
+    assert { (37202 === '酒').should be_true }
   end
 
   describe "divisible_by?" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -15,6 +15,12 @@ describe "Int" do
     assert { (2 ** 2.5).should eq(5.656854249492381) }
   end
 
+  describe "#===(:Char)" do
+    assert { (99 === 'c').should    be_true }
+    assert { (99_u8 === 'c').should be_true }
+    assert { (99 === 'z').should    be_false }
+  end
+
   describe "divisible_by?" do
     assert { 10.divisible_by?(5).should be_true }
     assert { 10.divisible_by?(3).should be_false }

--- a/src/char.cr
+++ b/src/char.cr
@@ -496,4 +496,8 @@ struct Char
       io.write chars.to_slice, i
     end
   end
+
+  def ===(byte : Int)
+    ord === byte
+  end
 end

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -32,7 +32,7 @@ class CSV::Builder
       @io << '"'
       value.each_byte do |byte|
         case byte
-        when '"'.ord
+        when '"'
           @io << %("")
         else
           @io.write_byte byte

--- a/src/int.cr
+++ b/src/int.cr
@@ -119,6 +119,10 @@ struct Int
     to_f ** other
   end
 
+  def ===(char : Char)
+    self === char.ord
+  end
+
   def bit(bit)
     self & (1 << bit) == 0 ? 0 : 1
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -812,13 +812,13 @@ class String
     return self if bytesize == 0
 
     case cstr[bytesize - 1]
-    when '\n'.ord
+    when '\n'
       if bytesize > 1 && cstr[bytesize - 2] == '\r'.ord
         byte_slice 0, bytesize - 2
       else
         byte_slice 0, bytesize - 1
       end
-    when '\r'.ord
+    when '\r'
       byte_slice 0, bytesize - 1
     else
       self

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -238,7 +238,7 @@ class URI
   private def escape(str, io)
     str.each_byte do |byte|
       case byte
-      when ':'.ord, '@'.ord, '/'.ord
+      when ':', '@', '/'
         io << '%'
         byte.to_s(16, io, upcase: true)
       else


### PR DESCRIPTION
The https://github.com/manastech/crystal/commit/35b177b1797c98d5852c1d2c0f17bcda0477b2ff patch made me think this might be a bit nicer for case statements on bytes.