### PR TITLE
Process.run bugfixes and enhancements:

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -80,6 +80,31 @@ describe Process do
     $?.exit_code.should eq(0)
   end
 
+  describe "environ" do
+    it "clears the environment" do
+      value = Process.run("env", clear_env: true) do |proc|
+        proc.output.read
+      end
+      value.should eq("")
+    end
+
+    it "sets an environment variable" do
+      env = { "FOO" => "bar" }
+      value = Process.run("env", clear_env: true, env: env) do |proc|
+        proc.output.read
+      end
+      value.should eq("FOO=bar\n")
+    end
+
+    it "deletes an environment variable" do
+      env = { "HOME" => nil }
+      value = Process.run("env | egrep '^HOME='", env: env, shell: true) do |proc|
+        proc.output.read
+      end
+      value.should eq("")
+    end
+  end
+
   describe "kill" do
     it "kills a process" do
       pid = fork { loop {} }

--- a/src/env.cr
+++ b/src/env.cr
@@ -99,6 +99,10 @@ module ENV
     end
   end
 
+  def self.clear
+    keys.each { |k| delete k }
+  end
+
   # Writes the contents of the environment to `io`.
   def self.inspect(io)
     io << "{"

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -10,12 +10,13 @@ class Process
   # * `true`: inherit from parent
   # * `IO`: use the given IO
   alias Stdio = Nil | Bool | IO
+  alias Env = Nil | Hash(String, Nil) | Hash(String, String?) |  Hash(String, String)
 
   # Executes a process and waits for it to complete.
   #
   # By default the process is configured without input, output or error.
-  def self.run(cmd : String, args = nil, input = false : Stdio, output = false : Stdio, error = false : Stdio) : Process::Status
-    new(cmd, args, input, output, error).wait
+  def self.run(cmd : String, args = nil, env = nil : Env, clear_env = false : Bool, shell = false : Bool, input = false : Stdio, output = false : Stdio, error = false : Stdio, chdir = nil : String?) : Process::Status
+    new(cmd, args, env, clear_env, shell, input, output, error, chdir).wait
   end
 
   # Executes a process, yields the block, and then waits for it to finish.
@@ -24,13 +25,19 @@ class Process
   # will be closed automatically at the end of the block.
   #
   # Returns the block's value.
-  def self.run(cmd : String, args = nil, input = nil : Stdio, output = nil : Stdio, error = nil : Stdio)
-    process = new(cmd, args, input, output, error)
-    value = yield process
-    process.close
-    $? = process.wait
-    value
+  def self.run(cmd : String, args = nil, env = nil : Env, clear_env = false : Bool, shell = false : Bool, input = nil : Stdio, output = nil : Stdio, error = nil : Stdio, chdir = nil : String?)
+    process = new(cmd, args, env, clear_env, shell, input, output, error, chdir)
+    begin
+      value = yield process
+      $? = process.wait
+      value
+    rescue ex
+      process.kill
+      raise ex
+    end
   end
+
+  getter pid
 
   # A pipe to this process's input. Raises if a pipe wasn't asked when creating the process.
   getter! input
@@ -46,12 +53,18 @@ class Process
   # To wait for it to finish, invoke `wait`.
   #
   # By default the process is configured without input, output or error.
-  def initialize(command : String, args = nil, input = false : Stdio, output = false : Stdio, error = false : Stdio)
-    argv = [command.to_unsafe]
-    args.try &.each do |arg|
-      argv << arg.to_unsafe
+  def initialize(command : String, args = nil, env = nil : Env, clear_env = false : Bool, shell = false : Bool, input = false : Stdio, output = false : Stdio, error = false : Stdio, chdir = nil : String?)
+    cmd, argv = if shell
+      raise "args not allowed with shell" if args
+      {"/bin/sh", ["/bin/sh".to_unsafe, "-c".to_unsafe, command.to_unsafe, Pointer(UInt8).null]}
+    else
+      a = [command.to_unsafe]
+      args.try &.each do |arg|
+        a << arg.to_unsafe
+      end
+      a << Pointer(UInt8).null
+      {command, a}
     end
-    argv << Pointer(UInt8).null
 
     @wait_count = 0
 
@@ -59,7 +72,7 @@ class Process
       fork_input, process_input = IO.pipe(read_blocking: true)
       if input
         @wait_count += 1
-        spawn { copy_io(input, process_input, channel) }
+        spawn { copy_io(input, process_input, channel, close_dst: true) }
       else
         @input = process_input
       end
@@ -69,7 +82,7 @@ class Process
       process_output, fork_output = IO.pipe(write_blocking: true)
       if output
         @wait_count += 1
-        spawn { copy_io(process_output, output, channel) }
+        spawn { copy_io(process_output, output, channel, close_src: true) }
       else
         @output = process_output
       end
@@ -79,7 +92,7 @@ class Process
       process_error, fork_error = IO.pipe(write_blocking: true)
       if error
         @wait_count += 1
-        spawn { copy_io(process_error, error, channel) }
+        spawn { copy_io(process_error, error, channel, close_src: true) }
       else
         @error = process_error
       end
@@ -93,11 +106,19 @@ class Process
         reopen_io(fork_output || output, STDOUT, "w")
         reopen_io(fork_error || error, STDERR, "w")
 
-        # Dir.chdir(chdir) if chdir
+        ENV.clear if clear_env
+        env.try &.each do |key, val|
+          if val
+            ENV[key] = val
+          else
+            ENV.delete key
+          end
+        end
 
-        LibC.execvp(command, argv)
+        Dir.chdir(chdir) if chdir
+
+        LibC.execvp(cmd, argv)
       rescue ex
-        # TODO: print backtrace
         ex.inspect(STDERR)
         STDERR.flush
       ensure
@@ -110,12 +131,24 @@ class Process
     fork_error.try &.close
   end
 
-  # Waits for this process to complete.
+  # See Process.kill
+  def kill sig = Signal::TERM
+    Process.kill sig, @pid
+  end
+
+  # Waits for this process to complete and closes any pipes.
   def wait : Process::Status
-    @wait_count.times { channel.receive }
+    close_io @input # only closed when a pipe was created but not managed by copy_io
+
+    @wait_count.times do
+      ex = channel.receive
+      raise ex if ex
+    end
 
     exit_code = Process.waitpid(@pid)
     Status.new(exit_code)
+  ensure
+    close
   end
 
   # Closes any pipes to the child process.
@@ -126,19 +159,34 @@ class Process
   end
 
   private def channel
-    @channel ||= Channel(Nil).new
+    @channel ||= Channel(Exception?).new
   end
 
   private def needs_pipe?(io)
     io.nil? || (io.is_a?(IO) && !io.is_a?(FileDescriptorIO))
   end
 
-  private def copy_io(src, dst, channel)
+  private def copy_io(src, dst, channel, close_src = false, close_dst = false)
     return unless src.is_a?(IO) && dst.is_a?(IO)
 
-    IO.copy(src, dst)
-    dst.close
-    channel.send nil
+    begin
+      IO.copy(src, dst)
+
+      # close is called here to trigger exceptions
+      # close must be called before channel.send or the process may deadlock
+      src.close if close_src
+      close_src = false
+      dst.close if close_dst
+      close_dst = false
+
+      channel.send nil
+    rescue ex
+      channel.send ex
+    ensure
+      # any exceptions are silently ignored because of spawn
+      src.close if close_src
+      dst.close if close_dst
+    end
   end
 
   private def reopen_io(src_io, dst_io, mode)


### PR DESCRIPTION
  Close the correct pipes when using copy_io.
  Pass exceptions back to main fiber when using copy_io.
  Attempt to kill process if exception occurs in run block.
  Chdir param is back.
  New env modification params (ruby compatible).
  New shell param.
  New method .kill.

ENV additions:
  Enumerable
  New method .clear
  New method .keys