### PR TITLE
Let loop yield the iteration count

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -406,6 +406,14 @@ describe Iterator do
       iter.rewind
       iter.next.should eq({1, 10})
     end
+
+    it "does with_index with a block" do
+      y = -1
+      (1..3).each.with_index do |n, i|
+        i.should eq y+1
+        y = i
+      end
+    end
   end
 
   describe "with object" do

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -1,0 +1,34 @@
+require "spec"
+
+describe "Toplevel" do
+  describe "loop" do
+    it "yields" do
+      i = 0
+      loop do
+        i += 1
+        break if i == 3
+      end
+      i.should eq 3
+    end
+
+    it "returns an iterator" do
+      iter = loop
+      iter.next.should be_nil
+      iter.next.should be_nil
+      iter.next.should be_nil
+      iter.rewind
+      iter.next.should be_nil
+      iter.next.should be_nil
+      iter.next.should be_nil
+
+      y = 0
+      loop.with_index(2) do |i|
+        i.should_not eq 0
+        y += 1
+        break if i == 3 || y == 5
+      end
+
+      y.should eq 2
+    end
+  end
+end

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -870,6 +870,14 @@ module Iterator(T)
     WithIndex(typeof(self), T).new(self, offset)
   end
 
+  # Yields each item of the iterator to the given block alongside with its
+  # index, see `Enumerable#each_with_index`
+  def with_index(offset = 0)
+    each_with_index(offset) do |e, i|
+      yield e, i
+    end
+  end
+
   # :nodoc:
   class WithIndex(I, T)
     include Iterator({T, Int32})

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -22,6 +22,44 @@ def loop
   end
 end
 
+
+# Returns an iterator that returns `nil` forever. Useful in conjunction
+# with other *Iterator* methods such as `with_index`:
+#
+# ```
+# loop.with_index do |i|
+#   print i
+#   break if i == 3
+# end
+# ```
+def loop
+  LoopIterator.new
+end
+
+# :nodoc:
+struct LoopIterator
+  include Iterator(Int64)
+
+  def next
+  end
+
+  def rewind
+    self
+  end
+
+  def each_with_index(offset=0)
+    super(offset) do |_, i|
+      yield i
+    end
+  end
+
+  def with_index(offset=0)
+    each_with_index(offset) do |i|
+      yield i
+    end
+  end
+end
+
 # Reads a line from STDIN. See `IO#gets`.
 def gets(*args)
   STDIN.gets(*args)


### PR DESCRIPTION
So we can replace things like

```cr
(0..Float32::INFINITY).each do |i|
 yada yada(i)
end
```

with

```cr
loop do |i|
  yada yada(i)
end
```