### PR TITLE
Escaped '<' and '>' characters during the creation of documentation

### DIFF
--- a/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
@@ -120,8 +120,8 @@ class Crystal::Doc::MarkdownDocRenderer < Markdown::HTMLRenderer
 
   def end_code
     if @inside_code
-      text = Highlighter.highlight @code_buffer.to_s
-      @io << text
+      text = @code_buffer.to_s.gsub('<', "&lt;").gsub('>', "&gt;")
+      @io << Highlighter.highlight(text)
     end
 
     @inside_code = false

--- a/src/html/builder.cr
+++ b/src/html/builder.cr
@@ -11,7 +11,7 @@ require "html"
 #   text "crystal is awesome"
 # end
 #
-# puts html # => "<a href="google.com">crystal is awesome</a>
+# puts html # => <a href="google.com">crystal is awesome</a>
 # ```
 #
 # Or also you can use `build` method:
@@ -21,7 +21,7 @@ require "html"
 #   a({href: "google.com"}) do
 #     text "crystal is awesome"
 #   end
-# end # => "<a href="google.com">crystal is awesome</a>
+# end # => <a href="google.com">crystal is awesome</a>
 # ```
 struct HTML::Builder
   def initialize


### PR DESCRIPTION
Fixed #1067 

![screenshot 2015-07-31 21 13 33](https://cloud.githubusercontent.com/assets/1147484/9014122/096d68c0-37c9-11e5-81e4-27b06ca67cc6.jpg)

/cc @bcardiff