### PR TITLE
We can use llvm 3.5 or newer to build crystal

### DIFF
--- a/_gitbook/installation/from_source_repository.md
+++ b/_gitbook/installation/from_source_repository.md
@@ -2,7 +2,7 @@
 
 If you want to contribute then you might want to install Crystal from sources. But Crystal is written in Crystal itself! So you first need to use one of the previous described methods to have a running compiler.
 
-You will also need LLVM 3.5 present in the path. If you are using Mac and the Homebrew formula, this will be automatically configured for you if you install Crystal adding `--with-llvm` flag.
+You will also need LLVM 3.5 or 3.6 present in the path. If you are using Mac and the Homebrew formula, this will be automatically configured for you if you install Crystal adding `--with-llvm` flag.
 
 Then clone the repository:
 


### PR DESCRIPTION
* Related to #1214 

As noticed in https://github.com/manastech/crystal/issues/1214#issuecomment-137002138 newer llvm versions are also good to install crystal (when I installed it I thought it HAD to be 3.5 so that's why I installed 3.5).

Hope that this is accurate :)