### PR TITLE
Add flat method for arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -429,6 +429,24 @@ describe "Array" do
     end
   end
 
+  describe "flat" do
+    it "flats empty arrays" do
+      ([] of Int32).flat.should eq([] of Int32)
+    end
+
+    it "flats flat arrays" do
+      [1, 2, 3].flat.should eq([1, 2, 3])
+    end
+
+    it "flats a level 2 array" do
+      [[1, 2], 5, [3, 4]].flat.should eq([1, 2, 5, 3, 4])
+    end
+
+    it "flats also mixed arrays" do
+      [[1, 2, "a"], 5, "b", [3, 4, "c"]].flat.should eq([1, 2, "a", 5, "b", 3, 4, "c"])
+    end
+  end
+
   describe "flat_map" do
     it "does example 1" do
       [1, 2, 3, 4].flat_map { |e| [e, -e] }.should eq([1, -1, 2, -2, 3, -3, 4, -4])

--- a/src/array.cr
+++ b/src/array.cr
@@ -603,6 +603,20 @@ class Array(T)
     first { nil }
   end
 
+  # Gets you a flat list of the same typed sub arrays.
+  #
+  # ```
+  # a = [[1, "a"], 5, "b", [3, 4, "c"]]
+  # a.flat    #=> [1, "a", 5, "b", 3, 4, "c"]
+  # b = [1, [1, 2, [3]]]
+  # b.flat    #=> Compile Error
+  # ```
+  def flat
+    ary = [] of T
+    each { |e| e.is_a?(Array) ? ary.concat(e) : ary << e }
+    ary
+  end
+
   def hash
     inject(31 * @length) do |memo, elem|
       31 * memo + elem.hash


### PR DESCRIPTION
I set up a really simple `Array#flat` method. I'm not sure yet if this is the way to go. I would be very happy if I could get some feedback about it. Thank you!

(Btw. I'm a little bit confused by the array notation in the specs and the docs as we sometimes use spaces like `[ 3, 4 ]` and `[3, 4]`)