### PR TITLE
Fixed to_s for macros AST

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -28,4 +28,13 @@ describe "ASTNode#to_s" do
   expect_to_s %(foo do |k, v|\n  k.bar(1, 2, 3)\nend)
   expect_to_s %(foo(3, &.*(2)))
   expect_to_s %(return begin\n  1\n  2\nend)
+  expect_to_s %(macro foo\n  %bar = 1\nend)
+  expect_to_s %(macro foo\n  %bar = 1; end)
+  expect_to_s %(macro foo\n  %bar{1, x} = 1\nend)
+  expect_to_s %({% foo %})
+  expect_to_s %({{ foo }})
+  expect_to_s %({% if foo %}\n  foo_then\n{% end %})
+  expect_to_s %({% if foo %}\n  foo_then\n{% else %}\n  foo_else\n{% end %})
+  expect_to_s %({% for foo in bar %}\n  {{ foo }}\n{% end %})
+  expect_to_s %(macro foo\n  {% for foo in bar %}\n    {{ foo }}\n  {% end %}\nend)
 end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1879,13 +1879,11 @@ module Crystal
 
   # if inside a macro
   #
-  #     {% 'if' cond }
+  #     {% 'if' cond %}
   #       then
-  #     [
-  #     {% 'else' }
+  #     {% 'else' %}
   #       else
-  #     ]
-  #     %{ 'end' }
+  #     {% 'end' %}
   class MacroIf < ASTNode
     property :cond
     property :then
@@ -1911,9 +1909,9 @@ module Crystal
 
   # for inside a macro:
   #
-  #    {- for x1, x2, ... , xn in exp }
+  #    {% for x1, x2, ... , xn in exp %}
   #      body
-  #    {- end }
+  #    {% end %}
   class MacroFor < ASTNode
     property vars
     property exp

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -615,7 +615,7 @@ module Crystal
       accept_with_indent node.body
       @inside_macro = false
 
-      newline
+      # newline
       append_indent
       @str << keyword("end")
       false
@@ -623,8 +623,9 @@ module Crystal
 
     def visit(node : MacroExpression)
       @str << (node.output ? "{{" : "{% ")
-      @str << " "
+      @str << " " if node.output
       node.exp.accept self
+      @str << " " if node.output
       @str << (node.output ? "}}" : " %}")
       false
     end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -632,13 +632,13 @@ module Crystal
     def visit(node : MacroIf)
       @str << "{% if "
       node.cond.accept self
-      @str << " }"
+      @str << " %}"
       node.then.accept self
       unless node.else.nop?
-        @str << "{% else }"
+        @str << "{% else %}"
         node.else.accept self
       end
-      @str << "{% end }"
+      @str << "{% end %}"
       false
     end
 
@@ -650,9 +650,9 @@ module Crystal
       end
       @str << " in "
       node.exp.accept self
-      @str << " }"
+      @str << " %}"
       node.body.accept self
-      @str << "{% end }"
+      @str << "{% end %}"
       false
     end
 


### PR DESCRIPTION
I fixed a bug:

```crystal
macro print_in_compile(foo)
  {% p foo %}
end
print_in_compile({% for x in [1, 2] %}{% end %})
#=> {% for x in [1, 2] }{% end }
# What? missing '%' at close macro expansion?
```

and some indents for macros AST.