### PR TITLE
HTTP Cookie handling

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -1,0 +1,100 @@
+require "spec"
+require "http/cookie"
+
+module HTTP
+  describe Cookie do
+    it "parses key=value" do
+      cookie = HTTP::Cookie.parse("key=value")
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.to_header.should eq("key=value; path=/")
+    end
+
+    it "parses key=key=value" do
+      cookie = HTTP::Cookie.parse("key=key=value")
+      cookie.name.should eq("key")
+      cookie.value.should eq("key=value")
+      cookie.to_header.should eq("key=key%3Dvalue; path=/")
+    end
+
+    it "parses key=key%3Dvalue" do
+      cookie = HTTP::Cookie.parse("key=key%3Dvalue")
+      cookie.name.should eq("key")
+      cookie.value.should eq("key=value")
+      cookie.to_header.should eq("key=key%3Dvalue; path=/")
+    end
+
+    it "parses path" do
+      cookie = HTTP::Cookie.parse("key=value; path=/test")
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.path.should eq("/test")
+      cookie.to_header.should eq("key=value; path=/test")
+    end
+
+    it "parses Secure" do
+      cookie = HTTP::Cookie.parse("key=value; Secure")
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.secure.should eq(true)
+      cookie.to_header.should eq("key=value; path=/; Secure")
+    end
+
+    it "parses HttpOnly" do
+      cookie = HTTP::Cookie.parse("key=value; HttpOnly")
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.http_only.should eq(true)
+      cookie.to_header.should eq("key=value; path=/; HttpOnly")
+    end
+
+    it "parses domain" do
+      cookie = HTTP::Cookie.parse("key=value; domain=www.example.com")
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.domain.should eq("www.example.com")
+      cookie.to_header.should eq("key=value; path=/; domain=www.example.com")
+    end
+
+    it "parses expires rfc1123" do
+      cookie = HTTP::Cookie.parse("key=value; expires=Sun, 06 Nov 1994 08:49:37 GMT")
+      time = Time.new(1994, 11, 6, 8, 49, 37)
+
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.expires.should eq(time)
+    end
+
+    it "parses expires rfc1036" do
+      cookie = HTTP::Cookie.parse("key=value; expires=Sunday, 06-Nov-94 08:49:37 GMT")
+      time = Time.new(1994, 11, 6, 8, 49, 37)
+
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.expires.should eq(time)
+    end
+
+    it "parses expires ansi c" do
+      cookie = HTTP::Cookie.parse("key=value; expires=Sun Nov  6 08:49:37 1994")
+      time = Time.new(1994, 11, 6, 8, 49, 37)
+
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.expires.should eq(time)
+    end
+
+    it "parses full" do
+      cookie = HTTP::Cookie.parse("key=value; path=/test; domain=www.example.com; HttpOnly; Secure; expires=Sun, 06 Nov 1994 08:49:37 GMT")
+      time = Time.new(1994, 11, 6, 8, 49, 37)
+
+      cookie.name.should eq("key")
+      cookie.value.should eq("value")
+      cookie.path.should eq("/test")
+      cookie.domain.should eq("www.example.com")
+      cookie.http_only.should eq(true)
+      cookie.secure.should eq(true)
+      cookie.expires.should eq(time)
+    end
+  end
+end
+

--- a/spec/std/http/http_spec.cr
+++ b/spec/std/http/http_spec.cr
@@ -1,0 +1,26 @@
+require "spec"
+require "http"
+
+describe HTTP do
+  it "parses RFC1123" do
+    time = Time.new(1994, 11, 6, 8, 49, 37)
+    HTTP.parse_time("Sun, 06 Nov 1994 08:49:37 GMT").should eq(time)
+  end
+
+  it "parses RFC1036" do
+    time = Time.new(1994, 11, 6, 8, 49, 37)
+    HTTP.parse_time("Sunday, 06-Nov-94 08:49:37 GMT").should eq(time)
+  end
+
+  it "parses ANSI C" do
+    time = Time.new(1994, 11, 6, 8, 49, 37)
+    HTTP.parse_time("Sun Nov  6 08:49:37 1994").should eq(time)
+    time2 = Time.new(1994, 11, 16, 8, 49, 37)
+    HTTP.parse_time("Sun Nov 16 08:49:37 1994").should eq(time2)
+  end
+
+  it "generates RFC1123" do
+    time = Time.new(1994, 11, 6, 8, 49, 37)
+    HTTP.rfc1123_date(time).should eq("Sun, 06 Nov 1994 08:49:37 GMT")
+  end
+end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -1,4 +1,6 @@
 module HTTP
+  DATE_PATTERNS = {"%a, %d %b %Y %H:%M:%S %z", "%A, %d-%b-%y %H:%M:%S %z", "%a %b %e %H:%M:%S %Y"}
+
   def self.parse_headers_and_body(io, mandatory_body = false)
     headers = Headers.new
 
@@ -78,6 +80,7 @@ module HTTP
         end
       end
     end
+
     io << "\r\n"
     io << body if body
   end
@@ -97,9 +100,26 @@ module HTTP
       true
     end
   end
+
+  def self.parse_time(time_str : String)
+    DATE_PATTERNS.each do |pattern|
+      begin
+        return Time.parse(time_str, pattern)
+      rescue Time::Format::Error
+      end
+    end
+
+    nil
+  end
+
+  def self.rfc1123_date(time : Time) : String
+    # TODO: GMT should come from the Time classes instead
+    time.to_s("%a, %d %b %Y %H:%M:%S GMT")
+  end
 end
 
 require "./request"
 require "./response"
 require "./headers"
 require "./content"
+require "./cookie"

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -1,0 +1,109 @@
+require "cgi"
+require "./common"
+
+module HTTP
+  class Cookie
+    def self.parse(str : String) : Cookie
+      # TODO: error handling, empty string + no name=value pair
+      parts = str.split(/[;]\s?/)
+      name, value = parts[0].split(/\s*=\s*/, 2)
+
+      cookie = HTTP::Cookie.new(name, value)
+      (1...parts.size).each do |i|
+        part = parts[i]
+        case part
+        when .=~ /^\s*path=(.+)/i
+          cookie.path = $~[1] if $~
+        when .=~ /^\s*domain=(.+)/i
+          cookie.domain = $~[1] if $~
+        when .=~ /Secure/
+          cookie.secure = true
+        when .=~ /HttpOnly/
+          cookie.http_only = true
+        when .=~ /^\s*expires=(.+)/
+          cookie.expires = HTTP.parse_time($~[1]) if $~
+        end
+      end
+
+      cookie
+    end
+
+    property name
+    property value
+    property path
+    property expires
+    property domain
+    property secure
+    property http_only
+
+    def initialize(@name, value, @path = "/",  @expires = nil, @domain = nil, @secure = false, @http_only = false)
+      @value = CGI.unescape value
+    end
+
+    def to_header
+      String.build do |header|
+        header << "#{@name}=#{CGI.escape value}"
+        header << "; path=#{@path}" if @path
+        header << "; expires=#{HTTP.rfc1123_date(@expires as Time)}" if @expires
+        header << "; domain=#{@domain}" if @domain
+        header << "; Secure" if @secure
+        header << "; HttpOnly" if @http_only
+      end
+    end
+  end
+
+  class Cookies
+    include Enumerable(Cookie)
+
+    def self.from_headers(headers)
+      new.tap do |cookies|
+        {"Cookie", "Set-Cookie"}.each do |key|
+          if values = headers.get?(key)
+            values.each do |header|
+              cookies << Cookie.parse(header)
+            end
+            headers.delete key
+          end
+        end
+      end
+    end
+
+    def initialize
+      @cookies = {} of String => Cookie
+    end
+
+    def []=(key, value)
+      @cookies[key] = value
+    end
+
+    def [](key)
+      @cookies[key]
+    end
+
+    def <<(cookie : Cookie)
+      self[cookie.name] = cookie
+    end
+
+    def each(&block : T -> _)
+      @cookies.values.each do |cookie|
+        yield cookie
+      end
+    end
+
+    def add_request_headers(headers)
+      add_headers "Cookie", headers
+    end
+
+    def add_response_headers(headers)
+      add_headers "Set-Cookie", headers
+    end
+
+    private def add_headers key, headers
+      each do |cookie|
+        headers.add(key, cookie.to_header)
+      end
+
+      headers
+    end
+  end
+end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -16,6 +16,10 @@ class HTTP::Request
     end
   end
 
+  def cookies
+    @cookies ||= Cookies.from_headers(headers)
+  end
+
   def uri
     URI.parse(@path)
   end
@@ -26,7 +30,9 @@ class HTTP::Request
 
   def to_io(io)
     io << @method << " " << @path << " " << @version << "\r\n"
-    HTTP.serialize_headers_and_body(io, @headers, @body)
+    cookies = @cookies
+    headers = cookies ? cookies.add_request_headers(@headers) : @headers
+    HTTP.serialize_headers_and_body(io, headers, @body)
   end
 
   def self.from_io(io)

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -32,6 +32,10 @@ class HTTP::Response
     @body
   end
 
+  def cookies
+    @cookies ||= Cookies.from_headers(headers)
+  end
+
   def keep_alive?
     HTTP.keep_alive?(self)
   end
@@ -54,7 +58,9 @@ class HTTP::Response
 
   def to_io(io)
     io << @version << " " << @status_code << " " << @status_message << "\r\n"
-    HTTP.serialize_headers_and_body(io, @headers, @body)
+    cookies = @cookies
+    headers = cookies ? cookies.add_response_headers(@headers) : @headers
+    HTTP.serialize_headers_and_body(io, headers, @body)
   end
 
   # :nodoc:


### PR DESCRIPTION
I've added HTTP Cookie handling.

It's not entirely finished as there's still 3 TODO:s left as far as I see it, but I wouldn't mind comments on how to solve that in the best way.

The HTTP::Cookie.parse one is probably the biggest one, I'm not entierly sure what's the idiomatic way of solving the error handling there. Same with HTTP.parse_time.

The last one is in HTTP.rfc1123_string and that's because Time can't handle timezone names as far as i can tell. That name could probably use some work too.

All feedback is welcome.