### PR TITLE
Parse empty HTTP header

### DIFF
--- a/spec/std/http/client_spec.cr
+++ b/spec/std/http/client_spec.cr
@@ -20,7 +20,7 @@ module HTTP
 
     it "raises if URI is missing scheme" do
       expect_raises(ArgumentError) do
-        HTTP::Client.get "www.google.com"
+        HTTP::Client.get "www.example.com"
       end
     end
   end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -5,12 +5,12 @@ module HTTP
   describe Request do
     it "serialize GET" do
       headers = HTTP::Headers.new
-      headers["Host"] = "host.domain.com"
+      headers["Host"] = "host.example.org"
       request = Request.new "GET", "/", headers
 
       io = StringIO.new
       request.to_io(io)
-      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")
+      io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
     end
 
     it "serialize POST (with body)" do
@@ -21,25 +21,26 @@ module HTTP
     end
 
     it "parses GET" do
-      request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")).not_nil!
+      request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).not_nil!
       request.method.should eq("GET")
       request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.domain.com"})
+      request.headers.should eq({"Host" => "host.example.org"})
     end
 
+
     it "parses GET without \\r" do
-      request = Request.from_io(StringIO.new("GET / HTTP/1.1\nHost: host.domain.com\n\n")).not_nil!
+      request = Request.from_io(StringIO.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).not_nil!
       request.method.should eq("GET")
       request.path.should eq("/")
-      request.headers.should eq({"Host" => "host.domain.com"})
+      request.headers.should eq({"Host" => "host.example.org"})
     end
 
     it "headers are case insensitive" do
-      request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.domain.com\r\n\r\n")).not_nil!
+      request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).not_nil!
       headers = request.headers.not_nil!
-      headers["HOST"].should eq("host.domain.com")
-      headers["host"].should eq("host.domain.com")
-      headers["Host"].should eq("host.domain.com")
+      headers["HOST"].should eq("host.example.org")
+      headers["host"].should eq("host.example.org")
+      headers["Host"].should eq("host.example.org")
     end
 
     it "parses POST (with body)" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -35,6 +35,13 @@ module HTTP
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
+    it "parses empty header" do
+      request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\nReferer:\r\n\r\n")).not_nil!
+      request.method.should eq("GET")
+      request.path.should eq("/")
+      request.headers.should eq({"Host" => "host.example.org", "Referer" => ""})
+    end
+
     it "headers are case insensitive" do
       request = Request.from_io(StringIO.new("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).not_nil!
       headers = request.headers.not_nil!

--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -79,12 +79,12 @@ describe Markdown do
   assert_render "01. Hello\n02. World", "<ol><li>Hello</li><li>World</li></ol>"
   assert_render "Params:\n  1. Foo\n  2. Bar", "<p>Params:</p>\n\n<ol><li>Foo</li><li>Bar</li></ol>"
 
-  assert_render "Hello [world](http://foo.com)", %(<p>Hello <a href="http://foo.com">world</a></p>)
-  assert_render "Hello [world](http://foo.com)!", %(<p>Hello <a href="http://foo.com">world</a>!</p>)
-  assert_render "Hello [world **2**](http://foo.com)!", %(<p>Hello <a href="http://foo.com">world <strong>2</strong></a>!</p>)
+  assert_render "Hello [world](http://example.com)", %(<p>Hello <a href="http://example.com">world</a></p>)
+  assert_render "Hello [world](http://example.com)!", %(<p>Hello <a href="http://example.com">world</a>!</p>)
+  assert_render "Hello [world **2**](http://example.com)!", %(<p>Hello <a href="http://example.com">world <strong>2</strong></a>!</p>)
 
-  assert_render "Hello ![world](http://foo.com)", %(<p>Hello <img src="http://foo.com" alt="world"/></p>)
-  assert_render "Hello ![world](http://foo.com)!", %(<p>Hello <img src="http://foo.com" alt="world"/>!</p>)
+  assert_render "Hello ![world](http://example.com)", %(<p>Hello <img src="http://example.com" alt="world"/></p>)
+  assert_render "Hello ![world](http://example.com)!", %(<p>Hello <img src="http://example.com" alt="world"/>!</p>)
 
   assert_render "[![foo](bar)](baz)", %(<p><a href="baz"><img src="bar" alt="foo"/></a></p>)
 
@@ -95,5 +95,5 @@ describe Markdown do
 
   assert_render "hello < world", "<p>hello &lt; world</p>"
 
-  assert_render "Hello __[World](http://foo.com)__!", %(<p>Hello <strong><a href="http://foo.com">World</a></strong>!</p>)
+  assert_render "Hello __[World](http://example.com)__!", %(<p>Hello <strong><a href="http://example.com">World</a></strong>!</p>)
 end

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -17,47 +17,47 @@ private def assert_uri(string, scheme = nil, host = nil, port = nil, path = "", 
 end
 
 describe "URI" do
-  assert_uri("http://www.google.com", scheme: "http", host: "www.google.com")
-  assert_uri("http://www.google.com:81", scheme: "http", host: "www.google.com", port: 81)
-  assert_uri("http://www.google.com/foo", scheme: "http", host: "www.google.com", path: "/foo")
-  assert_uri("http://www.google.com/foo?q=1", scheme: "http", host: "www.google.com", path: "/foo", query: "q=1")
-  assert_uri("http://www.google.com?q=1", scheme: "http", host: "www.google.com", query: "q=1")
-  assert_uri("https://www.google.com", scheme: "https", host: "www.google.com")
-  assert_uri("https://alice:pa55w0rd@www.google.com", scheme: "https", host: "www.google.com", user: "alice", password: "pa55w0rd")
-  assert_uri("https://alice@www.google.com", scheme: "https", host: "www.google.com", user: "alice", password: nil)
-  assert_uri("https://www.google.com/#top", scheme: "https", host: "www.google.com", path: "/", fragment: "top")
-  assert_uri("http://www.foo-bar.com", scheme: "http", host: "www.foo-bar.com")
+  assert_uri("http://www.example.com", scheme: "http", host: "www.example.com")
+  assert_uri("http://www.example.com:81", scheme: "http", host: "www.example.com", port: 81)
+  assert_uri("http://www.example.com/foo", scheme: "http", host: "www.example.com", path: "/foo")
+  assert_uri("http://www.example.com/foo?q=1", scheme: "http", host: "www.example.com", path: "/foo", query: "q=1")
+  assert_uri("http://www.example.com?q=1", scheme: "http", host: "www.example.com", query: "q=1")
+  assert_uri("https://www.example.com", scheme: "https", host: "www.example.com")
+  assert_uri("https://alice:pa55w0rd@www.example.com", scheme: "https", host: "www.example.com", user: "alice", password: "pa55w0rd")
+  assert_uri("https://alice@www.example.com", scheme: "https", host: "www.example.com", user: "alice", password: nil)
+  assert_uri("https://www.example.com/#top", scheme: "https", host: "www.example.com", path: "/", fragment: "top")
+  assert_uri("http://www.foo-bar.example.com", scheme: "http", host: "www.foo-bar.example.com")
   assert_uri("/foo", path: "/foo")
   assert_uri("/foo?q=1", path: "/foo", query: "q=1")
   assert_uri("mailto:foo@example.org", scheme: "mailto", path: nil, opaque: "foo@example.org")
 
-  assert { URI.parse("http://www.google.com/foo").full_path.should eq("/foo") }
-  assert { URI.parse("http://www.google.com").full_path.should eq("/") }
-  assert { URI.parse("http://www.google.com/foo?q=1").full_path.should eq("/foo?q=1") }
-  assert { URI.parse("http://www.google.com/?q=1").full_path.should eq("/?q=1") }
-  assert { URI.parse("http://www.google.com?q=1").full_path.should eq("/?q=1") }
+  assert { URI.parse("http://www.example.com/foo").full_path.should eq("/foo") }
+  assert { URI.parse("http://www.example.com").full_path.should eq("/") }
+  assert { URI.parse("http://www.example.com/foo?q=1").full_path.should eq("/foo?q=1") }
+  assert { URI.parse("http://www.example.com/?q=1").full_path.should eq("/?q=1") }
+  assert { URI.parse("http://www.example.com?q=1").full_path.should eq("/?q=1") }
 
   describe "userinfo" do
-    assert { URI.parse("http://www.google.com").userinfo.should be_nil }
-    assert { URI.parse("http://foo@www.google.com").userinfo.should eq("foo") }
-    assert { URI.parse("http://foo:bar@www.google.com").userinfo.should eq("foo:bar") }
+    assert { URI.parse("http://www.example.com").userinfo.should be_nil }
+    assert { URI.parse("http://foo@www.example.com").userinfo.should eq("foo") }
+    assert { URI.parse("http://foo:bar@www.example.com").userinfo.should eq("foo:bar") }
   end
 
   describe "to_s" do
-    assert { URI.new("http", "www.google.com").to_s.should eq("http://www.google.com") }
-    assert { URI.new("http", "www.google.com", 80).to_s.should eq("http://www.google.com") }
+    assert { URI.new("http", "www.example.com").to_s.should eq("http://www.example.com") }
+    assert { URI.new("http", "www.example.com", 80).to_s.should eq("http://www.example.com") }
     assert do
-      u = URI.new("http", "www.google.com")
+      u = URI.new("http", "www.example.com")
       u.user = "alice"
-      u.to_s.should eq("http://alice@www.google.com")
+      u.to_s.should eq("http://alice@www.example.com")
       u.password = "s3cr3t"
-      u.to_s.should eq("http://alice:s3cr3t@www.google.com")
+      u.to_s.should eq("http://alice:s3cr3t@www.example.com")
     end
-    assert { URI.new("http", "www.google.com", user: "@al:ce", password: "s/cr3t").to_s.should eq("http://%40al%3Ace:s%2Fcr3t@www.google.com") }
-    assert { URI.new("http", "www.google.com", fragment: "top").to_s.should eq("http://www.google.com#top") }
-    assert { URI.new("http", "www.google.com", 1234).to_s.should eq("http://www.google.com:1234") }
-    assert { URI.new("http", "www.google.com", 80, "/hello").to_s.should eq("http://www.google.com/hello") }
-    assert { URI.new("http", "www.google.com", 80, "/hello", "a=1").to_s.should eq("http://www.google.com/hello?a=1") }
+    assert { URI.new("http", "www.example.com", user: "@al:ce", password: "s/cr3t").to_s.should eq("http://%40al%3Ace:s%2Fcr3t@www.example.com") }
+    assert { URI.new("http", "www.example.com", fragment: "top").to_s.should eq("http://www.example.com#top") }
+    assert { URI.new("http", "www.example.com", 1234).to_s.should eq("http://www.example.com:1234") }
+    assert { URI.new("http", "www.example.com", 80, "/hello").to_s.should eq("http://www.example.com/hello") }
+    assert { URI.new("http", "www.example.com", 80, "/hello", "a=1").to_s.should eq("http://www.example.com/hello?a=1") }
     assert { URI.new("mailto", opaque: "foo@example.com").to_s.should eq("mailto:foo@example.com") }
   end
 end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -33,8 +33,9 @@ module HTTP
     cstr = line.to_unsafe
     bytesize = line.bytesize
 
-    # Get the colon index
+    # Get the colon index and name
     colon_index = cstr.to_slice(bytesize).index(':'.ord) || 0
+    name = line.byte_slice(0, colon_index)
 
     # Get where the header value starts (skip space)
     middle_index = colon_index + 1
@@ -44,13 +45,14 @@ module HTTP
 
     # Get where the header value ends (chomp line)
     right_index = bytesize
-    if right_index > 1 && cstr[right_index - 2] === '\r' && cstr[right_index - 1] === '\n'
+    if middle_index >= right_index
+      return {name, ""}
+    elsif right_index > 1 && cstr[right_index - 2] === '\r' && cstr[right_index - 1] === '\n'
       right_index -= 2
     elsif right_index > 0 && cstr[right_index - 1] === '\n'
       right_index -= 1
     end
 
-    name = line.byte_slice(0, colon_index)
     value = line.byte_slice(middle_index, right_index - middle_index)
 
     {name, value}


### PR DESCRIPTION
Which are perfectly valid. Related to discussion in #1077

Also slay uses of non RFC2606 domains in the specs