### PR TITLE
Implement interpolations within heredocs.

### DIFF
--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1637,12 +1637,8 @@ module Crystal
           old_pos    = current_pos
           old_column = @column_number
 
-          loop do
-            if current_char != ' '
-              break
-            else
-              next_char
-            end
+          while current_char == ' '
+            next_char
           end
 
           if string_end.starts_with?(current_char)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -127,64 +127,35 @@ module Crystal
             next_char :"<<="
           when '-'
             here = StringIO.new(20)
-            here_start = 0
 
             while true
               case char = next_char
               when '\n'
                 @line_number += 1
                 @column_number = 0
-                next_char
-                here_start = current_pos
                 break
+              when '\\'
+                if peek_next_char == 'n'
+                  next_char
+                  raise "invalid heredoc identifier"
+                end
+              when ' '
+                case peek_next_char
+                when ' '
+                  next_char
+                when '\n'
+                  next_char
+                  break
+                else
+                  raise "invalid heredoc identifier"
+                end
               else
                 here << char
               end
             end
 
             here = here.to_s
-            char = next_char
-
-            while true
-              case char
-              when '\0'
-                raise "unterminated heredoc"
-              when '\n'
-                @line_number += 1
-                @column_number = 0
-
-                here_end = current_pos
-                is_here  = false
-                while true
-                  char = peek_next_char
-                  if char != ' '
-                    break
-                  else
-                    next_char
-                  end
-                end
-                here.each_char do |c|
-                  char = next_char
-                  unless char == c
-                    is_here = false
-                    break
-                  end
-                  is_here = true
-                end
-
-                if is_here
-                  peek = peek_next_char
-                  if peek == '\n' || peek == '\0'
-                    next_char
-                    @token.value = string_range(here_start, here_end)
-                    @token.type = :STRING
-                    break
-                  end
-                end
-              else
-                char = next_char
-              end
-            end
+            delimited_pair :heredoc, here, here
           else
             @token.type = :"<<"
           end
@@ -1657,11 +1628,53 @@ module Crystal
           @token.value = "#"
         end
       when '\n'
-        next_char
-        @column_number = 1
-        @line_number += 1
-        @token.type = :STRING
-        @token.value = "\n"
+       next_char
+       @column_number = 1
+       @line_number += 1
+
+       if delimiter_state.kind == :heredoc
+         string_end = string_end.to_s
+         old_pos    = current_pos
+         old_column = @column_number
+
+         loop do
+           if current_char != ' '
+             break
+           else
+             next_char
+           end
+         end
+
+         if string_end.starts_with?(current_char)
+           reached_end = false
+
+           string_end.each_char do |c|
+             unless c == current_char
+               reached_end = false
+               break
+             end
+             next_char
+             reached_end = true
+           end
+
+           if reached_end &&
+             (current_char == '\n' || current_char == '\0')
+             @token.type = :DELIMITER_END
+           else
+             @reader.pos    = old_pos
+             @column_number = old_column
+             next_string_token delimiter_state
+           end
+         else
+           @reader.pos    = old_pos
+           @column_number = old_column
+           @token.type    = :STRING
+           @token.value   = "\n"
+         end
+       else
+         @token.type  = :STRING
+         @token.value = "\n"
+       end
       else
         start = current_pos
         count = 0
@@ -1683,9 +1696,10 @@ module Crystal
 
     def raise_unterminated_quoted(string_end)
       msg = case string_end
-            when '`' then "unterminated command"
-            when '/' then "unterminated regular expression"
-            else          "unterminated string literal"
+            when '`'    then "unterminated command"
+            when '/'    then "unterminated regular expression"
+            when String then "unterminated heredoc"
+            else             "unterminated string literal"
             end
       raise msg, @line_number, @column_number
     end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1628,53 +1628,53 @@ module Crystal
           @token.value = "#"
         end
       when '\n'
-       next_char
-       @column_number = 1
-       @line_number += 1
+        next_char
+        @column_number = 1
+        @line_number += 1
 
-       if delimiter_state.kind == :heredoc
-         string_end = string_end.to_s
-         old_pos    = current_pos
-         old_column = @column_number
+        if delimiter_state.kind == :heredoc
+          string_end = string_end.to_s
+          old_pos    = current_pos
+          old_column = @column_number
 
-         loop do
-           if current_char != ' '
-             break
-           else
-             next_char
-           end
-         end
+          loop do
+            if current_char != ' '
+              break
+            else
+              next_char
+            end
+          end
 
-         if string_end.starts_with?(current_char)
-           reached_end = false
+          if string_end.starts_with?(current_char)
+            reached_end = false
 
-           string_end.each_char do |c|
-             unless c == current_char
-               reached_end = false
-               break
-             end
-             next_char
-             reached_end = true
-           end
+            string_end.each_char do |c|
+              unless c == current_char
+                reached_end = false
+                break
+              end
+              next_char
+              reached_end = true
+            end
 
-           if reached_end &&
-             (current_char == '\n' || current_char == '\0')
-             @token.type = :DELIMITER_END
-           else
-             @reader.pos    = old_pos
-             @column_number = old_column
-             next_string_token delimiter_state
-           end
-         else
-           @reader.pos    = old_pos
-           @column_number = old_column
-           @token.type    = :STRING
-           @token.value   = "\n"
-         end
-       else
-         @token.type  = :STRING
-         @token.value = "\n"
-       end
+            if reached_end &&
+              (current_char == '\n' || current_char == '\0')
+              @token.type = :DELIMITER_END
+            else
+              @reader.pos    = old_pos
+              @column_number = old_column
+              next_string_token delimiter_state
+            end
+          else
+            @reader.pos    = old_pos
+            @column_number = old_column
+            @token.type    = :STRING
+            @token.value   = "\n"
+          end
+        else
+          @token.type  = :STRING
+          @token.value = "\n"
+        end
       else
         start = current_pos
         count = 0

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1588,6 +1588,8 @@ module Crystal
             raise "Unterminated command"
           when :regex
             raise "Unterminated regular expression"
+          when :heredoc
+            raise "Unterminated heredoc"
           else
             raise "Unterminated string literal"
           end


### PR DESCRIPTION
This pull request implements heredocs as a delimited pair within the lexer, allowing string interpolation as a solution for #1066.

I had to adjust the heredoc specs to match the new implementation.

This patch also fixes a bug I stumbled upon when implementing a fix:
```crystal
a = <<-EOS\n #=> bug in compiler, index out of bounds
```
as seen [here](http://play.crystal-lang.org/#/r/9kd) (the above code now raises `invalid heredoc identifier`).