### PR TITLE
Make anchors in docs conformant to HTML5

### DIFF
--- a/src/compiler/crystal/tools/doc/html/method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/method_detail.html
@@ -2,7 +2,7 @@
   <h2><%= title %></h2>
   <% methods.each do |method| %>
     <div class="entry-detail">
-      <div class="signature" id="<%= method.id %>">
+      <div class="signature" id="<%= method.html_id %>">
         <%= method.abstract? ? "abstract " : "" %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
       </div>

--- a/src/compiler/crystal/tools/doc/html/method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/method_detail.html
@@ -2,7 +2,7 @@
   <h2><%= title %></h2>
   <% methods.each do |method| %>
     <div class="entry-detail">
-      <div class="signature" id="<%= method.anchor %>">
+      <div class="signature" id="<%= method.id %>">
         <%= method.abstract? ? "abstract " : "" %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
       </div>

--- a/src/compiler/crystal/tools/doc/html/method_summary.html
+++ b/src/compiler/crystal/tools/doc/html/method_summary.html
@@ -3,7 +3,7 @@
   <ul>
     <% methods.each do |method| %>
       <li class="entry-summary">
-        <a href="#<%= method.anchor %>" class="signature"><strong><%= method.prefix %><%= method.name %></strong><%= method.args_to_s %></a>
+        <a href="<%= method.anchor %>" class="signature"><strong><%= method.prefix %><%= method.name %></strong><%= method.args_to_s %></a>
         <% if summary = method.formatted_summary %>
           <div class="summary"><%= summary %></div>
         <% end %>

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -25,11 +25,15 @@ class Crystal::Doc::Macro
     @generator.source_link(@macro)
   end
 
-  def anchor
+  def id
     String.build do |io|
-      CGI.escape(to_s, io)
+      io << to_s.gsub(' ', "")
       io << "-macro"
     end
+  end
+
+  def anchor
+    "#" + CGI.escape(id)
   end
 
   def prefix

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -1,3 +1,4 @@
+require "html"
 require "./item"
 
 class Crystal::Doc::Macro
@@ -30,6 +31,10 @@ class Crystal::Doc::Macro
       io << to_s.gsub(' ', "")
       io << "-macro"
     end
+  end
+
+  def html_id
+    HTML.escape(id)
   end
 
   def anchor

--- a/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown_doc_renderer.cr
@@ -165,7 +165,7 @@ class Crystal::Doc::MarkdownDocRenderer < Markdown::HTMLRenderer
   end
 
   def method_link(method, text)
-    %(<a href="#{method.type.path_from(@type)}##{method.anchor}">#{text}</a>)
+    %(<a href="#{method.type.path_from(@type)}{method.anchor}">#{text}</a>)
   end
 
   def lookup_method(type, name, args)

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -42,15 +42,19 @@ class Crystal::Doc::Method
     @class_method ? "def self." : "def "
   end
 
-  def anchor
+  def id
     String.build do |io|
-      CGI.escape(to_s, io)
+      io << to_s.gsub(' ', "")
       if @class_method
         io << "-class-method"
       else
         io << "-instance-method"
       end
     end
+  end
+
+  def anchor
+    "#" + CGI.escape(id)
   end
 
   def to_s(io)

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -1,3 +1,4 @@
+require "html"
 require "./item"
 
 class Crystal::Doc::Method
@@ -51,6 +52,10 @@ class Crystal::Doc::Method
         io << "-instance-method"
       end
     end
+  end
+
+  def html_id
+    HTML.escape(id)
   end
 
   def anchor


### PR DESCRIPTION
One of the two options to fix ["Links from summary to detail don't work in API docs."](https://github.com/manastech/crystal/issues/1272)

I wanted to get some discussion on this first, but it's dead quiet, so here are the pull requests.

See commit message for details.