### PR TITLE
Add overload of `sleep` that accepts `TimeSpan`

### DIFF
--- a/src/concurrent/concurrent.cr
+++ b/src/concurrent/concurrent.cr
@@ -1,12 +1,16 @@
 require "fiber"
 require "./*"
 
-def sleep(seconds : Int | Float)
+def sleep(seconds : Number)
   if seconds < 0
     raise ArgumentError.new "sleep seconds must be positive"
   end
 
   Scheduler.sleep(seconds)
+end
+
+def sleep(time : TimeSpan)
+  sleep(time.total_seconds)
 end
 
 macro spawn


### PR DESCRIPTION
I noticed that there seem to be no specs for `sleep`. So no tests for this one either.
But I did check that this works.

By the way, this allows things like:
```crystal
sleep(5.minutes + 20.seconds)
```