### PR TITLE
Add `Array#zip?`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -936,6 +936,30 @@ describe "Array" do
     end
   end
 
+  describe "zip?" do
+    describe "when a block is provided" do
+      describe "and length of an arg is less than receiver" do
+        it "yields pairs of self's elements and passed array (with nil)" do
+          a, b, r = [1, 2, 3], [4, 5], ""
+          a.zip?(b) { |x, y| r += "#{x}:#{y}," }
+          r.should eq("1:4,2:5,3:,")
+        end
+      end
+    end
+
+    describe "when no block is provided" do
+      describe "and the arrays have different typed elements" do
+        describe "and length of an arg is less than receiver" do
+          it "returns an array of paired elements (tuples with nil)" do
+            a, b = [1, 2, 3], ["a", "b"]
+            r = a.zip?(b)
+            r.should eq([{1, "a"}, {2, "b"}, {3, nil}])
+          end
+        end
+      end
+    end
+  end
+
   it "does compact_map" do
     a = [1, 2, 3, 4, 5]
     b = a.compact_map { |e| e.divisible_by?(2) ? e : nil }

--- a/src/array.cr
+++ b/src/array.cr
@@ -1028,6 +1028,18 @@ class Array(T)
     pairs
   end
 
+  def zip?(other : Array)
+    each_with_index do |elem, i|
+      yield elem, other[i]?
+    end
+  end
+
+  def zip?(other : Array(U))
+    pairs = Array({T, U?}).new(length)
+    zip?(other) { |x, y| pairs << {x, y} }
+    pairs
+  end
+
   private def check_needs_resize
     resize_to_capacity(@capacity * 2) if @length == @capacity
   end


### PR DESCRIPTION
`Array#zip` raises Error when length of an arg is shorter than
the receiver. User should check each arrays length before call
`#zip`. For user dose not care to be included `nil`, add
`Array#zip?`.