### PR TITLE
Rebased iterator docs

### DIFF
--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -235,6 +235,12 @@ module Iterator(T)
     end
   end
 
+  # Calls block for each element of enum repeatedly forever.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # a.cycle { |x| puts x }  # print, a, b, c, a, b, c,.. forever.
+  # ```
   def cycle
     Cycle(typeof(self), T).new(self)
   end
@@ -258,6 +264,12 @@ module Iterator(T)
     end
   end
 
+  # Calls block for each element of enum repeatedly n times.
+  #
+  # ```
+  # a = ["a", "b", "c"]
+  # a.cycle(2) { |x| puts x }  # print, a, b, c, a, b, c.
+  # ```
   def cycle(n : Int)
     CycleN(typeof(self), T, typeof(n)).new(self, n)
   end
@@ -295,6 +307,13 @@ module Iterator(T)
     self
   end
 
+  # Calls the given block once for each element, passing that element
+  # as a parameter.
+  #
+  # ```
+  # a = [ "a", "b", "c" ]
+  # a.each {|x| print x, " " } # => "a b c"
+  # ```
   def each
     while true
       value = self.next
@@ -303,6 +322,14 @@ module Iterator(T)
     end
   end
 
+  # Iterates the given block for each slice of `n` elements.
+  #
+  # ```
+  # (1..9).each_slice(3) { |a| p a }
+  # # => [1, 2, 3]
+  # # => [4, 5, 6]
+  # # => [7, 8, 9]
+  # ```
   def each_slice(n)
     slice(n)
   end
@@ -333,6 +360,12 @@ module Iterator(T)
     end
   end
 
+  # Returns a new array with the results of running block once for
+  # every element in enum.
+  #
+  # ```
+  # [1, 2, 3].map &.*(2) # => [2, 4, 6]
+  # ```
   def map(&func : T -> U)
     Map(typeof(self), T, U).new(self, func)
   end
@@ -351,6 +384,8 @@ module Iterator(T)
     end
   end
 
+  # Returns an array for all elements of enum for which the given
+  # block returns false.
   def reject(&func : T -> U)
     Reject(typeof(self), T, U).new(self, func)
   end
@@ -373,6 +408,8 @@ module Iterator(T)
     end
   end
 
+  # Returns an array containing all elements of enum for which the
+  # given block returns a true value.
   def select(&func : T -> U)
     Select(typeof(self), T, U).new(self, func)
   end
@@ -483,6 +520,12 @@ module Iterator(T)
     end
   end
 
+
+  # Returns first `n` elements from enum.
+  #
+  # ```
+  # ["a", "b", "c"].take 2 # => ["a", "b"]
+  # ```
   def take(n)
     raise ArgumentError.new "Attempted to take negative size: #{n}" if n < 0
     Take(typeof(self), T).new(self, n)
@@ -561,6 +604,12 @@ module Iterator(T)
     end
   end
 
+  # Returns uniq elements from enum.
+  #
+  # ```
+  # ["a", "b", "c"].uniq      # => ["a", "b", "c"]
+  # ["a", "b", "c", "c"].uniq # => ["a", "b", "c"]
+  # ```
   def uniq
     uniq &.itself
   end
@@ -592,6 +641,16 @@ module Iterator(T)
     end
   end
 
+  # Returns uniq elements from enum. It will use the return value of
+  # the block for comparison.
+  #
+  # ```
+  # [["a", "a"], ["b", "a"], ["c", "a"]].uniq &.first
+  # # => [["a", "a"], ["b", "a"], ["c", "a"]]
+  #
+  # [["a", "a"], ["b", "a"], ["c", "a"]].uniq &.last
+  # # => [["a", "a"]]
+  # ```
   def uniq(&func : T -> U)
     Uniq(typeof(self), T, U).new(self, func)
   end
@@ -639,6 +698,16 @@ module Iterator(T)
     end
   end
 
+  # Takes one element from enum and merges corresponding elements from
+  # each args. This generates a sequence of n-element arrays with tuples,
+  # where n is one more than the count of arguments:
+  #
+  # ```
+  # a = [ 4, 5, 6 ]
+  # b = [ 7, 8, 9 ]
+  #
+  # a.zip(b) # => [{4, 7}, {5, 8}, {6, 9}]
+  # ```
   def zip(other : Iterator(U))
     Zip(typeof(self), typeof(other), T, U).new(self, other)
   end

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -235,8 +235,8 @@ module Iterator(T)
     end
   end
 
-  # Repeatedly returns the elements of the original iterator forever starting
-  # back at the beginning when the end was reached.
+  # Returns an iterator that repeatedly returns the elements of the original
+  # iterator forever starting back at the beginning when the end was reached.
   #
   #     iter = ["a", "b", "c"].each.cycle
   #     iter.next # => "a"
@@ -270,8 +270,9 @@ module Iterator(T)
     end
   end
 
-  # Repeatedly returns the elements of the original iterator starting
-  # back at the beginning when the end was reached, but only n times.
+  # Returns an iterator that repeatedly returns the elements of the original
+  # iterator starting back at the beginning when the end was reached,
+  # but only n times.
   #
   #     iter = ["a", "b", "c"].each.cycle(2)
   #     iter.next # => "a"
@@ -280,7 +281,7 @@ module Iterator(T)
   #     iter.next # => "a"
   #     iter.next # => "b"
   #     iter.next # => "c"
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   def cycle(n : Int)
     CycleN(typeof(self), T, typeof(n)).new(self, n)
   end
@@ -332,14 +333,15 @@ module Iterator(T)
     end
   end
 
-  # Creates slices of n elements from the iterator.
+  # Returns an iterator that then returns slices of n elements of the initial
+  # iterator.
   #
   #
   #     iter = (1..9).each.each_slice(3)
   #     iter.next # => [1, 2, 3]
   #     iter.next # => [4, 5, 6]
   #     iter.next # => [7, 8, 9]
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def each_slice(n)
     slice(n)
@@ -371,14 +373,15 @@ module Iterator(T)
     end
   end
 
-  # Applies the given block to each element of the iterator.
+  # Returns an iterator that applies the given block to the next element and
+  # returns the result.
   #
   #
   #     iter = [1, 2, 3].each.map &.*(2)
   #     iter.next # => 2
   #     iter.next # => 4
   #     iter.next # => 6
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def map(&func : T -> U)
     Map(typeof(self), T, U).new(self, func)
@@ -398,12 +401,12 @@ module Iterator(T)
     end
   end
 
-  # The returned iterator only returns elements for which the the block returned
-  # a falsey value.
+  # Returns an iterator that only returns elements for which the the passed in
+  # block returns a falsey value.
   #
   #     iter = [1, 2, 3].each.reject &.odd?
   #     iter.next # => 2
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def reject(&func : T -> U)
     Reject(typeof(self), T, U).new(self, func)
@@ -427,13 +430,13 @@ module Iterator(T)
     end
   end
 
-  # The returned iterator only returns elements for which the the block returned
-  # a truthy value.
+  # Returns an iterator that only returns elements for which the the passed
+  # in block returns a truthy value.
   #
   #     iter = [1, 2, 3].each.select &.odd?
   #     iter.next # => 1
   #     iter.next # => 3
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def select(&func : T -> U)
     Select(typeof(self), T, U).new(self, func)
@@ -546,13 +549,13 @@ module Iterator(T)
   end
 
 
-  # Returns an iterator that will just return the first n elements of the
+  # Returns an iterator that only returns the first n elements of the
   # initial iterator.
   #
   #     iter = ["a", "b", "c"].each.take 2
   #     iter.next # => "a"
   #     iter.next # => "b"
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def take(n)
     raise ArgumentError.new "Attempted to take negative size: #{n}" if n < 0
@@ -638,7 +641,7 @@ module Iterator(T)
   #     iter = [1, 2, 1].each.uniq
   #     iter.next # => 1
   #     iter.next # => 2
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def uniq
     uniq &.itself
@@ -651,7 +654,7 @@ module Iterator(T)
   #     iter = [["a", "a"], ["b", "a"], ["a", "c"]].uniq &.first
   #     iter.next # => ["a", "a"]
   #     iter.next # => ["b", "a"]
-  #     iter.next # => Iterator::Stop
+  #     iter.next # => Iterator::Stop::INSTANCE
   #
   def uniq(&func : T -> U)
     Uniq(typeof(self), T, U).new(self, func)
@@ -727,8 +730,8 @@ module Iterator(T)
     end
   end
 
-  # Returns an iterator that takes puts together the corresponding elements
-  # of the given iterators to a pair and returns them.
+  # Returns an iterator that returns the elements of this iterator and the given
+  # one pairwise as tupels.
   #
   #    iter1 = [4, 5, 6].each
   #    iter2 = [7, 8, 9].each
@@ -736,7 +739,7 @@ module Iterator(T)
   #    iter.next # => {4, 7}
   #    iter.next # => {5, 8}
   #    iter.next # => {6, 9}
-  #    iter.next # Iterator::Stop
+  #    iter.next # => Iterator::Stop::INSTANCE
   #
   def zip(other : Iterator(U))
     Zip(typeof(self), typeof(other), T, U).new(self, other)


### PR DESCRIPTION
This is based on and should deprecate #1063 :)

I took the original PR, rebased it against current master and rewrote the documentation so that it applies to iterator. It only includes the original docs right now, I'm keen on adding more either in this PR or maybe discuss and merge here and then add more docs in a separate PR.

Something that has been a bit difficult to me here is clearly formulating the method documentation. The iterator methods all return a new iterator instance that then does what? For instance reject, I went with:

> The returned iterator only returns elements for which the the block returned a falsey value.

Does that seem good? Do we want something different?

cc: @davydovanton 