### PR TITLE
Array(T)#*

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -63,6 +63,10 @@ describe "Array" do
     ([1, 2, 3, 4, 5] - [4, 2]).should eq([1, 3, 5])
   end
 
+  it "does *" do
+    ([1, 2, 3] * 3).should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
+  end
+
   describe "[]" do
     it "gets on positive index" do
       [1, 2, 3][1].should eq(2)

--- a/src/array.cr
+++ b/src/array.cr
@@ -225,6 +225,19 @@ class Array(T)
     ary
   end
 
+  # Repetition: Returns a new array built by concatenating `times` copies of `ary`.
+  #
+  # ```
+  # [ "a", "b", "c" ] * 2   #=> [ "a", "b", "c", "a", "b", "c" ]
+  # ```
+  def *(times : Int)
+    ary = Array(T).new(length * times)
+    times.times do
+      ary.concat(self)
+    end
+    ary
+  end
+
   def <<(value : T)
     push(value)
   end


### PR DESCRIPTION
This PR adds a tiny thing I missed the other day: Array repetition (the ability to create e.g. a 100 items array by doing `[1] * 100`).

Being a small method and out of curiosity, I coded 3 different implementations (one based on `+=`, one based on `concat`, and one based on `build`) and benchmarked them against different array sizes and multipliers. It turns out that:

* The `build` version performs always very similarly to the `concat` one (expected), but generally a tiny bit slower (unexpected for me)
* The `concat` version performs generally better than the `+=` (for some inputs much better), as I'd expect, but `+=` outperforms `concat` for big array lengths and/or multipliers (>10K)

Based on that, and on the use case I had in mind (creating test data, usually small), I chose the `concat` one, but I guess it's open for discussion. I can upload the benchmark code if needed.