### PR TITLE
Added HTML parsing to XML module, references #1240

### DIFF
--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -4,7 +4,7 @@ require "xml"
 describe XML do
     
     it "parses HTML" do
-        doc = XML.parseHTML(%(\
+        doc = XML.parse_html(%(\
           <!doctype html>
           <html>
           <head>

--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -1,0 +1,43 @@
+require "spec"
+require "xml"
+
+describe XML do
+    
+    it "parses HTML" do
+        doc = XML.parseHTML(%(\
+          <!doctype html>
+          <html>
+          <head>
+              <title>Samantha</title>
+          </head>
+          <body>
+              <h1 class="large">Boat</h1>
+          </body>
+          </html>
+        ))
+
+        html = doc.children[1]
+        html.name.should eq("html")
+        
+        head = html.children.find { |node| node.name == "head" }.not_nil!
+        head.name.should eq("head")
+        
+        title = head.children.find { |node| node.name == "title" }.not_nil!
+        title.text.should eq("Samantha")
+        
+        body = html.children.find { |node| node.name == "body" }.not_nil!
+        
+        h1 = body.children.find { |node| node.name == "h1" }.not_nil!
+
+        attrs = h1.attributes
+        attrs.empty?.should be_false
+        attrs.length.should eq(1)
+
+        attr = attrs[0]
+        attr.name.should eq("class")
+        attr.content.should eq("large")
+        attr.text.should eq("large")
+        attr.inner_text.should eq("large")
+    end
+    
+end

--- a/src/xml/html_parser_options.cr
+++ b/src/xml/html_parser_options.cr
@@ -1,0 +1,36 @@
+@[Flags]
+enum XML::HTMLParserOptions
+    #Relaxed parsing
+    RECOVER = 1
+    
+    # Do not default a doctype if not found
+    NODEFDTD = 4
+    
+    # Suppress error reports
+    NOERROR = 32
+    
+    # Suppress warning reports
+    NOWARNING = 64
+    
+    # Pedantic error reporting
+    PEDANTIC = 128
+    
+    # Remove blank nodes
+    NOBLANKS = 256
+    
+    # Forbid network access
+    NONET = 2048
+    
+    # Do not add implied html/body... elements
+    NOIMPLIED = 8192
+    
+    # Compact small text nodes
+    COMPACT = 65536
+    
+    # Ignore internal document encoding hint
+    IGNORE_ENC = 2097152
+    
+  def self.default
+    NOERROR | NOWARNING
+  end
+end

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -1,5 +1,6 @@
 require "./type"
 require "./parser_options"
+require "./html_parser_options"
 require "./save_options"
 
 @[Link("xml2")]
@@ -86,6 +87,8 @@ lib LibXML
   fun xmlTextReaderLocatorLineNumber(XMLTextReaderLocator) : Int32
 
   fun xmlReadMemory(buffer : UInt8*, size : Int32, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : DocPtr
+  
+  fun htmlReadMemory(buffer : UInt8*, size : Int32, url : UInt8*, encoding : UInt8*, options : XML::HTMLParserOptions) : DocPtr
 
   alias InputReadCallback = (Void*, UInt8*, Int32) -> Int32
   alias InputCloseCallback = (Void*) -> Int32

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -19,7 +19,7 @@ module XML
       )
   end
 
-  def self.parseHTML(string: String, options = HTMLParserOptions.default : HTMLParserOptions)
+  def self.parse_html(string: String, options = HTMLParserOptions.default : HTMLParserOptions)
       from_ptr LibXML.htmlReadMemory(string, string.bytesize, nil, nil, options)
   end
 

--- a/src/xml/xml.cr
+++ b/src/xml/xml.cr
@@ -19,6 +19,10 @@ module XML
       )
   end
 
+  def self.parseHTML(string: String, options = HTMLParserOptions.default : HTMLParserOptions)
+      from_ptr LibXML.htmlReadMemory(string, string.bytesize, nil, nil, options)
+  end
+
   protected def self.from_ptr(doc : LibXML::DocPtr)
     if doc
       Node.new doc


### PR DESCRIPTION
Let me know if you'd like more tests. I think since the HTML parsing functions of libxml2 return the same document structure as the XML ones it isn't worth duplicating most of the tests that already exist.