### PR TITLE
Don't require a Projectfile when generating docs

### DIFF
--- a/src/crystal/project_cli.cr
+++ b/src/crystal/project_cli.cr
@@ -3,7 +3,7 @@ require "./project"
 project = Crystal::Project.new
 begin
   project.eval do
-    {{ `cat Projectfile` }}
+    {{ `cat Projectfile 2> /dev/null || true` }}
   end
 
   command = ARGV.shift? || "install"


### PR DESCRIPTION
Was getting an error when trying to generate docs when a project does not have a Projectfile. This remedies that issue.