### PR TITLE
add MatchData#pre_match and #post_match and document MatchData

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -102,6 +102,34 @@ describe "Regex" do
     end
   end
 
+  describe "MatchData#pre_match" do
+    it "returns the part of the string before the match" do
+      "Crystal".match(/yst/) { |md| md.pre_match.should eq "Cr" }
+    end
+
+    it "returns an empty string when there's nothing before" do
+      "Crystal".match(/Cryst/) { |md| md.pre_match.should eq "" }
+    end
+
+    it "works with unicode" do
+      "há日本語".match(/本/) { |md| md.pre_match.should eq "há日" }
+    end
+  end
+
+  describe "MatchData#post_match" do
+    it "returns the part of the string after the match" do
+      "Crystal".match(/yst/) { |md| md.post_match.should eq "al" }
+    end
+
+    it "returns an empty string when there's nothing after" do
+      "Crystal".match(/ystal/) { |md| md.post_match.should eq "" }
+    end
+
+    it "works with unicode" do
+      "há日本語".match(/本/) { |md| md.post_match.should eq "語" }
+    end
+  end
+
   it "matches multiline" do
     ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
     ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -1,29 +1,122 @@
+# `MatchData` is the type of the special variable `$~`, and is the type
+# returned by `Regex#match` and `String#match`. It encapsulates all the
+# results of a regular expression match.
+#
+# `Regex#match` and `String#match` can return `nil`, to represent an
+# unsuccessful match, but there are overloads of both methods that accept a
+# block. These overloads are convenient to access the `MatchData` of a
+# successful match, since the block argument can't be `nil`.
+#
+# ```
+# "Crystal".match(/[p-s]/).length #=> undefined method 'length' for Nil
+#
+# "Crystal".match(/[p-s]/) do |md|
+#   md.string #=> "Crystal"
+#   md[0]     #=> "r"
+#   md[1]?    #=> nil
+# end
+# ```
+#
+# Many `MatchData` methods deal with capture groups, and accept an integer
+# argument to select the desired capture group. Capture groups are numbered
+# starting from `1`, so that `0` can be used to refer to the entire regular
+# expression without needing to capture it explicitly.
 class MatchData
+  # Returns the original regular expression.
+  #
+  # ```
+  # "Crystal".match(/[p-s]/) { |md| md.regex } #=> /[p-s]/
+  # ```
   getter regex
+
+  # Returns the number of capture groups, including named capture groups.
+  #
+  # ```
+  # "Crystal".match(/[p-s]/) { |md| md.length }          #=> 0
+  # "Crystal".match(/r(ys)/) { |md| md.length }          #=> 1
+  # "Crystal".match(/r(ys)(?<ok>ta)/) { |md| md.length } #=> 2
+  # ```
   getter length
+
+  # Returns the original string.
+  #
+  # ```
+  # "Crystal".match(/[p-s]/) { |md| md.string } #=> "Crystal"
+  # ```
   getter string
 
+  # :nodoc:
   def initialize(@regex, @code, @string, @pos, @ovector, @length)
   end
 
+  # Return the position of the first character of the `n`th match.
+  #
+  # When `n` is `0`, uses the match of the entire `Regex`. Otherwise, uses the
+  # match of the `n`th capture group.
+  #
+  # ```
+  # "Crystal".match(/r/) { |md| md.begin(0) }       #=> 1
+  # "Crystal".match(/r(ys)/) { |md| md.begin(1) }   #=> 2
+  # "クリスタル".match(/リ(ス)/) { |md| md.begin(0) } #=> 1
+  # ```
   def begin(n)
     byte_index_to_char_index byte_begin(n)
   end
 
+  # Return the position of the next character after the match.
+  #
+  # When `n` is `0`, uses the match of the entire `Regex`. Otherwise, uses the
+  # match of the `n`th capture group.
+  #
+  # ```
+  # "Crystal".match(/r/) { |md| md.end(0) }       #=> 2
+  # "Crystal".match(/r(ys)/) { |md| md.end(1) }   #=> 4
+  # "クリスタル".match(/リ(ス)/) { |md| md.end(0) } #=> 3
+  # ```
   def end(n)
     byte_index_to_char_index byte_end(n)
   end
 
+  # Return the position of the first byte of the `n`th match.
+  #
+  # When `n` is `0`, uses the match of the entire `Regex`. Otherwise, uses the
+  # match of the `n`th capture group.
+  #
+  # ```
+  # "Crystal".match(/r/) { |md| md.byte_begin(0) }       #=> 1
+  # "Crystal".match(/r(ys)/) { |md| md.byte_begin(1) }   #=> 4
+  # "クリスタル".match(/リ(ス)/) { |md| md.byte_begin(0) } #=> 3
+  # ```
   def byte_begin(n)
     check_index_out_of_bounds n
     @ovector[n * 2]
   end
 
+  # Return the position of the next byte after the match.
+  #
+  # When `n` is `0`, uses the match of the entire `Regex`. Otherwise, uses the
+  # match of the `n`th capture group.
+  #
+  # ```
+  # "Crystal".match(/r/) { |md| md.byte_end(0) }       #=> 2
+  # "Crystal".match(/r(ys)/) { |md| md.byte_end(1) }   #=> 4
+  # "クリスタル".match(/リ(ス)/) { |md| md.byte_end(0) } #=> 9
+  # ```
   def byte_end(n)
     check_index_out_of_bounds n
     @ovector[n * 2 + 1]
   end
 
+  # Returns the match of the `n`th capture group, or `nil` if there isn't
+  # an `n`th capture group.
+  #
+  # When `n` is `0`, returns the match for the entire `Regex`.
+  #
+  # ```
+  # "Crystal".match(/r(ys)/) { |md| md[0]? } #=> "rys"
+  # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
+  # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> nil
+  # ```
   def []?(n)
     return unless valid_group?(n)
 
@@ -33,18 +126,39 @@ class MatchData
     @string.byte_slice(start, finish - start)
   end
 
+  # Returns the match of the `n`th capture group, or raises an `IndexError`
+  # if there is no `n`th capture group.
+  #
+  # ```
+  # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
+  # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> raises IndexError
+  # ```
   def [](n)
     check_index_out_of_bounds n
 
     self[n]?.not_nil!
   end
 
+  # Returns the match of the capture group named by `group_name`, or
+  # `nil` if there is no such named capture group.
+  #
+  # ```
+  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"]? } #=> "ys"
+  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"]? } #=> nil
+  # ```
   def []?(group_name : String)
     ret = LibPCRE.get_stringnumber(@code, group_name)
     return if ret < 0
     self[ret]?
   end
 
+  # Returns the match of the capture group named by `group_name`, or
+  # raises an `ArgumentError` if there is no such named capture group.
+  #
+  # ```
+  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"] } #=> "ys"
+  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"] } #=> raises ArgumentError
+  # ```
   def [](group_name : String)
     match = self[group_name]?
     unless match
@@ -53,9 +167,8 @@ class MatchData
     match
   end
 
-  # Returns the part of the original string before the matching part.
-  # If the matching part of the string starts at the start of the
-  # string, then the empty string is returned.
+  # Returns the part of the original string before the match. If the match
+  # starts at the start of the string, returns the empty string.
   #
   # ```
   # "Crystal".match(/yst/) { |md| md.pre_match } #=> "Cr"
@@ -68,9 +181,8 @@ class MatchData
     end
   end
 
-  # Returns the part of the original string after the matching part.
-  # If the matching part of the string ends at the end of the
-  # string, then the empty string is returned.
+  # Returns the part of the original string after the match. If the match ends
+  # at the end of the string, returns the empty string.
   #
   # ```
   # "Crystal".match(/yst/) { |md| md.post_match } #=> "al"

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -53,6 +53,32 @@ class MatchData
     match
   end
 
+  # Returns the part of the original string before the matching part.
+  # If the matching part of the string starts at the start of the
+  # string, then the empty string is returned.
+  #
+  # ```
+  # "Crystal".match(/yst/) { |md| md.pre_match } #=> "Cr"
+  # ```
+  def pre_match
+    if self.begin(0) == 0
+      ""
+    else
+      @string[0..self.begin(0) - 1]
+    end
+  end
+
+  # Returns the part of the original string after the matching part.
+  # If the matching part of the string ends at the end of the
+  # string, then the empty string is returned.
+  #
+  # ```
+  # "Crystal".match(/yst/) { |md| md.post_match } #=> "al"
+  # ```
+  def post_match
+    @string[self.end(0)..-1]
+  end
+
   def inspect(io : IO)
     to_s(io)
   end


### PR DESCRIPTION
I don't have a lot of experience with unicode so hopefully those parts are OK.

While working on this I realized for the first time that Crystal has `Regex` whereas Ruby has `Regexp`. I appreciate this, because when spoken aloud in English, usually the P is either not pronounced, or spat out like a :watermelon: seed: "Reg Ex Puh".

It seems like `#begin`, etc, could accept `0` as a default argument, to reflect that `0` references a "capture group" that is created implicitly for the entire regex. Ruby doesn't do this, and I have wanted it once or twice over the years. Would this be a welcome change?