### PR TITLE
Base64

### DIFF
--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -104,15 +104,10 @@ describe "Base64" do
       Base64.strict_encode("Now is the time for all good coders\nto learn Crystal").should eq(
         "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")
     end
-    it "decode" do
-      Base64.strict_decode("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
-       "Now is the time for all good coders\nto learn Crystal")
-    end
     it "with spec symbols" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
       Base64.strict_encode(s).should eq(se)
-      Base64.strict_decode(se).should eq(s)
     end
   end
 
@@ -121,9 +116,7 @@ describe "Base64" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw"
       Base64.urlsafe_encode(s).should eq(se)
-      Base64.urlsafe_decode(se).should eq(s)
     end
   end
 
 end
-

--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -9,25 +9,25 @@ describe "Base64" do
            "abcdefg" => "YWJjZGVmZw==\n"}
     eqs.each do |a, b|
       it "encode #{a.inspect} to #{b.inspect}" do
-        Base64.encode64(a).should eq(b)
+        Base64.encode(a).should eq(b)
       end
       it "decode from #{b.inspect} to #{a.inspect}" do
-        Base64.decode64(b).should eq(a)
+        Base64.decode(b).should eq(a)
       end
     end
   end
 
   it "encodes byte slice" do
     slice = Slice(UInt8).new(5) { 1_u8 }
-    Base64.encode64(slice).should eq("AQEBAQE=\n")
-    Base64.strict_encode64(slice).should eq("AQEBAQE=")
+    Base64.encode(slice).should eq("AQEBAQE=\n")
+    Base64.strict_encode(slice).should eq("AQEBAQE=")
   end
 
   it "encodes static array" do
     array :: StaticArray(UInt8, 5)
     (0...5).each { |i| array[i] = 1_u8 }
-    Base64.encode64(array).should eq("AQEBAQE=\n")
-    Base64.strict_encode64(array).should eq("AQEBAQE=")
+    Base64.encode(array).should eq("AQEBAQE=\n")
+    Base64.strict_encode(array).should eq("AQEBAQE=")
   end
 
   describe "base" do
@@ -38,81 +38,81 @@ describe "Base64" do
            "hahah⊙ⓧ⊙" => "aGFoYWjiipnik6fiipk=\n"}
     eqs.each do |a, b|
       it "encode #{a.inspect} to #{b.inspect}" do
-        Base64.encode64(a).should eq(b)
+        Base64.encode(a).should eq(b)
       end
       it "decode from #{b.inspect} to #{a.inspect}" do
-        Base64.decode64(b).should eq(a)
+        Base64.decode(b).should eq(a)
       end
     end
 
     it "decode from strict form" do
-      Base64.decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
+      Base64.decode("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
        "Now is the time for all good coders\nto learn Crystal")
     end
 
     it "big message" do
       a = "a" * 100000
-      b = Base64.encode64(a)
-      Crypto::MD5.hex_digest(Base64.decode64(b)).should eq(Crypto::MD5.hex_digest(a))
+      b = Base64.encode(a)
+      Crypto::MD5.hex_digest(Base64.decode(b)).should eq(Crypto::MD5.hex_digest(a))
     end
 
     it "works for most characters" do
       a = String.build(65536 * 4) do |buf|
         65536.times { |i| buf << (i + 1).chr }
       end
-      b = Base64.encode64(a)
-      Crypto::MD5.hex_digest(Base64.decode64(b)).should eq(Crypto::MD5.hex_digest(a))
+      b = Base64.encode(a)
+      Crypto::MD5.hex_digest(Base64.decode(b)).should eq(Crypto::MD5.hex_digest(a))
     end
   end
 
   describe "decode cases" do
     it "decode \r\n" do
-      Base64.decode64("aGFo\r\nYWjiipnik6fiipk=\r\n").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\r\nYWjiipnik6fiipk=\r\n\r\n").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\r\nYWjiipnik6fiipk=\r\n").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\r\nYWjiipnik6fiipk=\r\n\r\n").should eq("hahah⊙ⓧ⊙")
     end
 
     it "decode \n in multiple places" do
-      Base64.decode64("aGFoYWjiipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\nYWjiipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\nYWji\nipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\nYWji\nipni\nk6fiipk=").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\nYWji\nipni\nk6fi\nipk=").should eq("hahah⊙ⓧ⊙")
-      Base64.decode64("aGFo\nYWji\nipni\nk6fi\nipk=\n").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFoYWjiipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\nYWjiipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\nYWji\nipnik6fiipk=").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\nYWji\nipni\nk6fiipk=").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\nYWji\nipni\nk6fi\nipk=").should eq("hahah⊙ⓧ⊙")
+      Base64.decode("aGFo\nYWji\nipni\nk6fi\nipk=\n").should eq("hahah⊙ⓧ⊙")
     end
 
     it "raise error when \n in incorrect place" do
       expect_raises Base64::Error do
-        Base64.decode64("aG\nFoYWjiipnik6fiipk=")
+        Base64.decode("aG\nFoYWjiipnik6fiipk=")
       end
     end
 
     it "raise error when incorrect symbol" do
       expect_raises Base64::Error do
-        Base64.decode64("()")
+        Base64.decode("()")
       end
     end
 
     it "raise error when incorrect length" do
       expect_raises Base64::Error do
-        Base64.decode64("a")
+        Base64.decode("a")
       end
     end
   end
 
   describe "scrict" do
     it "encode" do
-      Base64.strict_encode64("Now is the time for all good coders\nto learn Crystal").should eq(
+      Base64.strict_encode("Now is the time for all good coders\nto learn Crystal").should eq(
         "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==")
     end
     it "decode" do
-      Base64.strict_decode64("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
+      Base64.strict_decode("Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==").should eq(
        "Now is the time for all good coders\nto learn Crystal")
     end
     it "with spec symbols" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq/CsMKxwrLCsw=="
-      Base64.strict_encode64(s).should eq(se)
-      Base64.strict_decode64(se).should eq(s)
+      Base64.strict_encode(s).should eq(se)
+      Base64.strict_decode(se).should eq(s)
     end
   end
 
@@ -120,8 +120,8 @@ describe "Base64" do
     it "work" do
       s = String.build { |b| (160..179).each{|i| b << i.chr } }
       se = "wqDCocKiwqPCpMKlwqbCp8KowqnCqsKrwqzCrcKuwq_CsMKxwrLCsw"
-      Base64.urlsafe_encode64(s).should eq(se)
-      Base64.urlsafe_decode64(se).should eq(s)
+      Base64.urlsafe_encode(s).should eq(se)
+      Base64.urlsafe_decode(se).should eq(s)
     end
   end
 

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -47,10 +47,10 @@ module Base64
   #     Q3J5c3RhbA==
   def encode64(data)
     slice = data.to_slice
-    String.new(encode_size(slice.length, true)) do |buf|
+    String.new(encode_size(slice.length, new_lines: true)) do |buf|
       inc = 0
       appender = buf.appender
-      to_base64(slice, CHARS_STD, true) do |byte|
+      to_base64(slice, CHARS_STD, pad: true) do |byte|
         appender << byte
         inc += 1
         if inc >= LINE_SIZE
@@ -79,7 +79,7 @@ module Base64
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
       appender = buf.appender
-      to_base64(slice, CHARS_STD, true) { |byte| appender << byte }
+      to_base64(slice, CHARS_STD, pad: true) { |byte| appender << byte }
       count = appender.count
       {count, count}
     end
@@ -97,7 +97,7 @@ module Base64
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
       appender = buf.appender
-      to_base64(slice, CHARS_SAFE, padding) { |byte| appender << byte }
+      to_base64(slice, CHARS_SAFE, pad: padding) { |byte| appender << byte }
       count = appender.count
       {count, count}
     end

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -1,17 +1,50 @@
+# The Base64 module provides for the encoding (`encode`, `strict_encode`,
+# `urlsafe_encode`) and decoding (`decode`, `strict_decode`, `urlsafe_decode`)
+# of binary data using a Base64 representation.
+#
+# ###Example
+#
+# A simple encoding and decoding.
+#
+#     require "base64"
+#     enc   = Base64.encode("Send reinforcements")
+#                         # => "U2VuZCByZWluZm9yY2VtZW50cw==\n"
+#     plain = Base64.decode(enc)
+#                         # => "Send reinforcements"
+#
+# The purpose of using base64 to encode data is that it translates any binary
+# data into purely printable characters.
 module Base64
   extend self
 
   class Error < Exception; end
 
+  # :nodoc:
   CHARS_STD  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  # :nodoc:
   CHARS_SAFE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+  # :nodoc:
   LINE_SIZE = 60
+  # :nodoc:
   PAD = '='.ord.to_u8
+  # :nodoc:
   NL = '\n'.ord.to_u8
+  # :nodoc:
   NR = '\r'.ord.to_u8
 
   class Error < Exception; end
 
+  # Returns the Base64-encoded version of `data`.
+  # This method complies with RFC 2045.
+  # Line feeds are added to every 60 encoded characters.
+  #
+  #     require "base64"
+  #     puts Base64.encode64("Now is the time for all good coders\nto learn Crystal")
+  #
+  # Generates:
+  #
+  #     Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g
+  #     Q3J5c3RhbA==
   def encode64(data)
     slice = data.to_slice
     String.new(encode_size(slice.length, true)) do |buf|
@@ -33,6 +66,15 @@ module Base64
     end
   end
 
+  # Returns the Base64-encoded version of `data` with no newines.
+  # This method complies with RFC 4648.
+  #
+  #     require "base64"
+  #     puts Base64.strict_encode64("Now is the time for all good coders\nto learn Crystal")
+  #
+  # Generates:
+  #
+  #     Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==
   def strict_encode64(data)
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
@@ -43,6 +85,14 @@ module Base64
     end
   end
 
+  # Returns the Base64-encoded version of `data` using a urlsafe alphabet.
+  # This method complies with "Base 64 Encoding with URL and Filename Safe
+  # Alphabet" in RFC 4648.
+  #
+  # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+  #
+  # The `padding` paramter defaults to false. When true enough `=` characters
+  # are added to make the output divisiable by 3.
   def urlsafe_encode64(data, padding = false)
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
@@ -53,6 +103,8 @@ module Base64
     end
   end
 
+  # Returns the Base64-decoded version of `data`.
+  # This will decode either the normal or urlsafe alphabets.
   def decode64(data)
     slice = data.to_slice
     String.new(decode_size(slice.length)) do |buf|
@@ -62,10 +114,12 @@ module Base64
     end
   end
 
+  # An alias for `decode`
   def strict_decode64(str)
     decode64(str)
   end
 
+  # An alias for `decode`
   def urlsafe_decode64(str)
     decode64(str)
   end
@@ -158,6 +212,7 @@ module Base64
     res
   end
 
+  # :nodoc:
   DECODE_TABLE = Array(Int8).new(256) do |i|
     case i.chr
     when 'A'..'Z'   then (i - 0x41).to_i8

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -66,7 +66,7 @@ module Base64
     end
   end
 
-  # Returns the Base64-encoded version of `data` with no newines.
+  # Returns the Base64-encoded version of `data` with no newlines.
   # This method complies with RFC 4648.
   #
   #     require "base64"
@@ -91,8 +91,8 @@ module Base64
   #
   # The alphabet uses '-' instead of '+' and '_' instead of '/'.
   #
-  # The `padding` paramter defaults to false. When true enough `=` characters
-  # are added to make the output divisiable by 3.
+  # The `padding` parameter defaults to false. When true, enough `=` characters
+  # are added to make the output divisible by 3.
   def urlsafe_encode(data, padding = false)
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -39,13 +39,13 @@ module Base64
   # Line feeds are added to every 60 encoded characters.
   #
   #     require "base64"
-  #     puts Base64.encode64("Now is the time for all good coders\nto learn Crystal")
+  #     puts Base64.encode("Now is the time for all good coders\nto learn Crystal")
   #
   # Generates:
   #
   #     Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g
   #     Q3J5c3RhbA==
-  def encode64(data)
+  def encode(data)
     slice = data.to_slice
     String.new(encode_size(slice.length, new_lines: true)) do |buf|
       inc = 0
@@ -70,12 +70,12 @@ module Base64
   # This method complies with RFC 4648.
   #
   #     require "base64"
-  #     puts Base64.strict_encode64("Now is the time for all good coders\nto learn Crystal")
+  #     puts Base64.strict_encode("Now is the time for all good coders\nto learn Crystal")
   #
   # Generates:
   #
   #     Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gQ3J5c3RhbA==
-  def strict_encode64(data)
+  def strict_encode(data)
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
       appender = buf.appender
@@ -93,7 +93,7 @@ module Base64
   #
   # The `padding` paramter defaults to false. When true enough `=` characters
   # are added to make the output divisiable by 3.
-  def urlsafe_encode64(data, padding = false)
+  def urlsafe_encode(data, padding = false)
     slice = data.to_slice
     String.new(encode_size(slice.length)) do |buf|
       appender = buf.appender
@@ -105,7 +105,7 @@ module Base64
 
   # Returns the Base64-decoded version of `data`.
   # This will decode either the normal or urlsafe alphabets.
-  def decode64(data)
+  def decode(data)
     slice = data.to_slice
     String.new(decode_size(slice.length)) do |buf|
       appender = buf.appender
@@ -115,13 +115,13 @@ module Base64
   end
 
   # An alias for `decode`
-  def strict_decode64(str)
-    decode64(str)
+  def strict_decode(str)
+    decode(str)
   end
 
   # An alias for `decode`
-  def urlsafe_decode64(str)
-    decode64(str)
+  def urlsafe_decode(str)
+    decode(str)
   end
 
   private def encode_size(str_size, new_lines = false)

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -114,16 +114,6 @@ module Base64
     end
   end
 
-  # An alias for `decode`
-  def strict_decode(str)
-    decode(str)
-  end
-
-  # An alias for `decode`
-  def urlsafe_decode(str)
-    decode(str)
-  end
-
   private def encode_size(str_size, new_lines = false)
     size = (str_size * 4 / 3.0).to_i + 4
     size += size / LINE_SIZE if new_lines

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -24,7 +24,7 @@ class HTTP::Client
   end
 
   def basic_auth(username, password)
-    header = "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
+    header = "Basic #{Base64.strict_encode("#{username}:#{password}")}"
     before_request do |request|
       request.headers["Authorization"] = header
     end

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -9,7 +9,7 @@ class HTTP::WebSocketHandler < HTTP::Handler
   def call(request)
     if request.headers["Upgrade"]? == "websocket" && request.headers["Connection"]? == "Upgrade"
       key = request.headers["Sec-websocket-key"]
-      accept_code = Base64.strict_encode64(OpenSSL::SHA1.hash("#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+      accept_code = Base64.strict_encode(OpenSSL::SHA1.hash("#{key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
       response_headers = HTTP::Headers {
         "Upgrade" => "websocket",
         "Connection" => "Upgrade"

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -19,7 +19,7 @@ struct OAuth::Signature
 
   def compute(request, ssl, ts, nonce)
     base_string = base_string(request, ssl, ts, nonce)
-    Base64.strict_encode64(OpenSSL::HMAC.digest :sha1, key, base_string)
+    Base64.strict_encode(OpenSSL::HMAC.digest :sha1, key, base_string)
   end
 
   def authorization_header(request, ssl, ts, nonce)

--- a/src/oauth2/access_token/mac.cr
+++ b/src/oauth2/access_token/mac.cr
@@ -38,7 +38,7 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
              when "hmac-sha-256" then :sha256
              else raise "unsupported algorithm: #{mac_algorithm}"
              end
-    Base64.strict_encode64 OpenSSL::HMAC.digest(digest, mac_key, normalized_request_string)
+    Base64.strict_encode OpenSSL::HMAC.digest(digest, mac_key, normalized_request_string)
   end
 
   def to_json(io)

--- a/src/secure_random.cr
+++ b/src/secure_random.cr
@@ -3,11 +3,11 @@ require "openssl/lib_crypto"
 
 module SecureRandom
   def self.base64(n = 16)
-    Base64.strict_encode64(random_bytes(n))
+    Base64.strict_encode(random_bytes(n))
   end
 
   def self.urlsafe_base64(n = 16, padding = false)
-    Base64.urlsafe_encode64(random_bytes(n), padding)
+    Base64.urlsafe_encode(random_bytes(n), padding)
   end
 
   def self.hex(n = 16)


### PR DESCRIPTION
These can be applied progressively. The documentation two are fairly uncontroversial. 

I personally never liked in ruby how it was `Base64.encode64` I already said 64 once in the module name, why is it on the method name too?

For the other one, in some cases method alias are alright I suppose, but in this case the method names implied they were doing extra strict checking or urlsafeness things, when in reality they were just the same as `decode`.  