### PR TITLE
Fix class name generation for `crystal init`

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -24,9 +24,14 @@ module Crystal
     run_init_project("lib", "example", "tmp/example", "John Smith")
     run_init_project("app", "example_app", "tmp/example_app", "John Smith")
     run_init_project("lib", "example-lib", "tmp/example-lib", "John Smith")
+    run_init_project("lib", "camel_example-camel_lib", "tmp/camel_example-camel_lib", "John Smith")
 
     describe_file "example-lib/src/example-lib.cr" do |file|
       file.should contain("Example::Lib")
+    end
+
+    describe_file "camel_example-camel_lib/src/camel_example-camel_lib.cr" do |file|
+      file.should contain("CamelExample::CamelLib")
     end
 
     describe_file "example/.gitignore" do |gitignore|

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -107,7 +107,7 @@ DIR  - directory where project will be generated,
       end
 
       def module_name
-        config.name.camelcase.split("-").map(&.capitalize).join("::")
+        config.name.split("-").map(&.camelcase).join("::")
       end
 
       abstract def full_path


### PR DESCRIPTION
Creates class as `FooBar::Baz` not `Foobar::Baz` given “foo_bar-baz” as lib/app name.

```crystal
# old code
"foo_bar_boz-baz_kris".camelcase.split("-").map(&.capitalize).join("::") # => Foobarboz::Bazkris

# new code
"foo_bar_boz-baz_kris".split("-").map(&.camelcase).join("::") # => FooBarBoz::BazKris
```

