### PR TITLE
Treat negative arguments in Iterator

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -68,6 +68,17 @@ describe Iterator do
     it "does take with more than available" do
       (1..3).each.take(10).to_a.should eq([1, 2, 3])
     end
+
+    it "is cool to take 0 elements" do
+      iter = (1..3).each.take(0)
+      iter.next.should be_a Iterator::Stop
+    end
+
+    it "raises ArgumentError if negative size is provided" do
+      expect_raises(ArgumentError) do
+        (1..3).each.take(-1)
+      end
+    end
   end
 
   describe "take_while" do
@@ -104,6 +115,16 @@ describe Iterator do
 
       iter.rewind
       iter.next.should eq(3)
+    end
+
+    it "is cool to skip 0 elements" do
+      (1..3).each.skip(0).to_a.should eq [1, 2, 3]
+    end
+
+    it "raises ArgumentError if negative size is provided" do
+      expect_raises(ArgumentError) do
+        (1..3).each.skip(-1)
+      end
     end
   end
 
@@ -187,6 +208,16 @@ describe Iterator do
 
       iter.rewind
       iter.next.should eq(1)
+    end
+
+    it "does not cycle provided 0" do
+      iter = (1..2).each.cycle(0)
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "does not cycle provided a negative size" do
+      iter = (1..2).each.cycle(-1)
+      iter.next.should be_a(Iterator::Stop)
     end
   end
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -116,6 +116,7 @@ module Iterator(T)
   end
 
   def take(n)
+    raise ArgumentError.new "Attempted to take negative size: #{n}" if n < 0
     Take(typeof(self), T).new(self, n)
   end
 
@@ -124,6 +125,7 @@ module Iterator(T)
   end
 
   def skip(n)
+    raise ArgumentError.new "Attempted to skip negative size: #{n}" if n < 0
     Skip(typeof(self), T).new(self, n)
   end
 
@@ -439,6 +441,7 @@ module Iterator(T)
     end
 
     def next
+      return stop if @count >= @n
       value = @iterator.next
       if value.is_a?(Stop)
         @count += 1


### PR DESCRIPTION
noticed that some cases of negative arguments were not handled (skip/take)

* skip/take raise
* cycle(n) returns stop

(behavior akin to ruby)

```
2.2.0 :004 > (1..2).cycle(0).next
StopIteration: iteration reached an end
	from (irb):4:in `next'
	from (irb):4
	from /home/tobi/.rvm/rubies/ruby-2.2.0/bin/irb:11:in `<main>'
2.2.0 :005 > (1..2).cycle(-1).next
StopIteration: iteration reached an end
	from (irb):5:in `next'
	from (irb):5
	from /home/tobi/.rvm/rubies/ruby-2.2.0/bin/irb:11:in `<main>'
```