### PR TITLE
Fix to parse `foo.[]?(bar)`

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1033,6 +1033,7 @@ describe "Parser" do
   it_parses "enum Foo; protected def foo; 1; end; end", EnumDef.new("Foo".path, [VisibilityModifier.new(:protected, Def.new("foo", body: 1.int32))] of ASTNode)
 
   it_parses "1.[](2)", Call.new(1.int32, "[]", 2.int32)
+  it_parses "1.[]?(2)", Call.new(1.int32, "[]?", 2.int32)
   it_parses "1.[]=(2, 3)", Call.new(1.int32, "[]=", 2.int32, 3.int32)
 
   it_parses "a @b-1\nc", [Call.new(nil, "a", Call.new("@b".instance_var, "-", 1.int32)), "c".call] of ASTNode

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -511,7 +511,7 @@ module Crystal
 
     parse_operator :pow, :atomic_with_method, "Call.new left, method, [right] of ASTNode, name_column_number: method_column_number", ":\"**\""
 
-    AtomicWithMethodCheck = [:IDENT, :"+", :"-", :"*", :"/", :"%", :"|", :"&", :"^", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :">>", :">", :">=", :"<=>", :"||", :"&&", :"===", :"[]", :"[]=", :"!"]
+    AtomicWithMethodCheck = [:IDENT, :"+", :"-", :"*", :"/", :"%", :"|", :"&", :"^", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :">>", :">", :">=", :"<=>", :"||", :"&&", :"===", :"[]", :"[]=", :"[]?", :"!"]
 
     def parse_atomic_with_method
       location = @token.location


### PR DESCRIPTION
It's a tiny fix.

http://play.crystal-lang.org/#/r/a13

```crystal
foo.[]?(bar)
```

```
Syntax error in eval:1: expecting any of these tokens: IDENT, +, -, *, /, %, |, &, ^, **, <<, <, <=, ==, !=, =~, >>, >, >=, <=>, ||, &&, ===, [], []=, ! (not '[]?')
```