### PR TITLE
Do not delegate to LibSSL when there is nothing to read

### DIFF
--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -18,6 +18,7 @@ class OpenSSL::SSL::Socket
   end
 
   def read(slice : Slice(UInt8), count)
+    return 0 if count == 0
     LibSSL.ssl_read(@ssl, slice.pointer(count), count)
   end
 


### PR DESCRIPTION
In a HTTP::FixedLenghtContent that has an OpenSSL::SSL::Socket as it's
io, the connection was just hanging. This is because the last cycle of
the read loop would know that there are 0 remaining bytes to be read,
but the loop wouldn't actually break until the io's read tells it it has
read 0 bytes.

Apparently, LibSSL does not like to be asked to read 0 bytes, which we
would do every time. So, the solution is just to not delegate to LibSSL
at all in that situation.