### PR TITLE
Add flatten() for iterators

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -449,4 +449,84 @@ describe Iterator do
               .should eq([100, 102, 104])
     end
   end
+
+  describe "flatten" do
+    it "flattens an iterator of mixed-type iterators" do
+      iter = [(1..2).each, ('a'..'b').each].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+      iter.next.should eq('b')
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a', 'b'])
+    end
+
+    it "flattens an iterator of mixed-type elements and iterators" do
+      iter = [(1..2).each, 'a'].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a'])
+    end
+
+    it "flattens an iterator of mixed-type elements and iterators and iterators of iterators" do
+      iter = [(1..2).each, [['a', 'b'].each].each, "foo"].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq('a')
+      iter.next.should eq('b')
+      iter.next.should eq("foo")
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 'a', 'b', "foo"])
+    end
+
+    it "flattens deeply-nested and mixed type iterators" do
+      iter = [[[1], 2], [3, [[4, 5], 6], 7], "a"].each.flatten
+
+      iter.next.should eq(1)
+      iter.next.should eq(2)
+      iter.next.should eq(3)
+      iter.next.should eq(4)
+      iter.next.should eq(5)
+      iter.next.should eq(6)
+      iter.next.should eq(7)
+      iter.next.should eq("a")
+
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(1)
+
+      iter.rewind
+      iter.to_a.should eq([1, 2, 3, 4, 5, 6, 7, "a"])
+    end
+
+    it "flattens a variety of edge cases" do
+      ([] of Nil).each.flatten.to_a.should eq([] of Nil)
+      ['a'].each.flatten.to_a.should eq(['a'])
+      [[[[[["hi"]]]]]].each.flatten.to_a.should eq(["hi"])
+    end
+  end
 end


### PR DESCRIPTION
Implements Iterator(T).flatten(). Procs are used to track the current iterator and the stack of those needing to be rewound.

This follows on @colinmarc's work in #1009 and includes the same specs, plus a few more. I'm not sure at all that this is the right way to implement flatten, but it's the only one I've found so far that passes the specs. If there is a way to keep a stack of heterogenous iterators without losing their specific types, I think that would be better than this Proc trick -- but I haven't been able to find a way to do that.

I definitely think that `element_type` should be promoted out of here and `Array` and documented -- it seems likely to be generally useful. 