### PR TITLE
IO#read* refactoring for read_partial/read_nonblock

### DIFF
--- a/spec/std/io/buffered_io_spec.cr
+++ b/spec/std/io/buffered_io_spec.cr
@@ -17,7 +17,7 @@ class BufferedIOWrapper(T)
     io
   end
 
-  private def unbuffered_read(slice : Slice(UInt8))
+  private def unbuffered_read(slice : Slice(UInt8), wait = true)
     @io.read(slice)
   end
 
@@ -186,7 +186,7 @@ describe "BufferedIO" do
 
   it "raises argument error if reads negative length" do
     io = BufferedIOWrapper.new(StringIO.new("hello world"))
-    expect_raises(ArgumentError, "negative length") do
+    expect_raises(ArgumentError, "negative count") do
       io.read(-1)
     end
   end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -16,12 +16,18 @@ module FileUtils
     buf2 :: UInt8[1024]
 
     while true
-      read1 = stream1.read buf1.to_slice
-      read2 = stream2.read buf2.to_slice
+      read1 = cmp_read stream1, buf1.to_slice
+      read2 = cmp_read stream2, buf2.to_slice
 
       return false if read1 != read2
       return false if buf1.buffer.memcmp(buf2.buffer, read1) != 0
       return true if read1 == 0
     end
+  end
+
+  private def cmp_read io, slice
+    io.read slice
+  rescue IO::EOFError
+    0
   end
 end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -14,10 +14,10 @@ module HTTP
       @remaining = length
     end
 
-    def read(slice : Slice(UInt8))
+    def read(slice : Slice(UInt8), wait : Wait)
       count = slice.length
       count = Math.min(count, @remaining)
-      bytes_read = @io.read slice[0, count]
+      bytes_read = @io.read slice[0, count], wait
       @remaining -= bytes_read
       bytes_read
     end

--- a/src/io.cr
+++ b/src/io.cr
@@ -119,6 +119,13 @@ module IO
     End    = 2
   end
 
+  # :nodoc:
+  enum Wait
+    Never
+    Once
+    UntilFinished
+  end
+
   # Raised when an IO operation times out.
   #
   # ```
@@ -207,7 +214,7 @@ module IO
   # io.read(slice) #=> 1
   # slice #=> [111, 101, 108, 108]
   # ```
-  abstract def read(slice : Slice(UInt8))
+  abstract def read(slice : Slice(UInt8), wait : Wait)
 
   # Writes at most *slice.length* bytes from *slice* into this IO. Returns the number of bytes written.
   #
@@ -441,11 +448,8 @@ module IO
   # ```
   def read_fully(slice : Slice(UInt8))
     count = slice.length
-    while slice.length > 0
-      read_bytes = read slice
-      raise EOFError.new if read_bytes == 0
-      slice += read_bytes
-    end
+    read_bytes = read slice
+    raise EOFError.new if read_bytes != count
     count
   end
 
@@ -459,8 +463,12 @@ module IO
   def read : String
     buffer :: UInt8[2048]
     String.build do |str|
-      while (read_bytes = read(buffer.to_slice)) > 0
-        str.write buffer.to_slice[0, read_bytes]
+      begin
+        while (read_bytes = read(buffer.to_slice)) > 0
+          str.write buffer.to_slice[0, read_bytes]
+        end
+      rescue EOFError
+        # ignore
       end
     end
   end
@@ -475,18 +483,61 @@ module IO
   # io.read(3) #=> ""
   # ```
   def read(count : Int) : String
+    read count, Wait::UntilFinished
+  end
+
+  def read_partial(count : Int) : String
+    read count, Wait::Once
+  end
+
+  def read_nonblock(count : Int) : String
+    read count, Wait::Never
+  end
+
+  # :nodoc:
+  def read(count : Int, wait : Wait) : String
     raise ArgumentError.new "negative count" if count < 0
 
-    buffer :: UInt8[2048]
-    String.build(count) do |str|
-      while count > 0
-        read_length = read buffer.to_slice[0, Math.min(count, buffer.length)]
-        break if read_length == 0
+    slice = Slice(UInt8).new count
+    read_length = read slice, wait
+    String.new slice[0, read_length]
+  end
 
-        str.write buffer.to_slice[0, read_length]
-        count -= read_length
-      end
-    end
+  # Reads at most `slice.count` from this IO and returns the number of bytes read in to `slice`.
+  # Always reads `slice.count` bytes unless the io is closed or reaches EOF.
+  def read(slice : Slice(UInt8))
+    read slice, Wait::UntilFinished
+  end
+
+  # Reads at most `slice.count` bytes from the I/O stream.
+  # It blocks only if IO has no data immediately available.
+  # It doesn't block if some data available.
+  #
+  # read_partial is designed for streams such as pipe, socket, tty, etc.
+  # It blocks only when no data immediately available.
+  # This means that it blocks only when following all conditions hold.
+  # * the byte buffer in the IO object is empty.
+  # * the content of the stream is empty.
+  # * the stream is not reached to EOF.
+  #
+  # When read_partial blocks, it waits data or EOF on the stream.
+  # If some data is reached, readpartial returns with the data. If EOF is reached, read_partial raises IO::EOFError.
+  # When read_partial doesn't blocks, it returns or raises immediately.
+  # If the byte buffer is not empty, it returns the data in the buffer.
+  # Otherwise if the stream has some content, it returns the data in the stream.
+  # Otherwise if the stream is reached to EOF, it raises IO::EOFError.
+  def read_partial(slice : Slice(UInt8))
+    read slice, Wait::Once
+  end
+
+  # Reads at most maxlen bytes from ios using the read(2) system call.
+  # Nonblock (the default) must be set for this call to work correctly.
+  #
+  # read_nonblock causes IO::EOFError on EOF.
+  #
+  # This method is similar to read_partial except it will never block.
+  def read_nonblock(slice : Slice(UInt8))
+    read slice, Wait::Never
   end
 
   # Reads a line from this IO. A line is terminated by the `\n` character.
@@ -750,6 +801,11 @@ module IO
     ByteIterator.new(self)
   end
 
+  # :nodoc:
+  protected def raise_if_eof
+    raise EOFError.new if @read_eof
+  end
+
   # Copy all contents from *src* to *dst*.
   #
   # ```
@@ -761,11 +817,18 @@ module IO
   # io2.to_s #=> "hello"
   # ```
   def self.copy(src, dst)
+    src.raise_if_eof
+
     buffer :: UInt8[1024]
     count = 0
-    while (len = src.read(buffer.to_slice).to_i32) > 0
-      dst.write buffer.to_slice[0, len]
-      count += len
+    len = 0
+    begin
+      while (len = src.read(buffer.to_slice).to_i32) > 0
+        dst.write buffer.to_slice[0, len]
+        count += len
+      end
+    rescue IO::EOFError
+      # ignore
     end
     len < 0 ? len : count
   end

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -9,7 +9,7 @@ class IO::ARGF
     @read_from_stdin = false
   end
 
-  def read(slice : Slice(UInt8))
+  def read(slice : Slice(UInt8), wait : Wait)
     count = slice.length
     first_initialize unless @initialized
 

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -233,24 +233,4 @@ module IO
       LibTermios.tcsetattr(fd, LibTermios::OptionalActions::TCSANOW, pointerof(before))
     end
   end
-
-  def read_nonblock(length)
-    before = LibC.fcntl(fd, LibC::FCNTL::F_GETFL)
-    LibC.fcntl(fd, LibC::FCNTL::F_SETFL, before | LibC::O_NONBLOCK)
-
-    begin
-      String.new(length) do |buffer|
-        read_length = read Slice.new(buffer, length)
-        if read_length == 0
-          raise EOFError.new "read_nonblock: read nothing"
-        elsif LibC.errno == LibC::EWOULDBLOCK
-          raise Errno.new "exception in read_nonblock"
-        else
-          {read_length.to_i, 0}
-        end
-      end
-    ensure
-      LibC.fcntl(fd, LibC::FCNTL::F_SETFL, before)
-    end
-  end
 end

--- a/src/io/file_descriptor_io.cr
+++ b/src/io/file_descriptor_io.cr
@@ -13,6 +13,7 @@ class FileDescriptorIO
     @flush_on_newline = false
     @sync = false
     @closed = false
+    @read_eof = false
     @read_timed_out = false
     @write_timed_out = false
     @fd = fd
@@ -74,6 +75,7 @@ class FileDescriptorIO
       flags |= LibC::O_NONBLOCK
     end
     fcntl(LibC::FCNTL::F_SETFL, flags)
+    value
   end
 
   def close_on_exec?
@@ -165,16 +167,25 @@ class FileDescriptorIO
     self
   end
 
-  private def unbuffered_read(slice : Slice(UInt8))
+  private def unbuffered_read(slice : Slice(UInt8), wait = true : Bool)
+    return 0 if @read_eof
+
     count = slice.length
     loop do
       bytes_read = LibC.read(@fd, slice.pointer(count), LibC::SizeT.cast(count))
-      if bytes_read != -1
-        return bytes_read
+      return bytes_read if bytes_read > 0
+
+      if bytes_read == 0 # future reads will return -1 when NONBLOCK is set (we would lose track of EOF)
+        @read_eof = true
+        return 0
       end
 
       if LibC.errno == Errno::EAGAIN
-        wait_readable
+        if wait
+          wait_readable
+        else
+          return 0
+        end
       else
         raise Errno.new "Error reading file"
       end

--- a/src/io/pointer_io.cr
+++ b/src/io/pointer_io.cr
@@ -4,7 +4,7 @@ struct PointerIO
   def initialize(@pointer : UInt8**)
   end
 
-  def read(slice : Slice(UInt8))
+  def read(slice : Slice(UInt8), wait : Wait)
     count = slice.length
     slice.copy_from(@pointer.value, count)
     @pointer.value += count

--- a/src/io/string_io.cr
+++ b/src/io/string_io.cr
@@ -41,7 +41,8 @@ class StringIO
     io
   end
 
-  def read(slice : Slice(UInt8))
+  # :nodoc:
+  def read(slice : Slice(UInt8), wait : Wait)
     count = slice.length
     count = Math.min(count, @bytesize - @pos)
     slice.copy_from(@buffer + @pos, count)

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -17,7 +17,8 @@ class OpenSSL::SSL::Socket
     LibSSL.ssl_free(@ssl)
   end
 
-  def read(slice : Slice(UInt8))
+  # :nodoc:
+  def read(slice : Slice(UInt8), wait : Wait)
     count = slice.length
     return 0 if count == 0
     LibSSL.ssl_read(@ssl, slice.pointer(count), count)


### PR DESCRIPTION
  New methods IO#read_partial.
  New methods IO#read_nonblock.
  Documentation for both.
  Specs for both.
  IO#read always returns the amount of bytes requested unless EOF.
  IO#read_fully no longer loops, but relies on #read.
  IO#read* Raises IO::EOFError after all input has been consumed.
    Less likely to cause infinite loops.
    More likely to catch errors (like IO.copy starting at EOF)
    Necessary feedback mechanism for read_nonblock which may return 0
  A single method is required to implement an IO read interface.
  All other IO and IO like classes updated to use the new interface.
  io/console.cr: read_nonblock removed. (new BufferedIO compatible replacement in io.cr)