### PR TITLE
Fixed to run a inherited hook after class def

### DIFF
--- a/spec/compiler/codegen/hooks_spec.cr
+++ b/spec/compiler/codegen/hooks_spec.cr
@@ -66,4 +66,21 @@ describe "Code gen: hooks" do
       $x
       ").to_i.should eq(2)
   end
+
+  it "does inherited macro after class def" do
+    run("
+      $x = 0
+      class Foo
+        macro inherited
+          $y = $x
+        end
+      end
+
+      class Bar < Foo
+        $x += 1
+      end
+
+      $y
+      ").to_i.should eq(1)
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -445,9 +445,9 @@ module Crystal
     end
 
     def visit(node : ClassDef)
-      node.runtime_initializers.try &.each &.accept self
-
       accept node.body
+
+      node.runtime_initializers.try &.each &.accept self
       @last = llvm_nil
       false
     end


### PR DESCRIPTION
http://carc.in/#/r/9kp

```crystal
class A
  macro inherited
    {{p :inherit_mac}}
    p :inherit_run
  end
end

p :before
class B < A
  {{p :inner}}
  p :inner
end
p :after
```

I expected such a result:

```
:inner
:inherit_mac
:before
:inner
:inherit_run
:after
```

But `crystal run` returns such that:

```
:inner
:inherit_mac
:before
:inherit_run
:inner
:after
```

So I fixed it.