### PR TITLE
Sort enumerable methods (+ new specs)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -46,6 +46,18 @@ describe "Enumerable" do
     assert { Set { 1, nil, 2, nil, 3 }.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
   end
 
+  describe "count without block" do
+    it "returns the number of elements in the Enumerable" do
+      (1..3).count.should eq 3
+    end
+  end
+
+  describe "count with block" do
+    it "returns the number of the times the item is present" do
+      %w(a b c a d A).count("a").should eq 2
+    end
+  end
+
   describe "each_cons" do
     it "returns running pairs" do
       array = [] of Array(Int32)
@@ -97,6 +109,14 @@ describe "Enumerable" do
   end
 
   describe "each_with_index" do
+    it "yields the element and the index" do
+      collection = [] of {String, Int32}
+      ["a", "b", "c"].each_with_index do |e, i|
+        collection << {e, i}
+      end
+      collection.should eq [{"a", 0}, {"b", 1}, {"c", 2}]
+    end
+
     it "gets each_with_index iterator" do
       iter = [1, 2].each_with_index
       iter.next.should eq({1, 0})
@@ -109,6 +129,15 @@ describe "Enumerable" do
   end
 
   describe "each_with_object" do
+    it "yields the element and the given object" do
+      collection = [] of {Int32, String}
+      object = "a"
+      (1..3).each_with_object(object) do |e, o|
+        collection << {e, o}
+      end
+      collection.should eq [{1, object}, {2, object}, {3, object}]
+    end
+
     it "gets each_with_object iterator" do
       iter = [1, 2].each_with_object("a")
       iter.next.should eq({1, "a"})
@@ -396,6 +425,12 @@ describe "Enumerable" do
         i < 3
       end
       called.should eq 3
+    end
+  end
+
+  describe "to_a" do
+    it "converts to an Array" do
+      (1..3).to_a.should eq [1, 2, 3]
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -58,6 +58,31 @@ describe "Enumerable" do
     end
   end
 
+  describe "cycle" do
+    it "calls forever if we don't break" do
+      called = 0
+      elements = [] of Int32
+      (1..2).cycle do |e|
+        elements << e
+        called += 1
+        break if called == 6
+      end
+      called.should eq 6
+      elements.should eq [1, 2, 1, 2, 1, 2]
+    end
+
+    it "calls the block n times given the optional argument" do
+      called = 0
+      elements = [] of Int32
+      (1..2).cycle(3) do |e|
+        elements << e
+        called += 1
+      end
+      called.should eq 6
+      elements.should eq [1, 2, 1, 2, 1, 2]
+    end
+  end
+
   describe "each_cons" do
     it "returns running pairs" do
       array = [] of Array(Int32)
@@ -117,6 +142,14 @@ describe "Enumerable" do
       collection.should eq [{"a", 0}, {"b", 1}, {"c", 2}]
     end
 
+    it "accepts an optional offset parameter" do
+      collection = [] of {String, Int32}
+      ["Alice", "Bob"].each_with_index(1) do |e, i|
+        collection << {e, i}
+      end
+      collection.should eq [{"Alice", 1}, {"Bob", 2}]
+    end
+
     it "gets each_with_index iterator" do
       iter = [1, 2].each_with_index
       iter.next.should eq({1, 0})
@@ -149,28 +182,6 @@ describe "Enumerable" do
     end
   end
 
-  describe "first" do
-    it "gets first" do
-      (1..3).first.should eq(1)
-    end
-
-    it "raises if enumerable empty" do
-      expect_raises EmptyEnumerable do
-        (1...1).first
-      end
-    end
-  end
-
-  describe "first?" do
-    it "gets first?" do
-      (1..3).first?.should eq(1)
-    end
-
-    it "returns nil if enumerable empty" do
-      (1...1).first?.should be_nil
-    end
-  end
-
   describe "find" do
     it "finds" do
       [1, 2, 3].find { |x| x > 2 }.should eq(3)
@@ -186,9 +197,33 @@ describe "Enumerable" do
   end
 
   describe "first" do
+    it "gets first" do
+      (1..3).first.should eq(1)
+    end
+
+    it "raises if enumerable empty" do
+      expect_raises EmptyEnumerable do
+        (1...1).first
+      end
+    end
+
+    it "returns the first n elements with the optional argument" do
+      (1..5).first(2).should eq [1, 2]
+    end
+
     assert { [-1, -2, -3].first.should eq(-1) }
     assert { [-1, -2, -3].first(1).should eq([-1]) }
     assert { [-1, -2, -3].first(4).should eq([-1, -2, -3]) }
+  end
+
+  describe "first?" do
+    it "gets first?" do
+      (1..3).first?.should eq(1)
+    end
+
+    it "returns nil if enumerable empty" do
+      (1...1).first?.should be_nil
+    end
   end
 
   describe "flat_map" do
@@ -201,8 +236,23 @@ describe "Enumerable" do
     end
   end
 
+  describe "grep" do
+    it "works with regexes for instance" do
+      ["Alice", "Bob", "Cipher", "Anna"].grep(/^A/).should eq ["Alice", "Anna"]
+    end
+
+    it "returns empty array if nothing matches" do
+      %w(Alice Bob Mallory).grep(/nothing/).should eq [] of String
+    end
+  end
+
   describe "group_by" do
     assert { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
+
+    it "groups can group by length (like the doc example)" do
+      %w(Alice Bob Ary).group_by{|e| e.length}.should eq({ 3 => ["Bob", "Ary"],
+                                                           5 => ["Alice"]})
+    end
   end
 
   describe "in_groups_of" do
@@ -221,6 +271,36 @@ describe "Enumerable" do
       sums = [] of Int32
       [1, 2, 4].in_groups_of(2, 0) { |a| sums << a.sum }
       sums.should eq([3, 4])
+    end
+  end
+
+  describe "includes?" do
+    it "is true if the object exists in the collection" do
+      [1, 2, 3].includes?(2).should be_true
+    end
+
+    it "is false if the object is not part of the collection" do
+      [1, 2, 3].includes?(5).should be_false
+    end
+  end
+
+  describe "index with a block" do
+    it "returns the index of the first element where the blcok returns true" do
+      ["Alice", "Bob"].index { |name| name.length < 4 }.should eq 1
+    end
+
+    it "returns nil if no object could be found" do
+      ["Alice", "Bob"].index { |name| name.length < 3 }.should eq nil
+    end
+  end
+
+  describe "index with an object" do
+    it "returns the index of that object if found" do
+      ["Alice", "Bob"].index("Alice").should eq 0
+    end
+
+    it "returns nil if the object was not found" do
+      ["Alice", "Bob"].index("Mallory").should be_nil
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -22,46 +22,6 @@ describe "Enumerable" do
     end
   end
 
-  describe "skip" do
-    it "returns an array without the skipped elements" do
-      [1, 2, 3, 4, 5, 6].skip(3).should eq [4, 5, 6]
-    end
-
-    it "returns an empty array when skipping more elements than array size" do
-      [1, 2].skip(3).should eq [] of Int32
-    end
-
-    it "raises if count is negative" do
-      expect_raises(ArgumentError) do
-        [1, 2].skip(-1)
-      end
-    end
-  end
-
-  describe "skip_while" do
-    it "skips elements while the condition holds true" do
-      result = [1, 2, 3, 4, 5, 0].skip_while {|i| i < 3}
-      result.should eq [3, 4, 5, 0]
-    end
-
-    it "returns an empty array if the condition is always true" do
-      [1, 2, 3].skip_while {true}.should eq [] of Int32
-    end
-
-    it "returns the full Array if the the first check is false" do
-      [5, 0, 1, 2, 3].skip_while {|x| x < 4}.should eq [5, 0, 1, 2, 3]
-    end
-
-    it "does not yield to the block anymore once it returned false" do
-      called = 0
-      [1, 2, 3, 4, 4].skip_while do |i|
-        called += 1
-        i < 3
-      end
-      called.should eq 3
-    end
-  end
-
   describe "any? with block" do
     it "returns true if at least one element fulfills the condition" do
       ["ant", "bear", "cat"].any? { |word| word.length >= 4 }.should be_true
@@ -82,6 +42,106 @@ describe "Enumerable" do
     end
   end
 
+  describe "compact map" do
+    assert { Set { 1, nil, 2, nil, 3 }.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
+  end
+
+  describe "each_cons" do
+    it "returns running pairs" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
+      array.should eq([[1, 2], [2, 3], [3, 4]])
+    end
+
+    it "returns running triples" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
+      array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
+    end
+
+    it "returns each_cons iterator" do
+      iter = [1, 2, 3, 4, 5].each_cons(3)
+      iter.next.should eq([1, 2, 3])
+      iter.next.should eq([2, 3, 4])
+      iter.next.should eq([3, 4, 5])
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq([1, 2, 3])
+    end
+  end
+
+  describe "each_slice" do
+    it "returns partial slices" do
+      array = [] of Array(Int32)
+      [1, 2, 3].each_slice(2) { |slice| array << slice }
+      array.should eq([[1, 2], [3]])
+    end
+
+    it "returns full slices" do
+      array = [] of Array(Int32)
+      [1, 2, 3, 4].each_slice(2) { |slice| array << slice }
+      array.should eq([[1, 2], [3, 4]])
+    end
+
+    it "returns each_slice iterator" do
+      iter = [1, 2, 3, 4, 5].each_slice(2)
+      iter.next.should eq([1, 2])
+      iter.next.should eq([3, 4])
+      iter.next.should eq([5])
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq([1, 2])
+    end
+  end
+
+  describe "each_with_index" do
+    it "gets each_with_index iterator" do
+      iter = [1, 2].each_with_index
+      iter.next.should eq({1, 0})
+      iter.next.should eq({2, 1})
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq({1, 0})
+    end
+  end
+
+  describe "each_with_object" do
+    it "gets each_with_object iterator" do
+      iter = [1, 2].each_with_object("a")
+      iter.next.should eq({1, "a"})
+      iter.next.should eq({2, "a"})
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq({1, "a"})
+    end
+  end
+
+  describe "first" do
+    it "gets first" do
+      (1..3).first.should eq(1)
+    end
+
+    it "raises if enumerable empty" do
+      expect_raises EmptyEnumerable do
+        (1...1).first
+      end
+    end
+  end
+
+  describe "first?" do
+    it "gets first?" do
+      (1..3).first?.should eq(1)
+    end
+
+    it "returns nil if enumerable empty" do
+      (1...1).first?.should be_nil
+    end
+  end
+
   describe "find" do
     it "finds" do
       [1, 2, 3].find { |x| x > 2 }.should eq(3)
@@ -96,6 +156,12 @@ describe "Enumerable" do
     end
   end
 
+  describe "first" do
+    assert { [-1, -2, -3].first.should eq(-1) }
+    assert { [-1, -2, -3].first(1).should eq([-1]) }
+    assert { [-1, -2, -3].first(4).should eq([-1, -2, -3]) }
+  end
+
   describe "flat_map" do
     it "does example 1" do
       [1, 2, 3, 4].flat_map { |e| [e, -e] }.should eq([1, -1, 2, -2, 3, -3, 4, -4])
@@ -103,6 +169,29 @@ describe "Enumerable" do
 
     it "does example 2" do
       [[1, 2], [3, 4]].flat_map { |e| e + [100] }.should eq([1, 2, 100, 3, 4, 100])
+    end
+  end
+
+  describe "group_by" do
+    assert { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
+  end
+
+  describe "in_groups_of" do
+    assert { [1, 2, 3].in_groups_of(1).should eq([[1], [2], [3]]) }
+    assert { [1, 2, 3].in_groups_of(2).should eq([[1, 2], [3, nil]]) }
+    assert { ([] of Int32).in_groups_of(2).should eq([] of Array(Array(Int32 | Nil))) }
+    assert { [1, 2, 3].in_groups_of(2, "x").should eq([[1, 2], [3, "x"]]) }
+
+    it "raises argument error if size is less than 0" do
+      expect_raises ArgumentError, "size must be positive" do
+        [1, 2, 3].in_groups_of(0)
+      end
+    end
+
+    it "takes a block" do
+      sums = [] of Int32
+      [1, 2, 4].in_groups_of(2, 0) { |a| sums << a.sum }
+      sums.should eq([3, 4])
     end
   end
 
@@ -114,6 +203,24 @@ describe "Enumerable" do
       expect_raises EmptyEnumerable do
         ([] of Int32).inject { |memo, i| memo + i }
       end
+    end
+  end
+
+  describe "join" do
+    it "joins with separator and block" do
+      str = [1, 2, 3].join(", ") { |x| x + 1 }
+      str.should eq("2, 3, 4")
+    end
+
+    it "joins without separator and block" do
+      str = [1, 2, 3].join { |x| x + 1 }
+      str.should eq("234")
+    end
+
+    it "joins with io and block" do
+      str = StringIO.new
+      [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
+      str.to_s.should eq("2, 3, 4")
     end
   end
 
@@ -171,6 +278,93 @@ describe "Enumerable" do
     assert { [-1, -2, -3].minmax_of { |x| -x }.should eq({1, 3}) }
   end
 
+  describe "none?" do
+    assert { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
+    assert { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
+  end
+
+  describe "none? without block" do
+    assert { [nil, false].none?.should be_true }
+    assert { [nil, false, true].none?.should be_false }
+  end
+
+  describe "one?" do
+    assert { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
+    assert { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
+    assert { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
+  end
+
+  describe "partition" do
+    assert { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
+  end
+
+  describe "reject" do
+    it "rejects the values for which the block returns true" do
+      [1, 2, 3, 4].reject(&.even?).should eq([1, 3])
+    end
+  end
+
+  describe "select" do
+    it "selects the values for which the block returns true" do
+      [1, 2, 3, 4].select(&.even?).should eq([2, 4])
+    end
+  end
+
+  describe "skip" do
+    it "returns an array without the skipped elements" do
+      [1, 2, 3, 4, 5, 6].skip(3).should eq [4, 5, 6]
+    end
+
+    it "returns an empty array when skipping more elements than array size" do
+      [1, 2].skip(3).should eq [] of Int32
+    end
+
+    it "raises if count is negative" do
+      expect_raises(ArgumentError) do
+        [1, 2].skip(-1)
+      end
+    end
+  end
+
+  describe "skip_while" do
+    it "skips elements while the condition holds true" do
+      result = [1, 2, 3, 4, 5, 0].skip_while {|i| i < 3}
+      result.should eq [3, 4, 5, 0]
+    end
+
+    it "returns an empty array if the condition is always true" do
+      [1, 2, 3].skip_while {true}.should eq [] of Int32
+    end
+
+    it "returns the full Array if the the first check is false" do
+      [5, 0, 1, 2, 3].skip_while {|x| x < 4}.should eq [5, 0, 1, 2, 3]
+    end
+
+    it "does not yield to the block anymore once it returned false" do
+      called = 0
+      [1, 2, 3, 4, 4].skip_while do |i|
+        called += 1
+        i < 3
+      end
+      called.should eq 3
+    end
+  end
+
+  describe "sum" do
+    assert { ([] of Int32).sum.should eq(0) }
+    assert { [1, 2, 3].sum.should eq(6) }
+    assert { [1, 2, 3].sum(4).should eq(10) }
+    assert { [1, 2, 3].sum(4.5).should eq(10.5) }
+    assert { (1..3).sum { |x| x * 2 }.should eq(12) }
+    assert { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
+
+    it "uses zero from type" do
+      typeof([1, 2, 3].sum).should eq(Int32)
+      typeof([1.5, 2.5, 3.5].sum).should eq(Float64)
+      typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
+    end
+  end
+
   describe "take" do
     assert { [-1, -2, -3].take(1).should eq([-1]) }
     assert { [-1, -2, -3].take(4).should eq([-1, -2, -3]) }
@@ -205,96 +399,6 @@ describe "Enumerable" do
     end
   end
 
-  describe "first" do
-    assert { [-1, -2, -3].first.should eq(-1) }
-    assert { [-1, -2, -3].first(1).should eq([-1]) }
-    assert { [-1, -2, -3].first(4).should eq([-1, -2, -3]) }
-  end
-
-  describe "one?" do
-    assert { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
-    assert { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
-    assert { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
-  end
-
-  describe "none?" do
-    assert { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
-    assert { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
-  end
-
-  describe "none? without block" do
-    assert { [nil, false].none?.should be_true }
-    assert { [nil, false, true].none?.should be_false }
-  end
-
-  describe "group_by" do
-    assert { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
-  end
-
-  describe "in_groups_of" do
-    assert { [1, 2, 3].in_groups_of(1).should eq([[1], [2], [3]]) }
-    assert { [1, 2, 3].in_groups_of(2).should eq([[1, 2], [3, nil]]) }
-    assert { ([] of Int32).in_groups_of(2).should eq([] of Array(Array(Int32 | Nil))) }
-    assert { [1, 2, 3].in_groups_of(2, "x").should eq([[1, 2], [3, "x"]]) }
-
-    it "raises argument error if size is less than 0" do
-      expect_raises ArgumentError, "size must be positive" do
-        [1, 2, 3].in_groups_of(0)
-      end
-    end
-
-    it "takes a block" do
-      sums = [] of Int32
-      [1, 2, 4].in_groups_of(2, 0) { |a| sums << a.sum }
-      sums.should eq([3, 4])
-    end
-  end
-
-  describe "partition" do
-    assert { [1, 2, 2, 3].partition { |x| x == 2 }.should eq({[2, 2], [1, 3]}) }
-  end
-
-  describe "sum" do
-    assert { ([] of Int32).sum.should eq(0) }
-    assert { [1, 2, 3].sum.should eq(6) }
-    assert { [1, 2, 3].sum(4).should eq(10) }
-    assert { [1, 2, 3].sum(4.5).should eq(10.5) }
-    assert { (1..3).sum { |x| x * 2 }.should eq(12) }
-    assert { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
-
-    it "uses zero from type" do
-      typeof([1, 2, 3].sum).should eq(Int32)
-      typeof([1.5, 2.5, 3.5].sum).should eq(Float64)
-      typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
-    end
-  end
-
-  describe "compact map" do
-    assert { Set { 1, nil, 2, nil, 3 }.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
-  end
-
-  describe "first" do
-    it "gets first" do
-      (1..3).first.should eq(1)
-    end
-
-    it "raises if enumerable empty" do
-      expect_raises EmptyEnumerable do
-        (1...1).first
-      end
-    end
-  end
-
-  describe "first?" do
-    it "gets first?" do
-      (1..3).first?.should eq(1)
-    end
-
-    it "returns nil if enumerable empty" do
-      (1...1).first?.should be_nil
-    end
-  end
-
   describe "to_h" do
     it "for tuples" do
       hash = Tuple.new({:a, 1}, {:c, 2}).to_h
@@ -314,99 +418,5 @@ describe "Enumerable" do
         7 => "goodbye",
         9 => "something",
       })
-  end
-
-  it "selects" do
-    [1, 2, 3, 4].select(&.even?).should eq([2, 4])
-  end
-
-  it "rejects" do
-    [1, 2, 3, 4].reject(&.even?).should eq([1, 3])
-  end
-
-  it "joins with separator and block" do
-    str = [1, 2, 3].join(", ") { |x| x + 1 }
-    str.should eq("2, 3, 4")
-  end
-
-  it "joins without separator and block" do
-    str = [1, 2, 3].join { |x| x + 1 }
-    str.should eq("234")
-  end
-
-  it "joins with io and block" do
-    str = StringIO.new
-    [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
-    str.to_s.should eq("2, 3, 4")
-  end
-
-  describe "each_slice" do
-    it "returns partial slices" do
-      array = [] of Array(Int32)
-      [1, 2, 3].each_slice(2) { |slice| array << slice }
-      array.should eq([[1, 2], [3]])
-    end
-
-    it "returns full slices" do
-      array = [] of Array(Int32)
-      [1, 2, 3, 4].each_slice(2) { |slice| array << slice }
-      array.should eq([[1, 2], [3, 4]])
-    end
-
-    it "returns each_slice iterator" do
-      iter = [1, 2, 3, 4, 5].each_slice(2)
-      iter.next.should eq([1, 2])
-      iter.next.should eq([3, 4])
-      iter.next.should eq([5])
-      iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2])
-    end
-  end
-
-  describe "each_cons" do
-    it "returns running pairs" do
-      array = [] of Array(Int32)
-      [1, 2, 3, 4].each_cons(2) { |pair| array << pair }
-      array.should eq([[1, 2], [2, 3], [3, 4]])
-    end
-
-    it "returns running triples" do
-      array = [] of Array(Int32)
-      [1, 2, 3, 4, 5].each_cons(3) { |triple| array << triple }
-      array.should eq([[1, 2, 3], [2, 3, 4], [3, 4, 5]])
-    end
-
-    it "returns each_cons iterator" do
-      iter = [1, 2, 3, 4, 5].each_cons(3)
-      iter.next.should eq([1, 2, 3])
-      iter.next.should eq([2, 3, 4])
-      iter.next.should eq([3, 4, 5])
-      iter.next.should be_a(Iterator::Stop)
-
-      iter.rewind
-      iter.next.should eq([1, 2, 3])
-    end
-  end
-
-  it "gets each_with_index iterator" do
-    iter = [1, 2].each_with_index
-    iter.next.should eq({1, 0})
-    iter.next.should eq({2, 1})
-    iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq({1, 0})
-  end
-
-  it "gets each_with_object iterator" do
-    iter = [1, 2].each_with_object("a")
-    iter.next.should eq({1, "a"})
-    iter.next.should eq({2, "a"})
-    iter.next.should be_a(Iterator::Stop)
-
-    iter.rewind
-    iter.next.should eq({1, "a"})
   end
 end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -120,33 +120,29 @@ module Enumerable(T)
     n.times { each { |x| yield x } }
   end
 
-  # Returns an array with the first *count* elements removed from the original collection.
+  # Iterates over the collection yielding chunks of size *count*, but advancing one by one.
   #
-  # If *count* is bigger than the number of elements in the collection, returns an empty array.
+  #     [1, 2, 3, 4, 5].each_cons(2) do |cons|
+  #       puts cons
+  #     end
   #
-  #     [1, 2, 3, 4, 5, 6].skip(3)  #=> [4, 5, 6]
-  def skip(count : Int)
-    raise ArgumentError.new("attempt to skip negative size") if count < 0
-
-    array = Array(T).new
-    each_with_index do |e, i|
-      array << e if i >= count
+  # Prints:
+  #
+  #     [1, 2]
+  #     [2, 3]
+  #     [3, 4]
+  #     [4, 5]
+  #
+  def each_cons(count : Int)
+    cons = Array(T).new(count)
+    each do |elem|
+      cons << elem
+      cons.shift if cons.size > count
+      if cons.size == count
+        yield cons.dup
+      end
     end
-    array
-  end
-
-  # Skips elements up to, but not including, the first element for which the block returns nil or false and returns an array containing the remaining elements.
-  #
-  #     [1, 2, 3, 4, 5, 0].skip_while {|i| i < 3} #=> [3, 4, 5, 0]
-  #
-  def skip_while
-    result = Array(T).new
-    block_returned_false = false
-    each do |x|
-      block_returned_false = true unless block_returned_false || yield x
-      result << x if block_returned_false
-    end
-    result
+    nil
   end
 
   # Iterates over the collection in slices of size *count*, and runs the block for each of those.
@@ -172,31 +168,6 @@ module Enumerable(T)
       end
     end
     yield slice unless slice.empty?
-    nil
-  end
-
-  # Iterates over the collection yielding chunks of size *count*, but advancing one by one.
-  #
-  #     [1, 2, 3, 4, 5].each_cons(2) do |cons|
-  #       puts cons
-  #     end
-  #
-  # Prints:
-  #
-  #     [1, 2]
-  #     [2, 3]
-  #     [3, 4]
-  #     [4, 5]
-  #
-  def each_cons(count : Int)
-    cons = Array(T).new(count)
-    each do |elem|
-      cons << elem
-      cons.shift if cons.size > count
-      if cons.size == count
-        yield cons.dup
-      end
-    end
     nil
   end
 
@@ -565,6 +536,49 @@ module Enumerable(T)
     min_by &.itself
   end
 
+  # Returns the element for which the passed block returns with the minimum value.
+  #
+  # It compares using `<` so the block must return a type that supports that method
+  #
+  #     ["Alice", "Bob"].min_by { |name| name.length }  #=> "Bob"
+  #
+  # Raises `EmptyEnumerable` if the collection is empty.
+  def min_by(&block : T -> U)
+    min :: U
+    obj :: T
+    found = false
+
+    each_with_index do |elem, i|
+      value = yield elem
+      if i == 0 || value < min
+        min = value
+        obj = elem
+      end
+      found = true
+    end
+
+    found ? obj : raise EmptyEnumerable.new
+  end
+
+  # Like `min_by` but instead of the element, returns the value returned by the block.
+  #
+  #     ["Alice", "Bob"].min_of { |name| name.length }  #=> 3 (Bob's length)
+  #
+  def min_of(&block : T -> U)
+    min :: U
+    found = false
+
+    each_with_index do |elem, i|
+      value = yield elem
+      if i == 0 || value < min
+        min = value
+      end
+      found = true
+    end
+
+    found ? min : raise EmptyEnumerable.new
+  end
+
   # Returns a tuple with both the minimum and maximum value.
   #
   #     [1, 2, 3].minmax  #=> {1, 3}
@@ -625,49 +639,6 @@ module Enumerable(T)
     end
 
     found ? {min, max} : raise EmptyEnumerable.new
-  end
-
-  # Returns the element for which the passed block returns with the minimum value.
-  #
-  # It compares using `<` so the block must return a type that supports that method
-  #
-  #     ["Alice", "Bob"].min_by { |name| name.length }  #=> "Bob"
-  #
-  # Raises `EmptyEnumerable` if the collection is empty.
-  def min_by(&block : T -> U)
-    min :: U
-    obj :: T
-    found = false
-
-    each_with_index do |elem, i|
-      value = yield elem
-      if i == 0 || value < min
-        min = value
-        obj = elem
-      end
-      found = true
-    end
-
-    found ? obj : raise EmptyEnumerable.new
-  end
-
-  # Like `min_by` but instead of the element, returns the value returned by the block.
-  #
-  #     ["Alice", "Bob"].min_of { |name| name.length }  #=> 3 (Bob's length)
-  #
-  def min_of(&block : T -> U)
-    min :: U
-    found = false
-
-    each_with_index do |elem, i|
-      value = yield elem
-      if i == 0 || value < min
-        min = value
-      end
-      found = true
-    end
-
-    found ? min : raise EmptyEnumerable.new
   end
 
   # Returns `true` if the passed block returns `true` for none of the elements of the collection.
@@ -736,6 +707,35 @@ module Enumerable(T)
     ary = [] of T
     each { |e| ary << e if yield e }
     ary
+  end
+
+  # Returns an array with the first *count* elements removed from the original collection.
+  #
+  # If *count* is bigger than the number of elements in the collection, returns an empty array.
+  #
+  #     [1, 2, 3, 4, 5, 6].skip(3)  #=> [4, 5, 6]
+  def skip(count : Int)
+    raise ArgumentError.new("attempt to skip negative size") if count < 0
+
+    array = Array(T).new
+    each_with_index do |e, i|
+      array << e if i >= count
+    end
+    array
+  end
+
+  # Skips elements up to, but not including, the first element for which the block returns nil or false and returns an array containing the remaining elements.
+  #
+  #     [1, 2, 3, 4, 5, 0].skip_while {|i| i < 3} #=> [3, 4, 5, 0]
+  #
+  def skip_while
+    result = Array(T).new
+    block_returned_false = false
+    each do |x|
+      block_returned_false = true unless block_returned_false || yield x
+      result << x if block_returned_false
+    end
+    result
   end
 
   # Adds all the elements in the collection together.


### PR DESCRIPTION
With a messy table I'm a tidy person in software projects :D

Sorted the methods in enumerable/enumerable_spec alphabetically to have the file nice and tidy. The sorting makes navigating easier and it also makes it easier to check for missing specs, so in commit number 3 I already started speccing out methods that were not specced before (not all of them as I'm leaving the PC now) - will add more specs in another PR :)

Hope this sort of work is welcome (would also apply it to iterator/other parts of the code base). Feedback welcome as always.

Would appreciate a quick merge (diff is huge --> high probability of merge conflicts)