### PR TITLE
Fix nanosecond lie in HTTP::LogHandler

### DIFF
--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -19,6 +19,6 @@ class HTTP::LogHandler < HTTP::Handler
     millis = elapsed.total_milliseconds
     return "#{millis.round(2)}ms" if millis >= 1
 
-    "#{(millis * 1000).round(2)}ns"
+    "#{(millis * 1000).round(2)}µs"
   end
 end


### PR DESCRIPTION
Fix nanosecond lie in HTTP::LogHandler

A thousand nanoseconds equal to one microsecond.

A thousand microseconds equals to one millisecond.

*sigh*

My app just got a thousand times slower.