### PR TITLE
Update HTML::Builder library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Crystal [![Build Status](https://travis-ci.org/manastech/crystal.png)](https://travis-ci.org/manastech/crystal)
+Crystal [![Build Status](https://travis-ci.org/manastech/crystal.png)](https://travis-ci.org/manastech/crystal) [![Bountysource](https://api.bountysource.com/badge/team?team_id=89730&style=raised)](https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language)
 =======
 
 Crystal is a programming language with the following goals:

--- a/spec/std/html/builder_spec.cr
+++ b/spec/std/html/builder_spec.cr
@@ -13,12 +13,21 @@ describe "HTML" do
           body do
             a({href: "http://crystal-lang.org"}) { text "Crystal rocks!" }
             form({method: "POST"}) do
-              input({name: "name"}) {}
+              input({name: "name"})
             end
           end
         end
       end
-      str.should eq %(<!DOCTYPE html><html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks!</a><form method="POST"><input name="name"></input></form></body></html>)
+      str.should eq %(<!DOCTYPE html><html><head><title>Crystal Programming Language</title></head><body><a href="http://crystal-lang.org">Crystal rocks!</a><form method="POST"><input name="name"></form></body></html>)
+    end
+
+    it "builds html with some tag attributes" do
+      str = HTML::Builder.new.build do
+        a({ href: "http://crystal-lang.org", class: "crystal", id: "main" }) do
+          text "Crystal rocks!"
+        end
+      end
+      str.should eq %(<a href="http://crystal-lang.org" class="crystal" id="main">Crystal rocks!</a>)
     end
 
     it "escapes attribute values" do

--- a/src/html/builder.cr
+++ b/src/html/builder.cr
@@ -1,5 +1,28 @@
 require "html"
 
+# HTML::Builder
+#
+# HTML::Builder is a library for representing HTML in Crystal.
+#
+# Usage:
+#
+# ```
+# html = HTML::Builder.new.a({href: "google.com"}) do
+#   text "crystal is awesome"
+# end
+#
+# puts html # => "<a href="google.com">crystal is awesome</a>
+# ```
+#
+# Or also you can use `build` method:
+#
+# ```
+# HTML::Builder.new.build do
+#   a({href: "google.com"}) do
+#     text "crystal is awesome"
+#   end
+# end # => "<a href="google.com">crystal is awesome</a>
+# ```
 struct HTML::Builder
   def initialize
     @str = StringIO.new
@@ -10,37 +33,76 @@ struct HTML::Builder
     @str.to_s
   end
 
-  {% for tag in %w(a b body button div em h1 h2 h3 head html i img input li link ol p s script span strong table tbody td textarea thead thead title tr u ul form) %}
-    def {{tag.id}}(attrs = nil : Hash?)
-      @str << "<{{tag.id}}"
-      if attrs
-        @str << " "
-        attrs.each do |name, value|
-          @str << name
-          @str << %(=")
-          HTML.escape(value, @str)
-          @str << %(")
-        end
-      end
-      @str << ">"
+  # Returns html doctype tag.
+  #
+  # ```
+  # HTML::Builder.new.build { doctype } # => <doctype/>
+  # ```
+  def doctype
+    @str << "<!DOCTYPE html>"
+  end
+
+  # Returns br html tag.
+  #
+  # ```
+  # HTML::Builder.new.build { br } # => <br/>
+  # ```
+  def br
+    @str << "<br/>"
+  end
+
+  # Returns hr html tag.
+  #
+  # ```
+  # HTML::Builder.new.build { hr } # => <hr/>
+  # ```
+  def hr
+    @str << "<hr/>"
+  end
+
+  # Render escaped text in html tag.
+  #
+  # ```
+  # HTML::Builder.new.build { text "crystal is awesome" }
+  # # => crystal is awesome
+  # ```
+  def text(text)
+    @str << HTML.escape(text)
+  end
+
+  {% for tag in %w(a b body button div em h1 h2 h3 head html i li ol p s script span strong table tbody td textarea thead title tr u ul form) %}
+    # Returns `{{tag.id}}` html tag with any options.
+    #
+    # ```
+    # HTML::Builder.new.build do
+    #   {{tag.id}}({ class: "crystal" }) { text "crystal is awesome" }
+    # end
+    # # => <{{tag.id}} class="crystal">crystal is awesome</{{tag.id}}>
+    # ```
+    def {{tag.id}}(attrs = Hash(Symbol, String).new : Hash?)
+      @str << "<{{tag.id}}#{attributes_string(attrs)}>"
       with self yield self
       @str << "</{{tag.id}}>"
     end
   {% end %}
 
-  def doctype
-    @str << "<!DOCTYPE html>"
-  end
+  {% for tag in %w(link input img) %}
+    # Returns `{{tag.id}}` html tag with any options.
+    #
+    # ```
+    # HTML::Builder.new.build do
+    #   {{tag.id}}({ class: "crystal" })
+    # end
+    # # => <{{tag.id}} class="crystal">
+    # ```
+    def {{tag.id}}(attrs = Hash(Symbol, String).new : Hash?)
+      @str << "<{{tag.id}}#{attributes_string(attrs)}>"
+    end
+  {% end %}
 
-  def br
-    @str << "<br/>"
-  end
-
-  def hr
-    @str << "<hr/>"
-  end
-
-  def text(text)
-    @str << HTML.escape(text)
+  private def attributes_string(attrs : Hash)
+    attrs
+      .map { |name, value| " #{name}=\"#{HTML.escape(value)}\"" }
+      .join("")
   end
 end


### PR DESCRIPTION
1. Fixed spaces between html tag attributes
2. Selected not close html tags to a separate macro
3. Add simple documentation about library