### PR TITLE
Add StaticArray#== for equality comparisons

### DIFF
--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -45,6 +45,25 @@ describe "StaticArray" do
     a[2].should eq(2)
   end
 
+  describe "==" do
+    it "compares empty" do
+      (StaticArray(Int32, 0).new(0)).should eq(StaticArray(Int32, 0).new(0))
+      (StaticArray(Int32, 1).new(0)).should_not eq(StaticArray(Int32, 0).new(0))
+      (StaticArray(Int32, 0).new(0)).should_not eq(StaticArray(Int32, 1).new(0))
+    end
+
+    it "compares elements" do
+      a = StaticArray(Int32, 3).new { |i| i * 2 }
+      a.should eq(StaticArray(Int32, 3).new { |i| i * 2 })
+      a.should_not eq(StaticArray(Int32, 3).new { |i| i * 3 })
+    end
+
+    it "compares other" do
+      (StaticArray(Int32, 0).new(0)).should_not eq(nil)
+      (StaticArray(Int32, 3).new(0)).should_not eq(StaticArray(Int8, 3).new(0_i8))
+    end
+  end
+
   describe "values_at" do
     it "returns the given indexes" do
       StaticArray(Int32, 4).new { |i| i + 1 }.values_at(1, 0, 2).should eq({2, 1, 3})

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -25,6 +25,17 @@ struct StaticArray(T, N)
     new { value }
   end
 
+  def ==(other : self)
+    length == other.length && each_with_index do |e, i|
+      return false unless e == other[i]
+    end
+    true
+  end
+
+  def ==(other)
+    false
+  end
+
   def each
     N.times do |i|
       yield buffer[i]


### PR DESCRIPTION
Hey. I was writing a spec where I needed to compare two static arrays and the test was failing when it should have passed. Both were the same type and value.

This was the spec:

``` crystal
it "decodes message" do
  # ...
  message.target.should eq(StaticArray(UInt8, 8).new(0_u8))
end
```

And this was the error: 

<img width="636" alt="screen shot 2015-08-21 at 8 29 34 pm" src="https://cloud.githubusercontent.com/assets/19860/9407417/3b5d7742-484c-11e5-87af-48063c2cee53.png">

On IRC @jhass pointed out on that if I implemented `StaticArray#==` then this spec would work as expected. He also suggested opening a PR, so here we are! All feedback is welcome.