### PR TITLE
Allow Nested and Multiline Ternary Expr

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -481,6 +481,22 @@ describe "Parser" do
 
   it_parses "1 ? 2 : 3", If.new(1.int32, 2.int32, 3.int32)
   it_parses "1 ? a : b", If.new(1.int32, "a".call, "b".call)
+  it_parses "1 ? a : b ? c : 3", If.new(1.int32, "a".call, If.new("b".call, "c".call, 3.int32))
+  it_parses "a ? 1 : b ? 2 : c ? 3 : 0", If.new("a".call, 1.int32, If.new("b".call, 2.int32, If.new("c".call, 3.int32, 0.int32)))
+  it_parses "a ? 1
+             : b", If.new("a".call, 1.int32, "b".call)
+  it_parses "a ? 1 :
+             b ? 2 :
+             c ? 3
+             : 0", If.new("a".call, 1.int32, If.new("b".call, 2.int32, If.new("c".call, 3.int32, 0.int32)))
+  it_parses "a ? 1
+             : b ? 2
+             : c ? 3
+             : 0", If.new("a".call, 1.int32, If.new("b".call, 2.int32, If.new("c".call, 3.int32, 0.int32)))
+  it_parses "a ?
+             b ? b1 : b2
+             : c ? 3
+             : 0", If.new("a".call, If.new("b".call, "b1".call, "b2".call), If.new("c".call, 3.int32, 0.int32))
 
   it_parses "1 if 3", If.new(3.int32, 1.int32)
   it_parses "1 unless 3", Unless.new(3.int32, 1.int32)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -385,16 +385,23 @@ module Crystal
     end
 
     def parse_question_colon
-      location = @token.location
       cond = parse_range
+
       while @token.type == :"?"
+        location = @token.location
+
         check_void_value cond, location
 
         next_token_skip_space_or_newline
-        true_val = parse_range
-        check :":"
+        next_token_skip_space_or_newline if @token.type == :":"
+        true_val = parse_question_colon
+
+        check [:":", :NEWLINE]
+
         next_token_skip_space_or_newline
-        false_val = parse_range
+        next_token_skip_space_or_newline if @token.type == :":"
+        false_val = parse_question_colon
+
         cond = If.new(cond, true_val, false_val)
       end
       cond


### PR DESCRIPTION
This PR makes ternary expressions behave in a way consistent with Ruby by allowing both multline and nested ternaries. For example: 
```cr

def test(obj)
    puts obj.is_a?(Hash) ? "Hash"
    : obj.is_a?(Array)   ? "Array"
    : obj.is_a?(Int)     ? "Int"
    : obj.is_a?(String)  ? "String"
    : "I dont know"
end

test({} of String => String)
=> Hash
test([1])
=> Array
test("")
=> String
test(1)
=> Int
test(1.25)
=> I dont know
```

It allows nesting on either the left or right hand side of the expression.

Apologies if this behavior is excluded by design. However, I've found myself using ternary expressions way more than usual in crystal. 

I believe that the current behavior of nested ternaries is broken (although it could be intended), eg:
```cr
a ? "a" : b ? "b" : "neither" 
```
Compiles to:
```cr
if if a 
    "a"
  else
     b
  end
  "b"
else
  "neither"
end
```
This is valid syntax, but a bit odd. See a demonstration here:
http://play.crystal-lang.org/#/r/8pv

