### PR TITLE
Add documentation for Array#delete_at and Array#delete_if

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -575,6 +575,15 @@ class Array(T)
     delete_if { |e| e == obj }
   end
 
+  # Deletes the element at the given index, returning that element.
+  # Raises `IndexError` if the index is out of range.
+  #
+  # ```
+  # a = ["ant", "bat", "cat", "dog"]
+  # a.delete_at(2)  #=> "cat"
+  # a               #=> ["ant", "bat", "dog"]
+  # a.delete_at(99) #=> IndexError
+  # ```
   def delete_at(index : Int)
     index = check_index_out_of_bounds index
 
@@ -585,6 +594,18 @@ class Array(T)
     elem
   end
 
+  # Deletes every element of `self` for which block evaluates to true.
+  # The array is changed after the iteration is over,
+  # not every time the block is called.
+  #
+  # ```
+  # a = ["a", "b", "b", "c"]
+  # a.delete_if { |x| x == "b" } #=> true
+  # a                            #=> ["a", "c"]
+  # a.delete_if { |x| x == "z" } #=> false
+  # ```
+  #
+  # See also: `#reject!`.
   def delete_if
     i1 = 0
     i2 = 0


### PR DESCRIPTION
Also found some inconsistencies between Ruby and Crystal while documenting these two methods.

On `Array#delete_at` when trying to delete an index out of range, Ruby returns `nil` while Crystal raises `IndexError`.

`Array#delete_if` returns a boolean, while Ruby implementation returns `self`. Also, in Ruby the array is changed instantly every time the block is called, in Crystal it changes after the iteration is over.

Ruby:

```ruby
a = ["a", "b", "c"]
a.delete_if { |x| puts a.to_s; x == "b" }
# ["a", "b", "c"]
# ["a", "b", "c"]
# ["a", "c"]
```

Crystal:

```crystal
a = ["a", "b", "c"]
a.delete_if { |x| puts a.to_s; x == "b" }
# ["a", "b", "c"]
# ["a", "b", "c"]
# ["a", "b", "c"]
```

Are these desired behaviours, or should it be changed? If these are desired, should we document these differences, and where?

Thanks! And keep up the great work!