### PR TITLE
Travis: define inclusion rules instead of exclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ os:
 sudo: required
 services:
   - docker
-env:
-  - ARCH=i386 ARCH_CMD=linux32
-  - ARCH=x86_64 ARCH_CMD=linux64
+matrix:
+  include:
+    - env: ARCH=i386 ARCH_CMD=linux32
+      os: linux
+    - env: ARCH=x86_64 ARCH_CMD=linux64
+      os: linux
+    - os: osx
 before_install: |
   case $TRAVIS_OS_NAME in
     linux)
@@ -55,7 +59,3 @@ notifications:
       - "%{repository_slug}#%{commit} (%{branch} - %{commit_subject}): %{message} %{build_url}"
   slack:
     secure: Ng3nTqGWY+9p1pS6yjGqDhmRvdgbIZgTNpMWbO/ngwpCyicmD3jafZkShqqXbULZTJJr3OxIGzi6GHGusT0Ic/Pi9JCM3X3v/xuBruKIR+EnNyPo7IL4ZYAlwnXyJHlCHHDBq0gSHGvGJwsXn6IgZBPRfeIq+CCyQHVPyvc9EHE=
-matrix:
-  exclude:
-    - os: osx
-      env: ARCH=i386 ARCH_CMD=linux32

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: c
-os:
-  - linux
-  - osx
 sudo: required
 services:
   - docker


### PR DESCRIPTION
Crystal is being tested against Travis CI on both Linux and OSX
platforms.

When having multiple platforms defined in the Travis configuration
file (`.travis.yml`), any environment variable used will be
applied equally to each OS.

To reduce bogus failures or repeated builds, Travis give you options
of both inclusion and exclusion rules to consider for the test matrix.

Before this commit, an exclusion rule was applied so environment
variables used for both Linux 32 and 64 builds do not result in
duplicated builds on OSX.

This commit changes that from exclusion to an explicit matrix that
ensures no environment variable from Linux is leaked into the OSX
build, also avoiding the need to exclude the duplicate build.

While this change is simply cosmetic, it ensures clarity is taken
in consideration when quickly looking at CI results. (eg. Why it
says Linux64 for the OSX build?).

Thank you. :heart: :heart: :heart: 