### PR TITLE
Fix all cases of "Missing hash value" to "Missing hash key"

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -125,7 +125,7 @@ describe "Hash" do
 
     it "fetches and raises" do
       a = {1 => 2}
-      expect_raises KeyError, "Missing hash value: 2" do
+      expect_raises KeyError, "Missing hash key: 2" do
         a.fetch(2)
       end
     end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -167,7 +167,7 @@ end
 #
 # ```
 # h = {"foo" => "bar"}
-# h["baz"] #=> KeyError: Missing hash value: "baz"
+# h["baz"] #=> KeyError: Missing hash key: "baz"
 # ```
 class KeyError < Exception
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -84,7 +84,7 @@ class Hash(K, V)
       if block = @block
         block.call(self, key)
       else
-        raise KeyError.new "Missing hash value: #{key.inspect}"
+        raise KeyError.new "Missing hash key: #{key.inspect}"
       end
     end
   end

--- a/src/simple_hash.cr
+++ b/src/simple_hash.cr
@@ -8,7 +8,7 @@ struct SimpleHash(K, V)
 
   def [](key)
     fetch(key) do
-      raise KeyError.new "Missing hash value: #{key.inspect}"
+      raise KeyError.new "Missing hash key: #{key.inspect}"
     end
   end
 


### PR DESCRIPTION
Whenever the key is not found in a hash, the error message is "Missing hash value". This is wrong, and missleading. This fixes the issue