### PR TITLE
Remove the Enumerable#first(n) alias for Enumerable#take(n)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -207,13 +207,7 @@ describe "Enumerable" do
       end
     end
 
-    it "returns the first n elements with the optional argument" do
-      (1..5).first(2).should eq [1, 2]
-    end
-
     assert { [-1, -2, -3].first.should eq(-1) }
-    assert { [-1, -2, -3].first(1).should eq([-1]) }
-    assert { [-1, -2, -3].first(4).should eq([-1, -2, -3]) }
   end
 
   describe "first?" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -236,15 +236,6 @@ module Enumerable(T)
     raise EmptyEnumerable.new
   end
 
-  # Returns an array with the first *count* elements in the collection.
-  #
-  # If *count* is bigger than the number of elements in the collection, returns as many as possible. This
-  # include the case of calling it over an empty collection, in which case it returns an empty array (unlike the variant
-  # without a parameter).
-  def first(count : Int)
-    take(count)
-  end
-
   # Returns the first element in the collection. When the collection is empty, returns `nil`.
   def first?
     each { |e| return e }


### PR DESCRIPTION
* Current direction of crystal is one method for one thing,
  staying away from aliases. Consistently the first alias for
  take should go (take seems to be the more common name)