### PR TITLE
Fix documentation typo for URI#query

### DIFF
--- a/src/uri.cr
+++ b/src/uri.cr
@@ -70,7 +70,7 @@ class URI
   # Returns the query component of the URI.
   #
   # ```
-  # URI.parse("http://foo.com/bar?q=1").host # => "q=1"
+  # URI.parse("http://foo.com/bar?q=1").query # => "q=1"
   # ```
   getter query
 


### PR DESCRIPTION
Just a really tiny thing :)