### PR TITLE
String#succ

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1175,6 +1175,56 @@ describe "String" do
     assert { "12".rjust(7, 'あ').should eq("あああああ12") }
   end
 
+  describe "succ" do
+    it "returns an empty string for empty strings" do
+      "".succ.should eq("")
+    end
+
+    it "returns the successor by increasing the rightmost alphanumeric (digit => digit, letter => letter with same case)" do
+      "abcd".succ.should eq("abce")
+      "THX1138".succ.should eq("THX1139")
+
+      "<<koala>>".succ.should eq("<<koalb>>")
+      "==A??".succ.should eq("==B??")
+    end
+
+    it "increases non-alphanumerics (via ascii rules) if there are no alphanumerics" do
+      "***".succ.should eq("**+")
+      "**`".succ.should eq("**a")
+    end
+
+    it "increases the next best alphanumeric (jumping over non-alphanumerics) if there is a carry" do
+      "dz".succ.should eq("ea")
+      "HZ".succ.should eq("IA")
+      "49".succ.should eq("50")
+
+      "izz".succ.should eq("jaa")
+      "IZZ".succ.should eq("JAA")
+      "699".succ.should eq("700")
+
+      "6Z99z99Z".succ.should eq("7A00a00A")
+
+      "1999zzz".succ.should eq("2000aaa")
+      "NZ/[]ZZZ9999".succ.should eq("OA/[]AAA0000")
+    end
+
+    it "adds an additional character (just left to the last increased one) if there is a carry and no character left to increase" do
+      "z".succ.should eq("aa")
+      "Z".succ.should eq("AA")
+      "9".succ.should eq("10")
+
+      "zz".succ.should eq("aaa")
+      "ZZ".succ.should eq("AAA")
+      "99".succ.should eq("100")
+
+      "9Z99z99Z".succ.should eq("10A00a00A")
+
+      "ZZZ9999".succ.should eq("AAAA0000")
+      "/[]ZZZ9999".succ.should eq("/[]AAAA0000")
+      "Z/[]ZZZ9999".succ.should eq("AA/[]AAA0000")
+    end
+  end
+
   it "uses sprintf from top-level" do
     sprintf("Hello %d world", 123).should eq("Hello 123 world")
     sprintf("Hello %d world", [123]).should eq("Hello 123 world")

--- a/src/string.cr
+++ b/src/string.cr
@@ -1800,6 +1800,68 @@ class String
     end
   end
 
+  # Returns the successor of the string. The successor is calculated by incrementing characters starting from the rightmost
+  # alphanumeric (or the rightmost character if there are no alphanumerics) in the string. Incrementing a digit always
+  # results in another digit, and incrementing a letter results in another letter of the same case.
+  #
+  # If the increment generates a “carry”, the character to the left of it is incremented. This process repeats until
+  # there is no carry, adding an additional character if necessary.
+  #
+  # ```
+  # "abcd".succ        #=> "abce"
+  # "THX1138".succ     #=> "THX1139"
+  # "((koala))".succ   #=> "((koalb))"
+  # "1999zzz".succ     #=> "2000aaa"
+  # "ZZZ9999".succ     #=> "AAAA0000"
+  # "***".succ         #=> "**+"
+  # ```
+  def succ
+    return self if length == 0
+
+    chars = self.chars
+
+    carry = nil
+    last_alnum = 0
+    index = length - 1
+
+    while index >= 0
+      s = chars[index]
+      if s.alphanumeric?
+        carry = 0
+        if ('0' <= s && s < '9') ||
+           ('a' <= s && s < 'z') ||
+           ('A' <= s && s < 'Z')
+          chars[index] = s.succ
+          break
+        elsif s == '9'
+          chars[index] = '0'
+          carry = '1'
+        elsif s == 'z'
+          chars[index] = carry = 'a'
+        elsif s == 'Z'
+          chars[index] = carry = 'A'
+        end
+
+        last_alnum = index
+      end
+      index -= 1
+    end
+
+    if carry.nil? # there were no alphanumeric chars
+      chars[length - 1] = chars[length - 1].succ
+    end
+
+    if carry.is_a?(Char) && index < 0 # we still have a carry and already reached the beginning
+      chars.insert(last_alnum, carry)
+    end
+
+    String.build(chars.length) do |str|
+      chars.each do |char|
+        str << char
+      end
+    end
+  end
+
   def match(regex : Regex, pos = 0)
     match = regex.match self, pos
     $~ = match


### PR DESCRIPTION
This PR implements `String#succ`. Its main usecase is being able to use strings to define ranges, such as:

```crystal
("A".."ZZ") #=> ["A", "B", "C", ..., "Z", "AA", "AB", "AC", ..., "ZX", "ZY", "ZZ"]
```

Semantics/behavior (and most of the tests as well) is copied from [Rubyspec](https://github.com/rubyspec/rubyspec/blob/archive/core/string/shared/succ.rb). The implementation is heavily influenced by that of [Rubinius](https://github.com/rubinius/rubinius/blob/master/kernel/common/string.rb#L1330-1387), with some obvious differences, the main one using characters instead of bytes. Documentation is adapted, with little change, from [MRI's](https://github.com/ruby/ruby/blob/trunk/string.c#L3397-3415) (what a mix!).

A question: the mentioned projects' licenses allow this reuse, but probably require a mention. Any idea what would be the right way to include that mention? A comment in the code maybe?