### PR TITLE
Make anchors in docs conformant to HTML4

### DIFF
--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -1,4 +1,5 @@
 require "./item"
+require "crypto/md5"
 
 class Crystal::Doc::Macro
   include Item
@@ -27,8 +28,10 @@ class Crystal::Doc::Macro
 
   def anchor
     String.build do |io|
-      CGI.escape(to_s, io)
-      io << "-macro"
+      name = self.name.chars.select { |c| c.alphanumeric? || c == '_' } .join
+      io << name << '-' unless name.empty?
+      io << "macro"
+      io << '-' << Crypto::MD5.hex_digest(to_s)
     end
   end
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -1,4 +1,5 @@
 require "./item"
+require "crypto/md5"
 
 class Crystal::Doc::Method
   include Item
@@ -44,12 +45,14 @@ class Crystal::Doc::Method
 
   def anchor
     String.build do |io|
-      CGI.escape(to_s, io)
+      name = self.name.chars.select { |c| c.alphanumeric? || c == '_' } .join
+      io << name << '-' unless name.empty?
       if @class_method
-        io << "-class-method"
+        io << "class-method"
       else
-        io << "-instance-method"
+        io << "instance-method"
       end
+      io << '-' << Crypto::MD5.hex_digest(to_s)
     end
   end
 


### PR DESCRIPTION
One of the two options to fix ["Links from summary to detail don't work in API docs."](https://github.com/manastech/crystal/issues/1272)

I wanted to get some discussion on this first, but it's dead quiet, so here are the pull requests.

See commit message for details.