### PR TITLE
Implement deferred signal handling using libevent.

### DIFF
--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -5,4 +5,24 @@ describe "Signal" do
   typeof(Signal::PIPE.reset)
   typeof(Signal::PIPE.ignore)
   typeof(Signal::PIPE.trap { 1 })
+
+  it "runs a signal handler" do
+    ran = false
+    Signal::USR1.trap do
+      ran = true
+    end
+    Process.kill Signal::USR1, Process.pid
+    10.times do |i|
+      break if ran
+      sleep 0.1
+    end
+    ran.should be_true
+  end
+
+  it "ignores a signal" do
+    Signal::USR2.ignore
+    Process.kill Signal::USR2, Process.pid
+  end
+
+# TODO: test Signal::X.reset
 end

--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -67,6 +67,18 @@ class Scheduler
     event
   end
 
+  def self.create_signal_event signal : Signal, chan
+    flags = LibEvent2::EventFlags::Signal | LibEvent2::EventFlags::Persist
+    event = @@eb.new_event(Int32.cast(signal.to_i), flags, chan) do |s, flags, data|
+      ch = data as BufferedChannel(Signal)
+      sig = Signal.new(s)
+      ch.send sig
+      nil
+    end
+    event.add
+    event
+  end
+
   def self.yield
     @@runnables.unshift Fiber.current
     reschedule

--- a/src/event/signal_handler.cr
+++ b/src/event/signal_handler.cr
@@ -1,0 +1,73 @@
+# :nodoc:
+# Singleton that runs Signal events (libevent2) in it's own Fiber.
+class Event::SignalHandler
+  def self.add_handler *args
+    instance.add_handler *args
+  end
+
+  def self.del_handler signal
+    inst = @@instance
+    if inst
+      inst.del_handler signal
+    end
+  end
+
+  def self.instance
+    @@instance ||= begin
+      inst = new
+      spawn { inst.run }
+      inst
+    end
+  end
+
+  # finish processing signals
+  def self.close
+    @@instance.try &.close
+    @@instance = nil
+  end
+
+  record CallbackEvent, callback, event
+
+  def initialize
+    @channel = Channel(Signal).new(32)
+    @callbacks = Hash(Signal, CallbackEvent).new
+  end
+
+  # :nodoc:
+  def run
+    while sig = @channel.receive
+      handle_signal sig
+    end
+  end
+
+  def close
+     @channel.close
+  end
+
+  def add_handler signal : Signal, callback
+    event = Scheduler.create_signal_event signal, @channel
+    @callbacks[signal] = CallbackEvent.new callback, event
+  end
+
+  def del_handler signal : Signal
+    if cbe = @callbacks[signal]?
+      cbe.event.free
+      @callbacks.delete signal
+    end
+  end
+
+  private def handle_signal sig
+    if cbe = @callbacks[sig]?
+      cbe.callback.call sig
+    else
+      raise "missing #{sig} callback"
+    end
+  rescue ex
+    ex.inspect STDERR
+    STDERR.puts "FATAL ERROR: uncaught signal exception, exiting"
+    STDERR.flush
+    LibC._exit 1
+  end
+end
+
+

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -130,6 +130,7 @@ def abort(message, status = 1)
 end
 
 Signal::PIPE.ignore
+at_exit { Event::SignalHandler.close }
 
 # Background loop to cleanup unused fiber stacks
 spawn do
@@ -138,3 +139,4 @@ spawn do
     Fiber.stack_pool_collect
   end
 end
+


### PR DESCRIPTION
Very few system calls can run inside of a signal handler (not even malloc).
Signals are now processed through the event loop and run in a single fiber.
Any system/library call can be used with deferred signals.