### PR TITLE
Open all file descriptors with CLOEXEC set to avoid fd leaks.

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -22,7 +22,7 @@ class File < FileDescriptorIO
   DEFAULT_CREATE_MODE = LibC::S_IRUSR | LibC::S_IWUSR | LibC::S_IRGRP | LibC::S_IROTH
 
   def initialize(filename, mode = "r")
-    oflag = open_flag(mode)
+    oflag = open_flag(mode) | LibC::O_CLOEXEC
 
     fd = LibC.open(filename, oflag, DEFAULT_CREATE_MODE)
     if fd < 0

--- a/src/io.cr
+++ b/src/io.cr
@@ -1,5 +1,6 @@
 lib LibC
   enum FCNTL
+    F_GETFD = 1
     F_SETFD = 2
     F_GETFL = 3
     F_SETFL = 4
@@ -15,6 +16,7 @@ lib LibC
     O_CREAT    = 0o0000100
     O_TRUNC    = 0o0001000
     O_NONBLOCK = 0o0004000
+    O_CLOEXEC  = 0o2000000
   elsif darwin
     O_RDONLY   = 0x0000
     O_WRONLY   = 0x0001
@@ -23,6 +25,7 @@ lib LibC
     O_CREAT    = 0x0200
     O_TRUNC    = 0x0400
     O_NONBLOCK = 0x0004
+    O_CLOEXEC  = 0x1000000
   end
 
   S_IRWXU    = 0o000700         # RWX mask for owner
@@ -156,6 +159,8 @@ module IO
 
     r = FileDescriptorIO.new(pipe_fds[0], read_blocking)
     w = FileDescriptorIO.new(pipe_fds[1], write_blocking)
+    r.close_on_exec = true
+    w.close_on_exec = true
     w.sync = true
 
     {r, w}

--- a/src/io/file_descriptor_io.cr
+++ b/src/io/file_descriptor_io.cr
@@ -45,8 +45,14 @@ class FileDescriptorIO
     fcntl(LibC::FCNTL::F_SETFL, flags)
   end
 
+  def close_on_exec?
+    flags = fcntl(LibC::FCNTL::F_GETFD)
+    (flags & LibC::FD_CLOEXEC) == LibC::FD_CLOEXEC
+  end
+
   def close_on_exec=(arg : Bool)
     fcntl(LibC::FCNTL::F_SETFD, arg ? LibC::FD_CLOEXEC : 0)
+    arg
   end
 
   def fcntl cmd, arg = 0
@@ -105,6 +111,9 @@ class FileDescriptorIO
     if LibC.dup2(other.fd, self.fd) == -1
       raise Errno.new("Could not reopen file descriptor")
     end
+
+    # flag is lost after dup
+    self.close_on_exec = true
 
     other
   end

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -57,7 +57,6 @@ class Process
 
     if needs_pipe?(input)
       fork_input, process_input = IO.pipe(read_blocking: true)
-      process_input.close_on_exec = true
       if input
         @wait_count += 1
         spawn { copy_io(input, process_input, channel) }
@@ -68,7 +67,6 @@ class Process
 
     if needs_pipe?(output)
       process_output, fork_output = IO.pipe(write_blocking: true)
-      process_output.close_on_exec = true
       if output
         @wait_count += 1
         spawn { copy_io(process_output, output, channel) }
@@ -79,7 +77,6 @@ class Process
 
     if needs_pipe?(error)
       process_error, fork_error = IO.pipe(write_blocking: true)
-      process_error.close_on_exec = true
       if error
         @wait_count += 1
         spawn { copy_io(process_error, error, channel) }
@@ -159,6 +156,8 @@ class Process
     else
       raise "unknown object type #{src_io}"
     end
+
+    dst_io.close_on_exec = false
   end
 
   private def close_io(io)

--- a/src/socket/libc.cr
+++ b/src/socket/libc.cr
@@ -107,6 +107,12 @@ lib LibC
   SOCK_DGRAM = 2
   SOCK_RAW = 3
 
+  ifdef linux
+    SOCK_CLOEXEC = 0o2000000
+  else
+    SOCK_CLOEXEC = 0 # workaround in init_close_on_exec
+  end
+
   IPPROTO_IP = 0
   IPPROTO_TCP = 6
   IPPROTO_UDP = 17

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -40,6 +40,20 @@ class Socket < FileDescriptorIO
     self.sync = true
   end
 
+  protected def create_socket(family, stype, protocol = 0)
+    sock = LibC.socket(family, stype, protocol)
+    raise Errno.new("Error opening socket") if sock <= 0
+    init_close_on_exec sock
+    sock
+  end
+
+  # only used when SOCK_CLOEXEC doesn't exist on the current platform
+  protected def init_close_on_exec fd : Int32
+    {% if LibC::SOCK_CLOEXEC == 0 %}
+       LibC.fcntl(fd, LibC::FCNTL::F_SETFD, LibC::FD_CLOEXEC)
+    {% end %}
+  end
+
   def afamily(family)
     LibC::AF_UNSPEC.class.cast(family)
   end

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -3,8 +3,7 @@ require "./tcp_socket"
 class TCPServer < TCPSocket
   def initialize(host, port, backlog = 128)
     getaddrinfo(host, port, nil, LibC::SOCK_STREAM, LibC::IPPROTO_TCP) do |ai|
-      sock = LibC.socket(afamily(ai.family), ai.socktype, ai.protocol)
-      raise Errno.new("Error opening socket") if sock <= 0
+      sock = create_socket(afamily(ai.family), ai.socktype, ai.protocol)
 
       optval = 1
       LibC.setsockopt(sock, LibC::SOL_SOCKET, LibC::SO_REUSEADDR, pointerof(optval) as Void*, sizeof(Int32))

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -3,8 +3,7 @@ require "./ip_socket"
 class TCPSocket < IPSocket
   def initialize(host, port)
     getaddrinfo(host, port, nil, LibC::SOCK_STREAM, LibC::IPPROTO_TCP) do |ai|
-      sock = LibC.socket(afamily(ai.family), ai.socktype, ai.protocol)
-      raise Errno.new("Error opening socket") if sock <= 0
+      sock = create_socket(afamily(ai.family), ai.socktype, ai.protocol)
 
       if LibC.connect(sock, ai.addr, ai.addrlen) != 0
         LibC.close(sock)

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -36,9 +36,7 @@ require "./ip_socket"
 # ```
 class UDPSocket < IPSocket
   def initialize(family = Socket::Family::INET : Socket::Family)
-    super LibC.socket(family.value, LibC::SOCK_DGRAM, LibC::IPPROTO_UDP).tap do |sock|
-      raise Errno.new("Error opening socket") if sock <= 0
-    end
+    super create_socket(family.value, LibC::SOCK_DGRAM, LibC::IPPROTO_UDP)
   end
 
   # Creates a UDP socket from the given address.

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -4,8 +4,7 @@ class UNIXServer < UNIXSocket
   def initialize(@path : String, socktype =  Socket::Type::STREAM : Socket::Type, backlog = 128)
     File.delete(path) if File.exists?(path)
 
-    sock = LibC.socket(LibC::AF_UNIX, socktype.value, 0)
-    raise Errno.new("Error opening socket") if sock <= 0
+    sock = create_socket(LibC::AF_UNIX, socktype.value, 0)
 
     addr = LibC::SockAddrUn.new
     addr.family = LibC::AF_UNIX


### PR DESCRIPTION
Set CLOEXEC flag atomically when possible.