### PR TITLE
Class-level macros

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1143,4 +1143,28 @@ describe "Code gen: macro" do
       a
       )).to_i.should eq(123)
   end
+
+  it "expands macro as class method" do
+    run(%(
+      class Foo
+        macro bar
+          1
+        end
+      end
+
+      Foo.bar
+      )).to_i.should eq(1)
+  end
+
+  it "expands macro as class method and accesses @type" do
+    run(%(
+      class Foo
+        macro bar
+          {{@type.stringify}}
+        end
+      end
+
+      Foo.bar
+      )).to_string.should eq("Foo")
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -406,7 +406,7 @@ class Crystal::Call
               yields_to_block = block && !match.def.uses_block_arg
 
               if yields_to_block
-                raise_if_block_too_nested
+                raise_if_block_too_nested(match.def.block_nest)
                 match.def.block_nest += 1
               end
 
@@ -429,13 +429,13 @@ class Crystal::Call
     typed_defs
   end
 
-  def raise_if_block_too_nested
+  def raise_if_block_too_nested(block_nest)
     # When we visit this def's body, we nest. If we are nesting
     # over and over again, and there's a block, it means this will go on forever
     #
     # TODO Ideally this should check `> 1`, but the algorithm isn't precise. However,
     # manually nested blocks don't nest this deep.
-    if match.def.block_nest > 15
+    if block_nest > 15
       raise "recursive block expansion: blocks that yield are always inlined, and this call leads to an infinite inlining"
     end
   end


### PR DESCRIPTION
This pull request will allow macro calls to be prefixed by a type name. For example:

```crystal
class Foo
  macro bar
    1
  end
end

Foo.bar #=> 1
```

This will **only** work if the call has a Path AST node. A Path is something
of the form `Foo::Bar::Baz`. So this won't work:

```crystal
foo = Foo
foo.bar # undefined method 'bar' for Foo:Class
```

Inside a macro invoked as a class method, the macro variable `@type` refers
to the type to the left of the macro invocation. So:

```crystal
class Foo
  macro name
    {{@type.stringify}}
  end
end

class Bar < Foo; end

Foo.name #=> "Foo"
Bar.name #=> "Bar"
```

Note: in regular macro calls `@type` has the type of the scope that
invoked the macro, and in macro defs `@type` has the type of the
concrete class that will hold the method. So `@type` will have three
different meanings depending on the macro type, so we might want
to choose different names or just leave this as it is now if it's intuitive
enough. 

The motivation for this feature is that right now macros can be namespaced
but only used inside that namespace. General-purpose macros must be defined
globally or inside Object, both of which are "global" namespaces. With this change,
`json_mapping` could simply be a `mapping` macro inside the `JSON` module, and
invoked like `JSON.mapping({...})`.

Another motivation is a `flags` macro for enums. Right now you can do it
like this:

```crystal
macro flags(enum_type, *values)
  {% for value, i in values %}\
    {% if i != 0 %} | {% end %}\
    {{ enum_type }}::{{ value }}{% end %}\
end

@[Flags]
enum Bits
  One
  Two
  Three
end

bits = flags(Bits, One ,Two)
puts bits #=> One, Two
```

The problem is that `flags` needs to be defined in the global namespace.
With this new feature, and using the `@type` macro variable, you can do
it like this:

```crystal
struct Enum
  macro flags(*values)
    {% for value, i in values %}\
      {% if i != 0 %} | {% end %}\
      {{ @type }}::{{ value }}{% end %}\
  end
end

@[Flags]
enum Bits
  One
  Two
  Three
end

bits = Bits.flags(One, Two)
puts bits #=> One, Two
``` 

which is much easier to read and write, much more clear, and doesn't suffer
the global namespace issue.