### PR TITLE
Waitpid enhancements:

### DIFF
--- a/src/event/signal_child_handler.cr
+++ b/src/event/signal_child_handler.cr
@@ -1,0 +1,51 @@
+# :nodoc:
+# Singleton that handles SIG_CHLD and queues events for Process#waitpid.
+# Process.waitpid uses this class for nonblocking operation.
+class Event::SignalChildHandler
+  def self.instance
+    @@instance ||= new
+  end
+
+  alias ChanType = BufferedChannel(Process::Status?)
+
+  def initialize
+    @pending = Hash(LibC::PidT, Process::Status).new
+    @waiting = Hash(LibC::PidT, ChanType).new
+  end
+
+  def after_fork
+    @pending.clear
+    @waiting.each { |pid, chan| chan.send(nil) }
+    @waiting.clear
+  end
+
+  def trigger
+    while (pid = LibC.waitpid(-1, out exit_code, LibC::WNOHANG)) != -1
+      status = Process::Status.new exit_code
+      send_pending pid, status
+    end
+  end
+
+  private def send_pending pid, status
+# BUG: needs mutexes with threads
+    if chan = @waiting[pid]?
+      chan.send status
+      @waiting.delete pid
+    else
+      @pending[pid] = status
+    end
+  end
+
+  # returns a channel that sends a Process::Status
+  def waitpid pid : LibC::PidT
+    chan = ChanType.new(1)
+# BUG: needs mutexes with threads
+    if status = @pending[pid]?
+      chan.send status
+      @pending.delete pid
+    else
+      @waiting[pid] = chan
+    end
+    chan
+  end
+end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -140,7 +140,16 @@ def abort(message, status = 1)
   exit status
 end
 
+class Process
+  # hooks defined here due to load order problems
+  scheduler_after_cb = -> { Scheduler.after_fork; nil }
+  signal_after_cb = -> { Event::SignalHandler.after_fork; nil }
+  signal_child_after_cb = -> { Event::SignalChildHandler.instance.after_fork; nil }
+  @@after_fork_child_callbacks = [scheduler_after_cb, signal_after_cb, signal_child_after_cb]
+end
+
 Signal::PIPE.ignore
+Signal::CHLD.reset
 at_exit { Event::SignalHandler.close }
 
 # Background loop to cleanup unused fiber stacks

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -100,7 +100,7 @@ class Process
       end
     end
 
-    @pid = fork do
+    @pid = Process.fork(run_hooks: false) do
       begin
         # File.umask(umask) if umask
 
@@ -147,8 +147,7 @@ class Process
       raise ex if ex
     end
 
-    exit_code = Process.waitpid(@pid)
-    Status.new(exit_code)
+    Process.waitpid(@pid)
   ensure
     close
   end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -1,5 +1,6 @@
 lib LibC
   alias SigT = Int32 ->
+
   fun signal(sig : Int, handler : SigT) : SigT
 end
 
@@ -92,7 +93,16 @@ enum Signal
   end
 
   def reset
-    del_handler Proc(Int32, Void).new(Pointer(Void).new(0_u64), Pointer(Void).null)
+    case self
+    when CHLD
+      # don't ignore by default.  send events to a waitpid service
+      trap do
+        Event::SignalChildHandler.instance.trigger
+        nil
+      end
+    else
+      del_handler Proc(Int32, Void).new(Pointer(Void).new(0_u64), Pointer(Void).null)
+    end
   end
 
   def ignore
@@ -104,3 +114,4 @@ enum Signal
     LibC.signal value, block
   end
 end
+


### PR DESCRIPTION
  Nonblocking.
  Process#waitpid returns a Process::Status.

Deferred signals bugfixes:
  Works with fork.
  Up to 5 second delays are gone.
  Switched away from libevent signal handling (buggy).
  Now uses self pipe.
  Foundation set for enhanced signal status.

Other:
  Ensure fork { } always _exits.