### PR TITLE
Update code of conduct to Contributor Covenant version 1.2.0

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,31 +1,22 @@
-Contributor Code of Conduct
+# Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all
-people who contribute through reporting issues, posting feature requests,
-updating documentation, submitting pull requests or patches, and other
-activities.
+As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
 
-Examples of unacceptable behavior by participants include the use of sexual
-language or imagery, derogatory comments or personal attacks, trolling, public
-or private harassment, insults, or other unprofessional conduct.
+Examples of unacceptable behavior by participants include:
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct. Project maintainers who do not
-follow the Code of Conduct may be removed from the project team.
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Other unethical or unprofessional conduct.
 
-This code of conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening an issue or contacting one or more of the project
-maintainers.
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
 
-This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.1.0, available at
-http://contributor-covenant.org/version/1/1/0/
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/Contributing.md
+++ b/Contributing.md
@@ -72,6 +72,7 @@ If this guide is not clear and it needs improvements, please send pull requests 
 
 ## Code of Conduct
 
-Contributors to this project are expected to review and uphold the [code of conduct][coc].
+Please note that this project is released with a [Contributor Code of Conduct][ccoc].
+By participating in this project you agree to abide by its terms.
 
-[coc]: https://github.com/manastech/crystal/blob/master/CODE_OF_CONDUCT.md
+[ccoc]: https://github.com/manastech/crystal/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
@waj I didn’t have a chance to respond to your [question](https://github.com/manastech/crystal/pull/1081#issuecomment-127337111) before you merged https://github.com/manastech/crystal/pull/1081. I copied version 1.1.0 from [Bundler](https://github.com/bundler/bundler) but I don’t see any reason not to use the latest version.

I’ve also updated `Contributing.md` to use the introductory language recommended at http://contributor-covenant.org/.