### PR TITLE
Add before_each and after_each to spec dsl

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -84,22 +84,48 @@ describe "Spec matchers" do
   end
 end
 
-describe "before and after hooks" do
-  thing = 0
+call_tracker = [] of String
 
+describe "before and after hooks" do
   before_each do
-    thing += 2
+    call_tracker.push("before_each")
   end
 
   after_each do
-    thing -= 1
+    call_tracker.push("after_each")
   end
 
-  it "increments the variable by 2 before" do
-    thing.should eq(2)
+  it "calls before" do
+    call_tracker.should eq(["before_each"])
   end
 
   it "decrements the variable by 1 after" do
-    thing.should eq(3)
+    call_tracker.should eq(["before_each", "after_each", "before_each"])
+  end
+end
+
+describe "before and after hooks in another context" do
+  it "should not call the before and after hooks" do
+    call_tracker.should eq(["before_each", "after_each", "before_each", "after_each"])
+  end
+end
+
+global_call_tracker = [] of String
+
+before_each do
+  global_call_tracker.push("global_before_each")
+end
+
+after_each do
+  global_call_tracker.push("global_after_each")
+end
+
+describe "before and after hooks in a nested context" do
+  it "should call the before global hook" do
+    global_call_tracker.should eq(["global_before_each"])
+  end
+
+  it "should call the after global hook" do
+    global_call_tracker.should eq(["global_before_each", "global_after_each", "global_before_each"])
   end
 end

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -83,3 +83,23 @@ describe "Spec matchers" do
     end
   end
 end
+
+describe "before and after hooks" do
+  thing = 0
+
+  before_each do
+    thing += 2
+  end
+
+  after_each do
+    thing -= 1
+  end
+
+  it "increments the variable by 2 before" do
+    thing.should eq(2)
+  end
+
+  it "decrements the variable by 1 after" do
+    thing.should eq(3)
+  end
+end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -16,7 +16,7 @@ module Spec::DSL
     Spec.formatter.before_example description
 
     begin
-      Spec.run_before_each_hooks
+      Spec::RootContext.run_before_each_hooks
       yield
       Spec::RootContext.report(:success, description, file, line)
     rescue ex : Spec::AssertionFailed
@@ -26,7 +26,7 @@ module Spec::DSL
       Spec::RootContext.report(:error, description, file, line, ex)
       Spec.abort! if Spec.fail_fast?
     ensure
-      Spec.run_after_each_hooks
+      Spec::RootContext.run_after_each_hooks
     end
   end
 
@@ -40,11 +40,11 @@ module Spec::DSL
   end
 
   def before_each(&block)
-    Spec.before_each(&block)
+    Spec::RootContext.before_each(&block)
   end
 
   def after_each(&block)
-    Spec.after_each(&block)
+    Spec::RootContext.after_each(&block)
   end
 
   def assert(file = __FILE__, line = __LINE__)

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -39,6 +39,14 @@ module Spec::DSL
     Spec::RootContext.report(:pending, description, file, line)
   end
 
+  def before_each(&block)
+    Spec.before_each(&block)
+  end
+
+  def after_each(&block)
+    Spec.after_each(&block)
+  end
+
   def assert(file = __FILE__, line = __LINE__)
     it("assert", file, line) { yield }
   end

--- a/src/spec/spec.cr
+++ b/src/spec/spec.cr
@@ -147,26 +147,6 @@ module Spec
     @@fail_fast
   end
 
-  def self.before_each(&block)
-    before_each = @@before_each ||= [] of ->
-    before_each << block
-  end
-
-  def self.after_each(&block)
-    after_each = @@after_each ||= [] of ->
-    after_each << block
-  end
-
-  # :nodoc:
-  def self.run_before_each_hooks
-    @@before_each.try &.each &.call
-  end
-
-  # :nodoc:
-  def self.run_after_each_hooks
-    @@after_each.try &.each &.call
-  end
-
   # :nodoc
   def self.run
     start_time = Time.now


### PR DESCRIPTION
Was trying to use `before_each` / `after_each` in something I was writing and found that it was missing.
Pleasantly surprised to find out clean this code base is, this only took a few minutes to find and fix!