### PR TITLE
Fix #1253 and disallow illegal bodies on HTTP Response

### DIFF
--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -11,7 +11,7 @@ module HTTP
       response.headers["content-type"].should eq("text/plain")
       response.headers["content-length"].should eq("5")
       response.body?.should be_true
-      response.body.read.should eq("hello")
+      response.body.should eq("hello")
     end
 
     it "parses response with body without \\r" do
@@ -22,7 +22,7 @@ module HTTP
       response.headers["content-type"].should eq("text/plain")
       response.headers["content-length"].should eq("5")
       response.body?.should be_true
-      response.body.read.should eq("hello")
+      response.body.should eq("hello")
     end
 
     it "parses response with empty body" do
@@ -31,7 +31,7 @@ module HTTP
       response.status_message.should eq("Not Found")
       response.headers["content-length"].should eq("0")
       response.body?.should be_true
-      response.body.read.should eq("")
+      response.body.should eq("")
     end
 
     it "parses response without body" do
@@ -40,7 +40,7 @@ module HTTP
       response.status_message.should eq("Continue")
       response.headers.length.should eq(0)
       response.body?.should be_false
-      response.body.read.should eq("")
+      response.body.should eq("")
     end
 
     it "parses response with body but without Content-length" do
@@ -50,7 +50,7 @@ module HTTP
       response.status_message.should eq("OK")
       response.headers.length.should eq(0)
       response.body?.should be_true
-      response.body.read.should eq("helloworld")
+      response.body.should eq("helloworld")
     end
 
     it "parses response with duplicated headers" do
@@ -60,7 +60,7 @@ module HTTP
 
     it "parses response with chunked body" do
       response = Response.from_io(io = StringIO.new("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nabcde\r\na\r\n0123456789\r\n0\r\n"))
-      response.body.read.should eq("abcde0123456789")
+      response.body.should eq("abcde0123456789")
       io.gets.should be_nil
     end
 
@@ -102,6 +102,13 @@ module HTTP
         end
       end
       errors.should eq(4)
+    end
+    
+    it "allows reading the body as an IO" do
+      response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloworld"))
+      response.body?.should be_true
+      response.body_io.read(3).should eq("hel")
+      response.body_io.read.should eq("lo")
     end
 
     it "builds default not found" do

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -93,15 +93,11 @@ module HTTP
     end
 
     it "raises when creating 1xx, 204 or 304 with body" do
-      errors = 0
       [100, 101, 204, 304].each do |status|
-        begin
+        expect_raises ArgumentError do
           Response.new(status, "hello")
-        rescue ArgumentError
-          errors += 1
         end
       end
-      errors.should eq(4)
     end
     
     it "allows reading the body as an IO" do
@@ -112,15 +108,11 @@ module HTTP
     end
     
     it "raises when trying to fetch the body after an IO read" do
-      error = nil
-      begin
-        response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloworld"))
-        response.body_io.read(3)
+      response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloworld"))
+      response.body_io.read(3)
+      expect_raises ArgumentError do
         response.body
-      rescue ex
-        error = ex
       end
-      error.should be_a(ArgumentError)
     end
 
     it "builds default not found" do

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -43,6 +43,16 @@ module HTTP
       response.body.read.should eq("")
     end
 
+    it "parses response with body but without Content-length" do
+      response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\n\r\nhelloworld"))
+      response.version.should eq("HTTP/1.1")
+      response.status_code.should eq(200)
+      response.status_message.should eq("OK")
+      response.headers.length.should eq(0)
+      response.body?.should be_true
+      response.body.read.should eq("helloworld")
+    end
+
     it "parses response with duplicated headers" do
       response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nSet-Cookie: a=b\r\nSet-Cookie: c=d\r\n\r\nhelloworld"))
       response.headers.get("Set-Cookie").should eq(["a=b", "c=d"])

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -110,6 +110,18 @@ module HTTP
       response.body_io.read(3).should eq("hel")
       response.body_io.read.should eq("lo")
     end
+    
+    it "raises when trying to fetch the body after an IO read" do
+      error = nil
+      begin
+        response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloworld"))
+        response.body_io.read(3)
+        response.body
+      rescue ex
+        error = ex
+      end
+      error.should be_a(ArgumentError)
+    end
 
     it "builds default not found" do
       response = Response.not_found

--- a/spec/std/io/buffered_io_spec.cr
+++ b/spec/std/io/buffered_io_spec.cr
@@ -53,9 +53,13 @@ end
 describe "BufferedIO" do
   it "does gets" do
     io = BufferedIOWrapper.new(StringIO.new("hello\nworld\n"))
+    io.eof?.should be_false
     io.gets.should eq("hello\n")
+    io.eof?.should be_false
     io.gets.should eq("world\n")
+    io.eof?.should be_true
     io.gets.should be_nil
+    io.eof?.should be_true
   end
 
   it "does gets with big line" do

--- a/spec/std/io/string_io_spec.cr
+++ b/spec/std/io/string_io_spec.cr
@@ -4,14 +4,18 @@ describe "StringIO" do
   it "writes" do
     io = StringIO.new
     io.write Slice.new("hello".cstr, 3)
+    io.eof?.should be_false
     io.read.should eq("hel")
+    io.eof?.should be_true
   end
 
   it "writes big" do
     s = "hi" * 100
     io = StringIO.new
     io.write Slice.new(s.cstr, s.bytesize)
+    io.eof?.should be_false
     io.read.should eq(s)
+    io.eof?.should be_true
   end
 
   it "appends to another buffer" do
@@ -30,9 +34,13 @@ describe "StringIO" do
 
   it "reads each line" do
     io = StringIO.new("foo\r\nbar\r\n")
+    io.eof?.should be_false
     io.gets.should eq("foo\r\n")
+    io.eof?.should be_false
     io.gets.should eq("bar\r\n")
+    io.eof?.should be_true
     io.gets.should eq(nil)
+    io.eof?.should be_true
   end
 
   it "gets with char as delimiter" do

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -71,6 +71,13 @@ module HTTP
   end
 
   def self.serialize_headers_and_body(io, headers, body)
+    if body
+      headers ||= Headers.new
+      unless headers.has_key?("Content-length")
+        body = body.read unless body.is_a? String
+        headers["Content-length"] = body.size.to_s
+      end
+    end
     if headers
       headers.each do |name, values|
         values.each do |value|

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -9,6 +9,8 @@ module HTTP
           body = FixedLengthContent.new(io, content_length.to_i)
         elsif headers["Transfer-encoding"]? == "chunked"
           body = ChunkedContent.new(io)
+        elsif !io.eof?
+          body = UntilEofContent.new(io)
         end
 
         yield headers, body

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -60,6 +60,21 @@ module HTTP
     end
   end
   
+  class UntilEofContent < Content
+    include IO
+
+    def initialize(@io)
+    end
+    
+    def read(slice : Slice(UInt8), count)
+      @io.read(slice, count)
+    end
+    
+    def write(slice : Slice(UInt8), count)
+      raise IO::Error.new "Can't write to UntilEofContent"
+    end
+  end
+  
   class EmptyContent < Content
     include IO
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -59,4 +59,22 @@ module HTTP
       raise IO::Error.new "Can't write to ChunkedContent"
     end
   end
+  
+  class EmptyContent < Content
+    include IO
+
+    def initialize
+    end
+    
+    def read(slice : Slice(UInt8), count)
+      0
+    end
+    
+    def write(slice : Slice(UInt8), count)
+      raise IO::Error.new "Can't write to EmptyContent"
+    end
+    
+    def close
+    end
+  end
 end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -1,5 +1,11 @@
 module HTTP
   abstract class Content
+    getter pos
+    
+    def initialize
+      @pos = 0
+    end
+    
     def close
       buffer :: UInt8[1024]
       while read(buffer.to_slice) > 0
@@ -11,6 +17,7 @@ module HTTP
     include IO
 
     def initialize(@io, length)
+      super()
       @remaining = length
     end
 
@@ -18,6 +25,7 @@ module HTTP
       count = Math.min(count, @remaining)
       bytes_read = @io.read(slice, count)
       @remaining -= bytes_read
+      @pos += bytes_read
       bytes_read
     end
 
@@ -30,6 +38,7 @@ module HTTP
     include IO
 
     def initialize(@io)
+      super()
       @chunk_remaining = io.gets.not_nil!.to_i(16)
     end
 
@@ -52,6 +61,7 @@ module HTTP
           end
         end
       end
+      @pos += total_read
       total_read
     end
 
@@ -64,10 +74,13 @@ module HTTP
     include IO
 
     def initialize(@io)
+      super()
     end
     
     def read(slice : Slice(UInt8), count)
-      @io.read(slice, count)
+      bytes_read = @io.read(slice, count)
+      @pos += bytes_read
+      bytes_read
     end
     
     def write(slice : Slice(UInt8), count)
@@ -77,9 +90,6 @@ module HTTP
   
   class EmptyContent < Content
     include IO
-
-    def initialize
-    end
     
     def read(slice : Slice(UInt8), count)
       0

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -39,6 +39,9 @@ class HTTP::Response
   end
   
   def body
+    if body_io.pos != 0
+      raise ArgumentError.new("cannot use #body after a read on #body_io")
+    end
     body_io.read
   end
 

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -27,19 +27,23 @@ class HTTP::Response
     end
 
     if body.is_a? String
-      @body = StringIO.new(body)
+      @body_io = StringIO.new(body)
       @headers["Content-length"] = body.bytesize.to_s
     else
-      @body = body
+      @body_io = body
     end
   end
 
+  def body_io
+    @body_io || EmptyContent.new
+  end
+  
   def body
-    @body || EmptyContent.new
+    body_io.read
   end
 
   def body?
-    !!@body
+    !!@body_io
   end
 
   def keep_alive?
@@ -64,7 +68,7 @@ class HTTP::Response
 
   def to_io(io)
     io << @version << " " << @status_code << " " << @status_message << "\r\n"
-    HTTP.serialize_headers_and_body(io, @headers, @body)
+    HTTP.serialize_headers_and_body(io, @headers, @body_io)
   end
   
   def self.from_io(io)

--- a/src/io/buffered_io.cr
+++ b/src/io/buffered_io.cr
@@ -119,6 +119,11 @@ module BufferedIO
       b
     end
   end
+  
+  def eof?
+    fill_buffer if @in_buffer_rem.empty?
+    @in_buffer_rem.empty?
+  end
 
   private def read_char_with_bytesize
     return super unless @in_buffer_rem.length >= 4

--- a/src/io/string_io.cr
+++ b/src/io/string_io.cr
@@ -3,6 +3,7 @@ class StringIO
 
   getter buffer
   getter bytesize
+  getter pos
 
   def initialize(capacity = 64)
     @buffer = GC.malloc_atomic(capacity.to_u32) as UInt8*

--- a/src/io/string_io.cr
+++ b/src/io/string_io.cr
@@ -83,6 +83,10 @@ class StringIO
   def empty?
     @bytesize == 0
   end
+  
+  def eof?
+    @pos == @bytesize
+  end
 
   def rewind
     @pos = 0

--- a/src/oauth/consumer.cr
+++ b/src/oauth/consumer.cr
@@ -12,7 +12,7 @@ class OAuth::Consumer
     with_new_http_client(nil, nil, {"oauth_callback": oauth_callback}) do |client|
       response = client.post @request_token_uri
       handle_response(response) do
-        RequestToken.from_response(response.body)
+        RequestToken.from_response(response.body.read)
       end
     end
   end
@@ -34,7 +34,7 @@ class OAuth::Consumer
     with_new_http_client(request_token.token, request_token.secret, extra_params) do |client|
       response = client.post @access_token_uri
       handle_response(response) do
-        AccessToken.from_response(response.body)
+        AccessToken.from_response(response.body.read)
       end
     end
   end

--- a/src/oauth/consumer.cr
+++ b/src/oauth/consumer.cr
@@ -12,7 +12,7 @@ class OAuth::Consumer
     with_new_http_client(nil, nil, {"oauth_callback": oauth_callback}) do |client|
       response = client.post @request_token_uri
       handle_response(response) do
-        RequestToken.from_response(response.body.read)
+        RequestToken.from_response(response.body)
       end
     end
   end
@@ -34,7 +34,7 @@ class OAuth::Consumer
     with_new_http_client(request_token.token, request_token.secret, extra_params) do |client|
       response = client.post @access_token_uri
       handle_response(response) do
-        AccessToken.from_response(response.body.read)
+        AccessToken.from_response(response.body)
       end
     end
   end

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -36,7 +36,8 @@ lib LibSSL
 
   @[Raises]
   fun ssl_shutdown = SSL_shutdown(handle : SSL) : Int
-
+  
+  fun ssl_get_shutdown = SSL_get_shutdown(handle : SSL) : Int
   fun ssl_free = SSL_free(handle : SSL)
   fun ssl_ctx_use_certificate_chain_file = SSL_CTX_use_certificate_chain_file(ctx : SSLContext, file : UInt8*) : Int
   fun ssl_ctx_use_privatekey_file = SSL_CTX_use_PrivateKey_file(ctx : SSLContext, file : UInt8*, filetype : SSLFileType) : Int

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -32,6 +32,14 @@ class OpenSSL::SSL::Socket
     rescue IO::Error
     end
   end
+  
+  def closed?
+    LibSSL.ssl_get_shutdown(@ssl) != 0
+  end
+  
+  def eof?
+    closed?
+  end
 
   def self.open_client(io, context = Context.default)
     ssl_sock = new(io, :client, context)


### PR DESCRIPTION
As per [HTTP Spec, Section 7.2](http://www.w3.org/Protocols/HTTP/1.0/draft-ietf-http-spec.html#Entity-Body):

> For response messages, whether or not an entity body is included with a message is dependent on both the request method and the response code. All responses to the HEAD request method must not include a body, even though the presence of entity header fields may lead one to believe they do. All 1xx (informational), 204 (no content), and 304 (not modified) responses must not include a body. All other responses must include an entity body or a Content-Length header field defined with a value of zero (0).

Ensuring that a response to a HEAD request has no body is still user's responsibility.
The fix for #1253 is the last sentence.