### PR TITLE
Add Array prepend and append

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -587,6 +587,11 @@ describe "Array" do
       a << "c"
       a.should eq ["a", "b", "c"]
     end
+
+    it "has the append alias" do
+      a = ["a", "b"]
+      a.append("c").should eq ["a", "b", "c"]
+    end
   end
 
   it "does replace" do
@@ -873,11 +878,18 @@ describe "Array" do
     end
   end
 
-  it "does unshift" do
-    a = [2, 3]
-    expected = [1, 2, 3]
-    a.unshift(1).should eq(expected)
-    a.should eq(expected)
+  describe "unshift" do
+    it "does unshift" do
+      a = [2, 3]
+      expected = [1, 2, 3]
+      a.unshift(1).should eq(expected)
+      a.should eq(expected)
+    end
+
+    it "has the prepend alias" do
+      a = [2, 3]
+      a.prepend(1).should eq [1, 2, 3]
+    end
   end
 
   it "does update" do

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -570,6 +570,25 @@ describe "Array" do
     [1, 2, 3].product(['a', 'b']).should eq([{1,'a'}, {1,'b'}, {2,'a'}, {2,'b'}, {3,'a'}, {3,'b'}])
   end
 
+  describe "push" do
+    it "adds one element to the array" do
+      a = ["a", "b"]
+      a.push("c")
+      a.should eq ["a", "b", "c"]
+    end
+
+    it "returns the array" do
+      a = ["a", "b"]
+      a.push("c").should eq ["a", "b", "c"]
+    end
+
+    it "has the << alias" do
+      a = ["a", "b"]
+      a << "c"
+      a.should eq ["a", "b", "c"]
+    end
+  end
+
   it "does replace" do
     a = [1, 2, 3]
     b = [1]

--- a/src/array.cr
+++ b/src/array.cr
@@ -293,9 +293,7 @@ class Array(T)
   # a = [1,2]
   # a << 3 # => [1,2,3]
   # ```
-  def <<(value : T)
-    push(value)
-  end
+  alias_method :<<, :push
 
   # Returns the element at the given index.
   #

--- a/src/array.cr
+++ b/src/array.cr
@@ -294,6 +294,7 @@ class Array(T)
   # a << 3 # => [1,2,3]
   # ```
   alias_method :<<, :push
+  alias_method :append, :push
 
   # Returns the element at the given index.
   #
@@ -1221,6 +1222,8 @@ class Array(T)
   def unshift(obj : T)
     insert 0, obj
   end
+
+  alias_method :prepend, :unshift
 
   def update(index : Int)
     index = check_index_out_of_bounds index


### PR DESCRIPTION
First commit:
* added basic specs for Array#push
* used alias_method for << instead of the real definition

Second commit:
* aliased push to append and unshift to prepend

----------------------------------------------------------------------

Two commits as I recognize that one might be wanted and not the other (and they don't have that much in common).

About the aliases, append and prepend just seem to be the easiest names for these methods to me. I think matz once also said that he'd had named them like this but it was his English/perl at the time. I might have imagined that though.

I know we don't want too many aliases. In that case I'd actually be pro on removing push (I sort of like push though) and unshift (I really don't like unshift, always confuses me with unshift, shift).