### PR TITLE
CGI.parse: avoid malformed query string to raise exception

### DIFF
--- a/spec/std/cgi_spec.cr
+++ b/spec/std/cgi_spec.cr
@@ -58,6 +58,8 @@ describe "CGI" do
     { "foo=hello%2Bworld", {"foo" => ["hello+world"]} },
     { "foo=", {"foo" => [""]} },
     { "foo", {"foo" => [""]} },
+    { "foo=&bar", { "foo" => [""], "bar" => [""] } },
+    { "bar&foo", { "bar" => [""], "foo" => [""] } },
   ].each do |tuple|
     from, to = tuple
     it "parses #{from}" do

--- a/src/cgi.cr
+++ b/src/cgi.cr
@@ -76,7 +76,14 @@ module CGI
       when '&', ';'
         value = buffer.to_s
         buffer.clear
-        yield key.not_nil!, value
+
+        if key
+          yield key.not_nil!, value
+        else
+          yield value, ""
+        end
+
+        key = nil
         i += 1
       else
         i = unescape_one query, bytesize, i, byte, char, buffer


### PR DESCRIPTION
While RFC 3986 does not specify details of query format and
`key=value` requirement, it is known that query parameters without
value can omit both value reference or equal sign entirely.

In the wild, this might result in several query parameters that
do not include values:

```
pretty&expand
order=&pretty
```

These two scenarios weren't properly handled by `CGI.parse` and
resulted in a exception and improper association of value,
respectively.

The changes presented in this commit address those two scenarios
and match query-string parsing to the one found in Ruby.

```
$ ruby -v -rpp -rcgi -e 'pp CGI.parse("foo&bar")'
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]
{"foo"=>[], "bar"=>[]}

$ ruby -v -rpp -rcgi -e 'pp CGI.parse("foo=&bar")'
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]
{"foo"=>[""], "bar"=>[]}
```

Sending this pull request for consideration.

Thank you. :heart: :heart: :heart: 