### PR TITLE
Allow for sending masked data from websocket.

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -146,4 +146,22 @@ describe HTTP::WebSocket do
       String.new(buffer[0, 1023]).should eq("x" * 1023)
     end
   end
+
+  describe "send_masked" do
+    it "sends the data with a bitmask" do
+      sent_string = "hello"
+      io = StringIO.new
+      ws = HTTP::WebSocket.new(io)
+      ws.send_masked(sent_string)
+      bytes = io.to_slice
+      bytes.length.should eq(11) # 2 bytes header, 4 bytes mask, 5 bytes content
+      bytes[1].bit(7).should eq(1) # For mask bit
+      (bytes[1] - 128).should eq(sent_string.length)
+      (bytes[2] ^ bytes[6]).should eq('h'.ord)
+      (bytes[3] ^ bytes[7]).should eq('e'.ord)
+      (bytes[4] ^ bytes[8]).should eq('l'.ord)
+      (bytes[5] ^ bytes[9]).should eq('l'.ord)
+      (bytes[2] ^ bytes[10]).should eq('o'.ord)
+    end
+  end
 end

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -132,9 +132,7 @@ class HTTP::WebSocket
   end
 
   private def generate_mask
-    Array(UInt8).new(4, 0_u8).map do
-      Random.rand(256).to_u8
-    end
+    StaticArray(UInt8, 4).new { rand(256).to_u8 }
   end
 
   def close


### PR DESCRIPTION
~~Quick note: Reason for WIP flag is because there is no spec yet.~~ Spec got added.

Purpose:

From a server perspective, this does not need to be there. However, when used from a client perspective, you are most (if not all) of the times required to mask your data. This PR allows sending data while requesting to send it masked to the receiver.

I have opted to not create a separate method for it as it basically does the same as the normal 'send' method.

Any feedback is appreciated :)