### PR TITLE
Adds the bit reference method to Ints

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -65,6 +65,11 @@ describe "Int" do
     assert { 2.lcm(0).should eq(0) }
   end
 
+  describe "[]" do
+    assert { 28[1].should eq(0) }
+    assert { 28[2].should eq(1) }
+  end
+
   describe "to_s in base" do
     assert { 12.to_s(2).should eq("1100") }
     assert { -12.to_s(2).should eq("-1100") }

--- a/src/int.cr
+++ b/src/int.cr
@@ -144,7 +144,7 @@ struct Int
   # 28[2] #=> 1
   # ```
   def [](n : Int)
-    to_s(2).reverse[n].to_i
+    (self >> n) & 1
   end
 
   def abs

--- a/src/int.cr
+++ b/src/int.cr
@@ -136,6 +136,17 @@ struct Int
     end
   end
 
+  # Bit reference. Returns the `n`th bit in the binary representation of
+  # `self`, where `self[0]` is the least significant bit.
+  #
+  # ```
+  # 28[1] #=> 0
+  # 28[2] #=> 1
+  # ```
+  def [](n : Int)
+    to_s(2).reverse[n].to_i
+  end
+
   def abs
     self >= 0 ? self : -self
   end


### PR DESCRIPTION
This is a little convenience method, especially for those working actively with binary numbers. I've written it in a very quick and dirty way. I'd love feedback on better ways of doing it.