### PR TITLE
Expose Def#visibility to macros

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -748,6 +748,11 @@ describe "MacroExpander" do
     it "executes receiver" do
       assert_macro "x", %({{x.receiver}}), [Def.new("some_def", receiver: Var.new("self"))] of ASTNode, "self"
     end
+
+    it "executes visibility" do
+      assert_macro "x", %({{x.visibility}}), [Def.new("some_def")] of ASTNode, ":public"
+      assert_macro "x", %({{x.visibility}}), [Def.new("some_def").tap { |d| d.visibility = :private }] of ASTNode, ":private"
+    end
   end
 
   describe "call methods" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -628,6 +628,8 @@ module Crystal
         ArrayLiteral.map(self.args) { |arg| arg }
       when "receiver"
         receiver || Nop.new
+      when "visibility"
+        SymbolLiteral.new(visibility ? visibility.to_s : "public")
       else
         super
       end


### PR DESCRIPTION
Exposes the visibility of methods as per #953 : returns either `:public`, `:protected` or `:private`. For instance public methods of a class may be selected with:

```crystal
{% public_methods = @type.methods.select { |m| m.visibility == :public } %}
```

There was a discussion in #957 to have the `public_methods`, `private_methods` and `protected_methods` Ruby-like accessors, for simpler filtering. I can add them if we think it would be a good addition to macros.