### PR TITLE
Add pick and omit for hashes

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -487,4 +487,46 @@ describe "Hash" do
     iter.rewind
     iter.next.should eq(1)
   end
+
+  describe "omit" do
+    assert { { a: 2, b: 3 }.omit(:b, :d).should eq({ a: 2 }) }
+    assert { { a: 2, b: 3 }.omit(:b, :a).should eq({ } of Symbol => Int32) }
+    it "does not change currrent hash" do
+      h = { a: 3, b: 6, c: 9 }
+      h2 = h.omit(:b, :c)
+      h.should eq({ a: 3, b: 6, c: 9 })
+    end
+  end
+
+  describe "omit!" do
+    assert { { a: 2, b: 3 }.omit!(:b, :d).should eq({ a: 2 }) }
+    assert { { a: 2, b: 3 }.omit!(:b, :a).should eq({ } of Symbol => Int32) }
+    it "changes currrent hash" do
+      h = { a: 3, b: 6, c: 9 }
+      h.omit!(:b, :c)
+      h.should eq({ a: 3 })
+    end
+  end
+
+  describe "pick" do
+    assert { { a: 2, b: 3 }.pick(:b, :d).should eq({ b: 3 }) }
+    assert { { a: 2, b: 3 }.pick.should eq({ } of Symbol => Int32) }
+    assert { { a: 2, b: 3 }.pick(:b, :a).should eq({ a: 2, b: 3 }) }
+    it "does not change currrent hash" do
+      h = { a: 3, b: 6, c: 9 }
+      h2 = h.pick(:b, :c)
+      h.should eq({ a: 3, b: 6, c: 9 })
+    end
+  end
+
+  describe "pick!" do
+    assert { { a: 2, b: 3 }.pick!(:b, :d).should eq({ b: 3 }) }
+    assert { { a: 2, b: 3 }.pick!.should eq({ } of Symbol => Int32) }
+    assert { { a: 2, b: 3 }.pick!(:b, :a).should eq({ a: 2, b: 3 }) }
+    it "does not change currrent hash" do
+      h = { a: 3, b: 6, c: 9 }
+      h.pick!(:b, :c)
+      h.should eq({ b: 6, c: 9 })
+    end
+  end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -272,6 +272,49 @@ class Hash(K, V)
     self
   end
 
+  # Returns a new hash without the given keys.
+  #
+  # ```
+  # {"a": 1, "b": 2, "c": 3, "d": 4}.omit("a", "c") #=> {"b": 2, "d": 4}
+  # ```
+  def omit(*keys)
+    hash = self.dup
+    hash.omit!(*keys)
+  end
+
+  # Removes a list of keys out of hash.
+  #
+  # ```
+  # h = {"a": 1, "b": 2, "c": 3, "d": 4}.omit!("a", "c")
+  # h #=> {"b": 2, "d": 4}
+  # ```
+  def omit!(*keys)
+    keys.each { |k| delete(k) }
+    self
+  end
+
+  # Returns a new hash with the given keys.
+  #
+  # ```
+  # {"a": 1, "b": 2, "c": 3, "d": 4}.pick("a", "c") #=> {"a": 1, "c": 3}
+  # ```
+  def pick(*keys)
+    hash = {} of K => V
+    keys.each { |k| hash[k] = self[k] if has_key?(k) }
+    hash
+  end
+
+  # Removes every element except the given ones.
+  #
+  # ```
+  # h = {"a": 1, "b": 2, "c": 3, "d": 4}.pick!("a", "c")
+  # h #=> {"a": 1, "c": 3}
+  # ```
+  def pick!(*keys)
+    each { |k, v| delete(k) unless keys.includes?(k) }
+    self
+  end
+
   def self.zip(ary1 : Array(K), ary2 : Array(V))
     hash = {} of K => V
     ary1.each_with_index do |key, i|


### PR DESCRIPTION
This implements `slice` (now: `Hash#pick`) and `except` (now: `Hash#omit`) of Activesupport but with I think better and shorter names inspired from underscorejs (http://underscorejs.org/#pick).

I hope you can give me some feedback.
