### PR TITLE
Benchmark ips formatting improvements 

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -52,3 +52,25 @@ describe Benchmark::IPS::Entry, "#calculate_stats" do
     e.stddev.should   eq(2.0)
   end
 end
+
+private def h_mean(mean)
+  create_entry.tap {|e| e.mean = mean }.human_mean
+end
+
+describe Benchmark::IPS::Entry, "#human_mean" do
+  assert { h_mean(1.23456789012345).should eq("  1.23 ") }
+  assert { h_mean(12.3456789012345).should eq(" 12.35 ") }
+  assert { h_mean(123.456789012345).should eq("123.46 ") }
+
+  assert { h_mean(1234.56789012345).should eq("  1.23k") }
+  assert { h_mean(12345.6789012345).should eq(" 12.35k") }
+  assert { h_mean(123456.789012345).should eq("123.46k") }
+
+  assert { h_mean(1234567.89012345).should eq("  1.23M") }
+  assert { h_mean(12345678.9012345).should eq(" 12.35M") }
+  assert { h_mean(123456789.012345).should eq("123.46M") }
+
+  assert { h_mean(1234567890.12345).should eq("  1.23G") }
+  assert { h_mean(12345678901.2345).should eq(" 12.35G") }
+  assert { h_mean(123456789012.345).should eq("123.46G") }
+end

--- a/src/benchmark/benchmark.cr
+++ b/src/benchmark/benchmark.cr
@@ -12,11 +12,12 @@ require "./**"
 # end
 # ```
 #
-# This generates the following output:
+# This generates the following output showing the mean iterations per second,
+# the standard deviation relative to the mean, and a comparison:
 #
 # ```text
-#   short sleep    91.82 (±  1.11)  8.72× slower
-# shorter sleep   800.98 (±  4.72)       fastest
+#   short sleep    91.82 (± 2.51%)  8.72× slower
+# shorter sleep   800.98 (± 1.10%)       fastest
 # ```
 #
 # `Benchmark::IPS` defaults to 2 seconds of warmup time and 5 seconds of

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -46,9 +46,9 @@ module Benchmark
             compare = sprintf "%5.2f× slower", item.slower
           end
 
-          printf "%s %8.2f (± %4.2f%%) %s\n",
+          printf "%s %s (±%5.2f%%) %s\n",
             item.label.rjust(max_label),
-            item.mean,
+            item.human_mean,
             item.relative_stddev,
             compare
         end
@@ -157,6 +157,20 @@ module Benchmark
         @variance = (samples.inject(0) { |acc, i| acc + ((i - mean) ** 2) }).to_f / size.to_f
         @stddev = Math.sqrt(variance)
         @relative_stddev = 100.0 * (stddev / mean)
+      end
+
+      def human_mean
+        pair = case Math.log10(mean)
+               when 0..3
+                 {mean, ' '}
+               when 3..6
+                 {mean/1_000, 'k'}
+               when 6..9
+                 {mean/1_000_000, 'M'}
+               else
+                 {mean/1_000_000_000, 'G'}
+               end
+        "#{pair[0].round(2).to_s.rjust(6)}#{pair[1]}"
       end
     end
   end

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -46,10 +46,10 @@ module Benchmark
             compare = sprintf "%5.2f× slower", item.slower
           end
 
-          printf "%s %8.2f (± %5.2f) %s\n",
+          printf "%s %8.2f (± %4.2f%%) %s\n",
             item.label.rjust(max_label),
             item.mean,
-            item.stddev,
+            item.relative_stddev,
             compare
         end
       end
@@ -109,7 +109,7 @@ module Benchmark
 
     class Entry
       # Label of the benchmark
-      property label  :: String
+      property label :: String
 
       # Code to be benchmarked
       property action :: ->
@@ -129,6 +129,9 @@ module Benchmark
 
       # Statistcal standard deviation from calculation stage
       property! stddev :: Float
+
+      # Relative standard deviation as a percentage
+      property! relative_stddev :: Float
 
       # Multiple slower than the fastest entry
       property! slower :: Float
@@ -153,6 +156,7 @@ module Benchmark
         @mean = samples.sum.to_f / size.to_f
         @variance = (samples.inject(0) { |acc, i| acc + ((i - mean) ** 2) }).to_f / size.to_f
         @stddev = Math.sqrt(variance)
+        @relative_stddev = 100.0 * (stddev / mean)
       end
     end
   end


### PR DESCRIPTION
Two improvements, use relative stddev instead and also use SI suffixes on the means. The relative stddev I think is easier to understand. The shorter means is because in many of the cases I've seen the IPS is so high, it's hard to read the numbers.

now
```
stdlib 2054429.34 (± 142437.52)       fastest
reimpl 1952512.39 (± 208080.29)  1.05× slower
```
after
```
stdlib   2.06M (± 6.54%)       fastest
reimpl   1.95M (±11.47%)  1.04× slower  
```
