### PR TITLE
Fix typo

### DIFF
--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -11,7 +11,7 @@
 #     require "bit_array"
 #     ba = BitArray.new(12) # => "BitArray[000000000000]"
 #     ba[2]                 # => false
-#     0.upto(5) { |i| a[i*2] = true }
+#     0.upto(5) { |i| ba[i*2] = true }
 #     ba                    # => "BitArray[101010101010]"
 #     ba[2]                 # => true
 struct BitArray


### PR DESCRIPTION
Fix typo in sample code.

## Before
### Code
```ruby
0.upto(5) { |i| a[i*2] = true }
```

### Check in Playground
http://play.crystal-lang.org/#/r/d5t

`Error in line 4: undefined local variable or method 'a' (did you mean 'ba'?)`

## After
### Code
```ruby
0.upto(5) { |i| ba[i*2] = true }
```

### Check in Playground
http://play.crystal-lang.org/#/r/d5s
