### PR TITLE
[ci skip] Fix Docs of `superclass`

### DIFF
--- a/docs/macros.cr
+++ b/docs/macros.cr
@@ -1003,7 +1003,7 @@ module Macros
     def instance_vars : ArrayLiteral(MetaVar)
     end
 
-    # Returns the instance variables of this type, if any.
+    # Returns the direct superclass of this type.
     def superclass : TypeNode | NilLiteral
     end
 


### PR DESCRIPTION
```
class Baz
end

class Foo < Baz
end

class Bar < Foo
  {{p @type.superclass}}
end

#=> Foo (ptinted)
```
