### PR TITLE
Remove lib specific content from README generated by crystal init app

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -61,8 +61,26 @@ deps do
 end
 ```})
 
+      readme.should contain(%{TODO: Write a description here})
+      readme.should_not contain(%{TODO: Write installation instructions here})
       readme.should contain(%{require "example"})
       readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example/fork )})
+      readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
+    end
+
+    describe_file "example_app/README.md" do |readme|
+      readme.should contain("# example")
+
+      readme.should_not contain(%{```crystal
+deps do
+  github "[your-github-name]/example"
+end
+```})
+
+      readme.should contain(%{TODO: Write a description here})
+      readme.should contain(%{TODO: Write installation instructions here})
+      readme.should_not contain(%{require "example"})
+      readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example_app/fork )})
       readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
     end
 

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -1,28 +1,34 @@
 # <%= config.name %>
 
-TODO: Write a description here for library
+TODO: Write a description here
 
 ## Installation
 
-Add it to `Projectfile`
+<% if config.skeleton_type == "lib" %>
+Add this line to your application's `Projectfile`:
 
 ```crystal
 deps do
   github "[your-github-name]/<%= config.name %>"
 end
 ```
+<% else %>
+TODO: Write installation instructions here
+<% end %>
 
 ## Usage
 
+<% if config.skeleton_type == "lib" %>
 ```crystal
 require "<%= config.name %>"
 ```
+<% end %>
 
-TODO: Write usage here for library
+TODO: Write usage instructions here
 
 ## Development
 
-TODO: Write instructions for development
+TODO: Write development instructions here
 
 ## Contributing
 


### PR DESCRIPTION
This PR removes lib specific details from the app skeleton generated by `crystal init app <NAME>`.

I'm not totally convinced by the need for the `should_not` specs since they will still pass if something similar still appears in the generated app/lib skeleton. But since they already existed I included them also.

The wording in the README TODO's has also been consistent, following the pattern `TODO: write X here`.