### PR TITLE
Yield start and finish indices in Readline.autocomplete

### DIFF
--- a/spec/std/readline_spec.cr
+++ b/spec/std/readline_spec.cr
@@ -8,5 +8,5 @@ describe Readline do
   typeof(Readline.readline(add_history: false))
   typeof(Readline.line_buffer)
   typeof(Readline.point)
-  typeof(Readline.autocomplete { |s| %w(foo bar) })
+  typeof(Readline.autocomplete { |text, start, finish| %w(foo bar) })
 end

--- a/src/readline.cr
+++ b/src/readline.cr
@@ -13,7 +13,7 @@ end
 module Readline
   extend self
 
-  alias CompletionProc = String -> Array(String)?
+  alias CompletionProc = String, Int32, Int32 -> Array(String)?
 
   def readline(prompt = "", add_history = false)
     line = LibReadline.readline(prompt)
@@ -44,7 +44,7 @@ module Readline
     return Pointer(UInt8*).null unless completion_proc
 
     text = String.new(text_ptr)
-    matches = completion_proc.call(text)
+    matches = completion_proc.call(text, start, finish)
 
     return Pointer(UInt8*).null unless matches
     return Pointer(UInt8*).null if matches.empty?


### PR DESCRIPTION
As of today, `Readline.autocomplete` only yields the text sent by
readline for autocompletion, which only contains the last token inside
the current buffer. For example:

  > abc[TAB]
  => will yield "abc"

  > abc [TAB]
  => will yield ""

  > abc def[TAB]
  => will yield "def"

Yielding the positional indices of the yielded string inside the current
line buffer is necessary so the library is usable for performing some
useful autocompletion.

Note that we could use `Readline.line_buffer` directly to guess the
position from where the autocompletion request originated, but 1/ it
wouldn't be 100% deterministic, and 2/ this buffer is not updated in
real-time, so it frequently contains the previous line read by readline
instead of the current line.

---

Fwiw, if someone needs this now, you can always patch readline from the outside, [here's what I did](https://github.com/jbbarth/caoutchouc/blob/master/src/patches/readline/autocomplete_yield_start_finish.cr)