### PR TITLE
Docs: group inherited methods and add detailed tooltips

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -242,6 +242,7 @@ h1.type-name {
 }
 
 .method-inherited {
+  display: inline-block;
   text-decoration: none;
   color: #47266E;
 }
@@ -249,6 +250,14 @@ h1.type-name {
 .method-inherited a:hover {
   text-decoration: underline;
   color: #6C518B;
+}
+
+.method-inherited.tooltip span {
+  background: #D5CAE3;
+  color: #47266E;
+  padding: 4px 8px;
+  border-radius: 3px;
+  margin: -4px -8px;
 }
 
 pre {
@@ -264,6 +273,18 @@ pre {
 
 code {
   font-family: Consolas, 'Courier New', Courier, Monaco, monospace;
+}
+
+.tooltip span {
+  position: absolute;
+  opacity: 0;
+  display: none;
+  pointer-events: none;
+}
+
+.tooltip:hover span {
+  display: inline-block;
+  opacity: 1;
 }
 
 .c {

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -238,21 +238,26 @@ h1.type-name {
 }
 
 .methods-inherited {
+  padding-right: 10%;
+  line-height: 1.5em;
+}
+
+.methods-inherited h3 {
   margin-bottom: 4px;
 }
 
-.method-inherited {
+.methods-inherited a {
   display: inline-block;
   text-decoration: none;
   color: #47266E;
 }
 
-.method-inherited a:hover {
+.methods-inherited a:hover {
   text-decoration: underline;
   color: #6C518B;
 }
 
-.method-inherited.tooltip span {
+.methods-inherited .tooltip span {
   background: #D5CAE3;
   color: #47266E;
   padding: 4px 8px;

--- a/src/compiler/crystal/tools/doc/html/methods_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/methods_inherited.html
@@ -1,7 +1,9 @@
-<% methods = ancestor.instance_methods %>
-<% unless methods.empty? %>
+<% method_groups = ancestor.instance_methods.group_by { |method| method.name } %>
+<% unless method_groups.empty? %>
   <h3 class="methods-inherited">Methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
-  <% methods.each_with_index do |method, i| %>
-    <code><a href="<%= type.path_to(ancestor) %><%= method.anchor %>" class="method-inherited" title="<%= HTML.escape(method.name + method.args_to_s) %>"><%= method.name %></a></code><%= ", " if i != methods.length - 1 %>
+  <% method_groups.each_with_index do |method_name, methods, i| %>
+    <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="method-inherited tooltip">
+      <span><%= methods.map { |method| method.name + method.args_to_s } .join("<br/>") %></span>
+    <%= method_name %></a><%= ", " if i != method_groups.length - 1 %>
   <% end %>
 <% end %>

--- a/src/compiler/crystal/tools/doc/html/methods_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/methods_inherited.html
@@ -1,8 +1,8 @@
 <% method_groups = ancestor.instance_methods.group_by { |method| method.name } %>
 <% unless method_groups.empty? %>
-  <h3 class="methods-inherited">Methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
+  <h3>Methods inherited from <%= ancestor.kind %> <code><a href="<%= type.path_to(ancestor) %>"><%= ancestor.full_name %></a></code></h3>
   <% method_groups.each_with_index do |method_name, methods, i| %>
-    <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="method-inherited tooltip">
+    <a href="<%= type.path_to(ancestor) %><%= methods[0].anchor %>" class="tooltip">
       <span><%= methods.map { |method| method.name + method.args_to_s } .join("<br/>") %></span>
     <%= method_name %></a><%= ", " if i != method_groups.length - 1 %>
   <% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -87,9 +87,11 @@
 <%= MethodSummaryTemplate.new("Instance Method Summary", type.instance_methods) %>
 <%= MethodSummaryTemplate.new("Macro Summary", type.macros) %>
 
-<% type.ancestors.each do |ancestor| %>
-  <%= MethodsInheritedTemplate.new(type, ancestor) %>
-<% end %>
+<div class="methods-inherited">
+  <% type.ancestors.each do |ancestor| %>
+    <%= MethodsInheritedTemplate.new(type, ancestor) %>
+  <% end %>
+</div>
 
 <%= MethodDetailTemplate.new(type.program? ? "Method Detail" : "Class Method Detail", type.class_methods) %>
 <%= MethodDetailTemplate.new("Instance Method Detail", type.instance_methods) %>


### PR DESCRIPTION
Followup to https://github.com/manastech/crystal/commit/e0815e71e297642214b4e4d93837cb9c1588768e

![tooltip](https://cloud.githubusercontent.com/assets/371383/9585685/15f8abfc-5021-11e5-8162-6112428c73bd.png)


Looks quite good, but there is a slight problem when showing a tooltip near the right edge of the browser.