### PR TITLE
Add Block Comment Syntax

### DIFF
--- a/spec/compiler/lexer/lexer_comment_spec.cr
+++ b/spec/compiler/lexer/lexer_comment_spec.cr
@@ -1,7 +1,7 @@
 require "../../spec_helper"
 
 describe "Lexer comments" do
-  it "lexes without comments enabled" do
+  it "lexes line comments without comments enabled" do
     lexer = Lexer.new(%(# Hello\n1))
 
     token = lexer.next_token
@@ -11,7 +11,7 @@ describe "Lexer comments" do
     token.type.should eq(:NUMBER)
   end
 
-  it "lexes with comments enabled" do
+  it "lexes line comments with comments enabled" do
     lexer = Lexer.new(%(# Hello\n1))
     lexer.comments_enabled = true
 
@@ -60,5 +60,37 @@ describe "Lexer comments" do
 
     token = lexer.next_token
     token.type.should eq(:EOF)
+  end
+
+  it "lexes block comments without comments enabled" do
+    lexer = Lexer.new(%(1#[\n2\n3\n#]4))
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.value.should eq("1")
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.value.should eq("4")
+
+    token = lexer.next_token
+    token.type.should eq(:EOF)
+  end
+
+  it "lexes block comments with comments enabled" do
+    lexer = Lexer.new(%(1#[\n2\n3\n#]4))
+    lexer.comments_enabled = true
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.value.should eq("1")
+
+    token = lexer.next_token
+    token.type.should eq(:COMMENT)
+    token.value.should eq("#[\n2\n3\n#]")
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+    token.value.should eq("4")
   end
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1009,8 +1009,15 @@ module Crystal
 
     def skip_comment
       char = current_char
-      while char != '\n' && char != '\0'
-        char = next_char_no_column_increment
+      if char == '['
+        while char != '#' && peek_next_char != ']'
+          char = next_char_no_column_increment
+        end
+        2.times { next_char_no_column_increment }
+      else
+        while char != '\n' && char != '\0'
+          char = next_char_no_column_increment
+        end
       end
     end
 


### PR DESCRIPTION
```
puts "before"         # => before
#[
this is all a
puts "commented out"
comment
#]
puts "after"          # => after

pp 3 + #[ no #]5      # => 3 + 5 = 8
```

I looked through this [comment comparison](https://en.wikipedia.org/wiki/Comparison_of_programming_languages_(syntax)#Comment_comparison) list for languages that used `#` for inline comments, to see if any of their block comments felt right to me.

I wanted something that still had the `#` char, so ruby `==begin ==end` was out. Some were close, lisp `#| BlockComment |#`, and cobra `/# BlockComment #/`, and awk `<# BlockComment #>`.

However I think it's nice to have both "start block comment" and "end block comment" start with `#` so you can toggle sections quickly, by only editing one of the pair, so I came up with this.
