### PR TITLE
several small improvements to Regex

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -14,21 +14,16 @@ describe "MatchData" do
   end
 
   describe "#[]" do
-    it "raises if outside match range with []" do
-      "foo" =~ /foo/
-      expect_raises(IndexError) { $~[1] }
+    it "captures empty group" do
+      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
+      $~[1].should eq("")
+      $~["g1"].should eq("")
     end
 
     it "capture named group" do
       ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
       $~["g1"].should eq("oo")
       $~["g2"].should eq("ba")
-    end
-
-    it "captures empty group" do
-      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
-      $~[1].should eq("")
-      $~["g1"].should eq("")
     end
 
     it "raises exception on optional empty group" do
@@ -41,20 +36,14 @@ describe "MatchData" do
       ("foo" =~ /foo/).should eq(0)
       expect_raises(ArgumentError) { $~["group"] }
     end
+
+    it "raises if outside match range with []" do
+      "foo" =~ /foo/
+      expect_raises(IndexError) { $~[1] }
+    end
   end
 
   describe "#[]?" do
-    it "returns nil if outside match range with []" do
-      "foo" =~ /foo/
-      $~[1]?.should be_nil
-    end
-
-    it "capture named group" do
-      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
-      $~["g1"]?.should eq("oo")
-      $~["g2"]?.should eq("ba")
-    end
-
     it "capture empty group" do
       ("foo" =~ /(?<g1>z?)foo/).should eq(0)
       $~[1]?.should eq("")
@@ -67,37 +56,48 @@ describe "MatchData" do
       $~["g1"]?.should be_nil
     end
 
+    it "capture named group" do
+      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
+      $~["g1"]?.should eq("oo")
+      $~["g2"]?.should eq("ba")
+    end
+
     it "returns nil exception when named group doesn't exist" do
       ("foo" =~ /foo/).should eq(0)
       $~["group"]?.should be_nil
     end
-  end
 
-  describe "#pre_match" do
-    it "returns the part of the string before the match" do
-      "Crystal".match(/yst/) { |md| md.pre_match.should eq "Cr" }
-    end
-
-    it "returns an empty string when there's nothing before" do
-      "Crystal".match(/Cryst/) { |md| md.pre_match.should eq "" }
-    end
-
-    it "works with unicode" do
-      "há日本語".match(/本/) { |md| md.pre_match.should eq "há日" }
+    it "returns nil if outside match range with []" do
+      "foo" =~ /foo/
+      $~[1]?.should be_nil
     end
   end
 
   describe "#post_match" do
-    it "returns the part of the string after the match" do
-      "Crystal".match(/yst/) { |md| md.post_match.should eq "al" }
-    end
-
     it "returns an empty string when there's nothing after" do
       "Crystal".match(/ystal/) { |md| md.post_match.should eq "" }
     end
 
+    it "returns the part of the string after the match" do
+      "Crystal".match(/yst/) { |md| md.post_match.should eq "al" }
+    end
+
     it "works with unicode" do
       "há日本語".match(/本/) { |md| md.post_match.should eq "語" }
+    end
+  end
+
+  describe "#pre_match" do
+    it "returns an empty string when there's nothing before" do
+      "Crystal".match(/Cryst/) { |md| md.pre_match.should eq "" }
+    end
+
+    it "returns the part of the string before the match" do
+      "Crystal".match(/yst/) { |md| md.pre_match.should eq "Cr" }
+    end
+
+    it "works with unicode" do
+      "há日本語".match(/本/) { |md| md.pre_match.should eq "há日" }
     end
   end
 end

--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -1,0 +1,103 @@
+require "spec"
+
+describe "MatchData" do
+  it "does inspect" do
+    /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    /f(o)(x)?/.match("the fort").inspect.should eq(%(#<MatchData "fo" 1:"o" 2:nil>))
+    /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))
+  end
+
+  it "does to_s" do
+    /f(o)(x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
+    /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" lettero:"o" letterx:"x">))
+    /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
+  end
+
+  describe "#[]" do
+    it "raises if outside match range with []" do
+      "foo" =~ /foo/
+      expect_raises(IndexError) { $~[1] }
+    end
+
+    it "capture named group" do
+      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
+      $~["g1"].should eq("oo")
+      $~["g2"].should eq("ba")
+    end
+
+    it "captures empty group" do
+      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
+      $~[1].should eq("")
+      $~["g1"].should eq("")
+    end
+
+    it "raises exception on optional empty group" do
+      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
+      expect_raises(Exception) { $~[1] }
+      expect_raises(Exception) { $~["g1"] }
+    end
+
+    it "raises exception when named group doesn't exist" do
+      ("foo" =~ /foo/).should eq(0)
+      expect_raises(ArgumentError) { $~["group"] }
+    end
+  end
+
+  describe "#[]?" do
+    it "returns nil if outside match range with []" do
+      "foo" =~ /foo/
+      $~[1]?.should be_nil
+    end
+
+    it "capture named group" do
+      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
+      $~["g1"]?.should eq("oo")
+      $~["g2"]?.should eq("ba")
+    end
+
+    it "capture empty group" do
+      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
+      $~[1]?.should eq("")
+      $~["g1"]?.should eq("")
+    end
+
+    it "capture optional empty group" do
+      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
+      $~[1]?.should be_nil
+      $~["g1"]?.should be_nil
+    end
+
+    it "returns nil exception when named group doesn't exist" do
+      ("foo" =~ /foo/).should eq(0)
+      $~["group"]?.should be_nil
+    end
+  end
+
+  describe "#pre_match" do
+    it "returns the part of the string before the match" do
+      "Crystal".match(/yst/) { |md| md.pre_match.should eq "Cr" }
+    end
+
+    it "returns an empty string when there's nothing before" do
+      "Crystal".match(/Cryst/) { |md| md.pre_match.should eq "" }
+    end
+
+    it "works with unicode" do
+      "há日本語".match(/本/) { |md| md.pre_match.should eq "há日" }
+    end
+  end
+
+  describe "#post_match" do
+    it "returns the part of the string after the match" do
+      "Crystal".match(/yst/) { |md| md.post_match.should eq "al" }
+    end
+
+    it "returns an empty string when there's nothing after" do
+      "Crystal".match(/ystal/) { |md| md.post_match.should eq "" }
+    end
+
+    it "works with unicode" do
+      "há日本語".match(/本/) { |md| md.post_match.should eq "語" }
+    end
+  end
+end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -1,6 +1,48 @@
 require "spec"
 
 describe "Regex" do
+  it "compare to other instances" do
+    Regex.new("foo").should eq(Regex.new("foo"))
+    Regex.new("foo").should_not eq(Regex.new("bar"))
+  end
+
+  it "does =~" do
+    (/foo/ =~ "bar foo baz").should eq(4)
+    $~.length.should eq(0)
+  end
+
+  it "does inspect" do
+    /foo/.inspect.should eq("/foo/")
+  end
+
+  it "does to_s" do
+    /foo/.to_s.should eq("/foo/")
+    /foo/imx.to_s.should eq("/foo/imx")
+  end
+
+  it "doesn't crash when PCRE tries to free some memory (#771)" do
+    expect_raises(ArgumentError) { Regex.new("foo)") }
+  end
+
+  it "escapes" do
+    Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
+  end
+
+  it "matches ignore case" do
+    ("HeLlO" =~ /hello/).should be_nil
+    ("HeLlO" =~ /hello/i).should eq(0)
+  end
+
+  it "matches lines beginnings on ^ in multiline mode" do
+    ("foo\nbar" =~ /^bar/).should be_nil
+    ("foo\nbar" =~ /^bar/m).should eq(4)
+  end
+
+  it "matches multiline" do
+    ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
+    ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
+  end
+
   it "matches with =~ and captures" do
     ("fooba" =~ /f(o+)(bar?)/).should eq(0)
     $~.length.should eq(2)
@@ -21,16 +63,6 @@ describe "Regex" do
     $2.should eq("ba")
   end
 
-  it "does =~" do
-    (/foo/ =~ "bar foo baz").should eq(4)
-    $~.length.should eq(0)
-  end
-
-  it "raises if outside match range with []" do
-    "foo" =~ /foo/
-    expect_raises(IndexError) { $1 }
-  end
-
   describe "name_table" do
     it "is a map of capture group number to name" do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table
@@ -42,44 +74,12 @@ describe "Regex" do
     end
   end
 
-  it "matches multiline" do
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
-  end
-
-  it "matches ignore case" do
-    ("HeLlO" =~ /hello/).should be_nil
-    ("HeLlO" =~ /hello/i).should eq(0)
-  end
-
-  it "does to_s" do
-    /foo/.to_s.should eq("/foo/")
-    /foo/imx.to_s.should eq("/foo/imx")
-  end
-
-  it "does inspect" do
-    /foo/.inspect.should eq("/foo/")
-  end
-
   it "raises exception with invalid regex" do
     expect_raises(ArgumentError) { Regex.new("+") }
   end
 
-  it "escapes" do
-    Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
-  end
-
-  it "doesn't crash when PCRE tries to free some memory (#771)" do
-    expect_raises(ArgumentError) { Regex.new("foo)") }
-  end
-
-  it "compare to other instances" do
-    Regex.new("foo").should eq(Regex.new("foo"))
-    Regex.new("foo").should_not eq(Regex.new("bar"))
-  end
-
-  it "matches lines beginnings on ^ in multiline mode" do
-    ("foo\nbar" =~ /^bar/).should be_nil
-    ("foo\nbar" =~ /^bar/m).should eq(4)
+  it "raises if outside match range with []" do
+    "foo" =~ /foo/
+    expect_raises(IndexError) { $1 }
   end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -94,4 +94,36 @@ describe "Regex" do
     "foo" =~ /foo/
     expect_raises(IndexError) { $1 }
   end
+
+  describe ".union" do
+    it "constructs a Regex that matches things any of its arguments match" do 
+      re = Regex.union(/skiing/i, "sledding")
+      re.match("Skiing").not_nil![0].should eq "Skiing"
+      re.match("sledding").not_nil![0].should eq "sledding"
+    end
+
+    it "returns a regular expression that will match passed arguments" do
+      Regex.union("penzance").should eq /penzance/
+      Regex.union("skiing", "sledding").should eq /skiing|sledding/
+      Regex.union(/dogs/, /cats/i).should eq /(?-imx:dogs)|(?i-mx:cats)/
+    end
+  
+    it "quotes any string arguments" do
+      Regex.union("n", ".").should eq /n|\./
+    end
+  
+    it "returns a Regex with an Array(String) with special characters" do
+      Regex.union(["+","-"]).should eq /\+|\-/
+    end
+
+    it "accepts a single Array(String | Regexp) argument" do
+      Regex.union(["skiing", "sledding"]).should eq /skiing|sledding/
+      Regex.union([/dogs/, /cats/i]).should eq /(?-imx:dogs)|(?i-mx:cats)/
+      (/dogs/ + /cats/i).should eq /(?-imx:dogs)|(?i-mx:cats)/
+    end
+
+    it "combines Regex objects in the same way as Regex#+" do
+      Regex.union(/skiing/i, /sledding/).should eq(/skiing/i + /sledding/)
+    end
+  end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -42,94 +42,6 @@ describe "Regex" do
     end
   end
 
-  describe "MatchData#[]" do
-    it "raises if outside match range with []" do
-      "foo" =~ /foo/
-      expect_raises(IndexError) { $~[1] }
-    end
-
-    it "capture named group" do
-      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
-      $~["g1"].should eq("oo")
-      $~["g2"].should eq("ba")
-    end
-
-    it "captures empty group" do
-      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
-      $~[1].should eq("")
-      $~["g1"].should eq("")
-    end
-
-    it "raises exception on optional empty group" do
-      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
-      expect_raises(Exception) { $~[1] }
-      expect_raises(Exception) { $~["g1"] }
-    end
-
-    it "raises exception when named group doesn't exist" do
-      ("foo" =~ /foo/).should eq(0)
-      expect_raises(ArgumentError) { $~["group"] }
-    end
-  end
-
-  describe "MatchData#[]?" do
-    it "returns nil if outside match range with []" do
-      "foo" =~ /foo/
-      $~[1]?.should be_nil
-    end
-
-    it "capture named group" do
-      ("fooba" =~ /f(?<g1>o+)(?<g2>bar?)/).should eq(0)
-      $~["g1"]?.should eq("oo")
-      $~["g2"]?.should eq("ba")
-    end
-
-    it "capture empty group" do
-      ("foo" =~ /(?<g1>z?)foo/).should eq(0)
-      $~[1]?.should eq("")
-      $~["g1"]?.should eq("")
-    end
-
-    it "capture optional empty group" do
-      ("foo" =~ /(?<g1>z)?foo/).should eq(0)
-      $~[1]?.should be_nil
-      $~["g1"]?.should be_nil
-    end
-
-    it "returns nil exception when named group doesn't exist" do
-      ("foo" =~ /foo/).should eq(0)
-      $~["group"]?.should be_nil
-    end
-  end
-
-  describe "MatchData#pre_match" do
-    it "returns the part of the string before the match" do
-      "Crystal".match(/yst/) { |md| md.pre_match.should eq "Cr" }
-    end
-
-    it "returns an empty string when there's nothing before" do
-      "Crystal".match(/Cryst/) { |md| md.pre_match.should eq "" }
-    end
-
-    it "works with unicode" do
-      "há日本語".match(/本/) { |md| md.pre_match.should eq "há日" }
-    end
-  end
-
-  describe "MatchData#post_match" do
-    it "returns the part of the string after the match" do
-      "Crystal".match(/yst/) { |md| md.post_match.should eq "al" }
-    end
-
-    it "returns an empty string when there's nothing after" do
-      "Crystal".match(/ystal/) { |md| md.post_match.should eq "" }
-    end
-
-    it "works with unicode" do
-      "há日本語".match(/本/) { |md| md.post_match.should eq "語" }
-    end
-  end
-
   it "matches multiline" do
     ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
     ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
@@ -143,13 +55,6 @@ describe "Regex" do
   it "does to_s" do
     /foo/.to_s.should eq("/foo/")
     /foo/imx.to_s.should eq("/foo/imx")
-
-    /f(o)(x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" lettero:"o" letterx:"x">))
-    /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
-    /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /f(o)(x)?/.match("the fort").inspect.should eq(%(#<MatchData "fo" 1:"o" 2:nil>))
-    /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))
   end
 
   it "does inspect" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -13,11 +13,23 @@ describe "Regex" do
 
   it "does inspect" do
     /foo/.inspect.should eq("/foo/")
+    /foo/.inspect.should eq("/foo/")
+    /foo/imx.inspect.should eq("/foo/imx")
   end
 
   it "does to_s" do
-    /foo/.to_s.should eq("/foo/")
-    /foo/imx.to_s.should eq("/foo/imx")
+    /foo/.to_s.should eq("(?-imsx:foo)")
+    /foo/im.to_s.should eq("(?ims-x:foo)")
+    /foo/imx.to_s.should eq("(?imsx-:foo)")
+
+    "Crystal".match(/(?<bar>C)#{/(?<foo>R)/i}/).should be_truthy
+    "Crystal".match(/(?<bar>C)#{/(?<foo>R)/}/i).should be_falsey
+
+    "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/) do |md|
+      md[0].should eq("Cr")
+      md["bar"].should eq("C")
+      md["foo"].should eq("r")
+    end
   end
 
   it "doesn't crash when PCRE tries to free some memory (#771)" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -121,6 +121,11 @@ describe "Regex" do
       Regex.union([/dogs/, /cats/i]).should eq /(?-imsx:dogs)|(?i-msx:cats)/
       (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
+
+    it "accepts a single Tuple(String | Regexp) argument" do
+      Regex.union({"skiing", "sledding"}).should eq /skiing|sledding/
+      Regex.union({/dogs/, /cats/i}).should eq /(?-imsx:dogs)|(?i-msx:cats)/
+      (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
 
     it "combines Regex objects in the same way as Regex#+" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -105,7 +105,7 @@ describe "Regex" do
     it "returns a regular expression that will match passed arguments" do
       Regex.union("penzance").should eq /penzance/
       Regex.union("skiing", "sledding").should eq /skiing|sledding/
-      Regex.union(/dogs/, /cats/i).should eq /(?-imx:dogs)|(?i-mx:cats)/
+      Regex.union(/dogs/, /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
     end
   
     it "quotes any string arguments" do
@@ -118,8 +118,9 @@ describe "Regex" do
 
     it "accepts a single Array(String | Regexp) argument" do
       Regex.union(["skiing", "sledding"]).should eq /skiing|sledding/
-      Regex.union([/dogs/, /cats/i]).should eq /(?-imx:dogs)|(?i-mx:cats)/
-      (/dogs/ + /cats/i).should eq /(?-imx:dogs)|(?i-mx:cats)/
+      Regex.union([/dogs/, /cats/i]).should eq /(?-imsx:dogs)|(?i-msx:cats)/
+      (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
+    end
     end
 
     it "combines Regex objects in the same way as Regex#+" do

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -176,7 +176,7 @@ require "./*"
 # PCRE optionally permits named capture groups (named subpatterns) to not be
 # unique. Crystal exposes the name table of a Regex as a
 # Hash of String => Int32, and therefore requires named capture groups to have
-# unique names with a single Regex.
+# unique names within a single Regex.
 class Regex
   @[Flags]
   enum Options
@@ -235,8 +235,8 @@ class Regex
   # If it's not, a String containing the error message is returned.
   #
   # ```
-  # Regex.error("(foo|bar)") #=> nil
-  # Regex.error("(foo|bar") #=> "missing ) at 8"
+  # Regex.error?("(foo|bar)") #=> nil
+  # Regex.error?("(foo|bar") #=> "missing ) at 8"
   # ```
   def self.error?(source)
     re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK).value, out errptr, out erroffset, nil)
@@ -385,7 +385,7 @@ class Regex
   # optional flags included.
   #
   # ```
-  # /ab+c/ix.to_s #=> "/ab+c/ix"
+  # /ab+c/ix.inspect #=> "/ab+c/ix"
   # ```
   def inspect(io : IO)
     io << "/"
@@ -479,9 +479,9 @@ class Regex
   #
   # ```
   # re = /A*/i                 #=> /A*/i
-  # re.to_s                    #=> "(?i:A*)"
+  # re.to_s                    #=> "(?i-msx:A*)"
   # "Crystal".match(/t#{re}l/) #=> #<MatchData "tal">
-  # re = /A*/                  #=> "(?:A*)"
+  # re = /A*/                  #=> "(?-imsx:A*)"
   # "Crystal".match(/t#{re}l/) #=> nil
   # ```
   def to_s(io : IO)

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -279,8 +279,11 @@ class Regex
   # re = Regex.union([/skiing/i, "sledding"])
   # re.match("Skiing")   #=> #<MatchData "Skiing">
   # re.match("sledding") #=> #<MatchData "sledding">
+  # re = Regex.union({/skiing/i, "sledding"})
+  # re.match("Skiing")   #=> #<MatchData "Skiing">
+  # re.match("sledding") #=> #<MatchData "sledding">
   # ```
-  def self.union(patterns : Array(Regex | String))
+  def self.union(patterns : Enumerable(Regex | String))
     new patterns.map { |pattern| union_part pattern }.join("|")
   end
 
@@ -296,7 +299,7 @@ class Regex
   # re.match("sledding") #=> #<MatchData "sledding">
   # ```
   def self.union(*patterns : Regex | String)
-    new patterns.map { |pattern| union_part pattern }.join("|")    
+    union patterns
   end
 
   private def self.union_part(pattern : Regex)

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -20,6 +20,7 @@ class Regex
     NO_UTF8_CHECK = 0x00002000
   end
 
+  getter options
   getter source
 
   def initialize(source, @options = Options::None : Options)
@@ -135,10 +136,6 @@ class Regex
     end
 
     lookup
-  end
-
-  def options
-    @options
   end
 
   def to_s(io : IO)

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -269,6 +269,59 @@ class Regex
     end
   end
 
+  # Union. Returns a Regex that matches any of `patterns`. If any pattern
+  # contains a named capture group using the same name as a named capture
+  # group in any other pattern, an ArgumentError will be raised at runtime.
+  # All capture groups in the patterns after the first one will have their
+  # indexes offset.
+  #
+  # ```
+  # re = Regex.union([/skiing/i, "sledding"])
+  # re.match("Skiing")   #=> #<MatchData "Skiing">
+  # re.match("sledding") #=> #<MatchData "sledding">
+  # ```
+  def self.union(patterns : Array(Regex | String))
+    new patterns.map { |pattern| union_part pattern }.join("|")
+  end
+
+  # Union. Returns a Regex that matches any of `patterns`. If any pattern
+  # contains a named capture group using the same name as a named capture
+  # group in any other pattern, an ArgumentError will be raised at runtime.
+  # All capture groups in the patterns after the first one will have their
+  # indexes offset.
+  #
+  # ```
+  # re = Regex.union(/skiing/i, "sledding")
+  # re.match("Skiing")   #=> #<MatchData "Skiing">
+  # re.match("sledding") #=> #<MatchData "sledding">
+  # ```
+  def self.union(*patterns : Regex | String)
+    new patterns.map { |pattern| union_part pattern }.join("|")    
+  end
+
+  private def self.union_part(pattern : Regex)
+    pattern.to_s
+  end
+
+  private def self.union_part(pattern : String)
+    escape pattern
+  end
+
+  # Union. Returns a Regex that matches either of the operands. If either
+  # operand contains a named capture groups using the same name as a named
+  # capture group in the other operand, an ArgumentError will be raised at
+  # runtime. All capture groups in the second operand will have their indexes
+  # offset.
+  #
+  # ```
+  # re = /skiing/i + /sledding/
+  # re.match("Skiing")   #=> #<MatchData "Skiing">
+  # re.match("sledding") #=> #<MatchData "sledding">
+  # ```
+  def +(other)
+    Regex.union(self, other)
+  end
+
   # Equality. Two regexes are equal if their sources and options are the same.
   #
   # ```


### PR DESCRIPTION
* sort Regex methods
* convert a trivial getter (`options`) to use the getter macro
* document all public Regex methods
* add class overview documentation for Regex
* separate Regex specs from MatchData specs
* sort Regex and MatchData specs
* change the meaning of `Regex#to_s` to match that of Ruby
* add `Regex.union` and an equivalent operator, `Regex#+`

My original intention was only to add `Regex.union`, but I have resolved not to touch a class without documenting all its methods first!

Ruby pretty much completely documents Onigmo regular expression syntax with `Regexp`, but it seemed unwise to try to create such complete documentation for the regex syntax, when we can link to the existing (and I think quite good) PCRE docs. A weakness of PCRE is that it seems to lack a good introduction to regular expressions, presumably because Perl has an excellent one, so I wrote the class overview with the intention of filling that small gap for Crystal.

The more Ruby-ish behavior for `Regex#to_s` doesn't appear to break anything in the compiler, and it allows for one Regex to be transparently interpolated in another while retaining its flags. It does expose a small annoyance, which is that the PCRE options letters (imsx) are not exactly the same as Crystals's options letters (imx) - since we use groups inside the Regex like `(?i-msx:foo)` to preserve options, and these are ultimately passed to PCRE unchanged, we have to use the PCRE options letters. At this point, would it be better to use PCRE's options letters everywhere? Crystal combines PCRE_MULTILINE (m) with PCRE_DOTALL (s) to match Ruby behavior, but Crystal no longer has a goal of being source compatible with Ruby, and it might be beneficial to someone to be able to use PCRE_MULTILINE independently of PCRE_DOTALL or vice versa (I've never wanted it).

Because `Regex.union` (and `Regex#+`) is based on interpolation, it's possible that it will try to create an invalid regex and cause an ArgumentError to be raised at runtime. Since regex literals are syntax-checked at compile time and string components are escaped, I think the only time this can happen is when there are multiple same-named capture groups across two or more of the regexes to be combined, so I've tried to make this point clear in the docs.