### PR TITLE
typeof: add type flattening example

### DIFF
--- a/_gitbook/syntax_and_semantics/typeof.md
+++ b/_gitbook/syntax_and_semantics/typeof.md
@@ -20,4 +20,25 @@ hash = {} of Int32 => String
 another_hash = typeof(hash).new #:: Hash(Int32, String)
 ```
 
+Since `typeof` doesn't actually evaluate the expression, it can be
+used on methods at compile time, such as in this example, which
+recursively forms a union type out of nested type paramters:
+
+```ruby
+class Array
+  def self.elem_type(typ)
+    if typ.is_a?(Array)
+      elem_type(typ.first)
+    else
+      typ
+    end
+  end
+end
+
+nest = [1, ["b", [:c, ['d']]]]
+flat = Array(typeof(Array.elem_type(nest))).new
+typeof(nest) #=> Array(Int32 | Array(String | Array(Symbol | Array(Char))))
+typeof(flat) #=> Array(String | Int32 | Symbol | Char)
+```
+
 This expression is also available in the [type grammar](type_grammar.html).


### PR DESCRIPTION
And add note explaining why `typeof` can do this - please correct me if this is mistaken!

The example given here is a reduction of this eye-opening example: http://play.crystal-lang.org/#/r/7td

which was previously posted in this discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/crystal-lang/PbQD8ONHth0/43UaMVpKFAAJ