### PR TITLE
Fix the link for Homebrew tap

### DIFF
--- a/_gitbook/installation/on_mac_osx_using_homebrew.md
+++ b/_gitbook/installation/on_mac_osx_using_homebrew.md
@@ -1,6 +1,6 @@
 # On Mac OSX using Homebrew
 
-To easily install Crystall on Mac you can use our [Homebrew](http://brew.sh/) [tap](https://github.com/Homebrew/homebrew/wiki/brew-tap)
+To easily install Crystall on Mac you can use our [Homebrew](http://brew.sh/) [tap](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md)
 
 ```
 brew tap manastech/crystal


### PR DESCRIPTION
The link for Homebrew's tap feature is not correct.

I have changed the link URL because they have removed the wiki and move the documentation into their repository.