### PR TITLE
Fix Bcrypt Int32 overflow

### DIFF
--- a/spec/std/crypto/bcrypt_spec.cr
+++ b/spec/std/crypto/bcrypt_spec.cr
@@ -8,9 +8,9 @@ describe "Bcrypt" do
     end
   end
 
-  it "raises if cost is to high" do 
+  it "raises if cost is to high" do
     expect_raises ArgumentError, /Invalid cost size/ do
-      Crypto::Bcrypt.digest("secret", 32)
+      Crypto::Bcrypt.digest("secret", 64)
     end
   end
 

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -103,7 +103,7 @@ module Crypto::Bcrypt
     bf = Blowfish.new
     bf.salted_expand_key(sl, key)
 
-    1.upto(1 << cost.to_i) do |i|
+    1.upto(1_u32 << cost.to_i) do |i|
       bf.expand_key(key)
       bf.expand_key(salt)
     end

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -7,7 +7,7 @@ module Crypto::Bcrypt
   extend self
 
   MIN_COST = 4
-  MAX_COST = 31
+  MAX_COST = 63
   DEFAULT_COST = 10
   ENCODED_SALT_SIZE = 22
   MIN_HASH_SIZE = 59
@@ -103,7 +103,7 @@ module Crypto::Bcrypt
     bf = Blowfish.new
     bf.salted_expand_key(sl, key)
 
-    1.upto(1_u32 << cost.to_i) do |i|
+    1.upto(1_u64 << cost.to_i) do |i|
       bf.expand_key(key)
       bf.expand_key(salt)
     end


### PR DESCRIPTION
While reading through the `Bcrypt` implementation, I found a serious security issue: [This line](https://github.com/manastech/crystal/blob/8c28ea85011a8d24aee30e8e196194149919e820/src/crypto/bcrypt.cr#L106) performs a left shift on `1` to exponentially increase the number of times the password and salt are expanded (according to the cost). However, when the cost is `31` (`1 << 31 == 2147483648`), unsigned `Int32` overflows, resulting in `-2147483648`. This results in zero key expansions when there should be over 2 billion. Hashing the key this many times should take days, if not weeks; instead, it takes less than a second. Users who think they’re setting the maximum cost, and therefore the highest resilience to a brute-force attack, are actually getting the minimum, even lower than `MIN_COST`.

I couldn’t think of a good way to write a regression test this without it taking days. I’m happy to add specs if you can suggest how they should be written. The `bcrypt-ruby` library implements a `calibrate` method, used to verify that `cost` behaves as expected, but even if Crystal had implemented [their specs](https://github.com/codahale/bcrypt-ruby/blob/1f9184a8df2b90fa02d01a32a364eefc9072e1b9/spec/bcrypt/engine_spec.rb#L4-L8), it wouldn’t have caught this overflow.

I could not find Crystal’s policy for privately disclosing security, so I am disclosing it publicly. That means it is now a zero-day vulnerability for anyone using Bcrypt with cost set to `MAX_COST`. Hopefully, the set of affected users is zero, but since it’s impossible to know, I would suggest merging and shipping a patch release (0.7.7) as soon as possible and making an announcement on the blog and mailing list. I’d be happy to help write or review the announcement.

Here are a couple examples of responsible disclosure policies that other projects/companies use:
* [Ruby on Rails](http://rubyonrails.org/security/)
* [SoundCloud](http://help.soundcloud.com/customer/portal/articles/439715-responsible-disclosure)