### PR TITLE
Fix file name command ambiguity

### DIFF
--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -12,4 +12,17 @@ describe "Compiler" do
 
     `#{tempfile.path}`.should eq("Hello!")
   end
+
+  it "runs subcommand in preference to a filename " do
+    Dir.chdir "#{__DIR__}/data/" do
+      tempfile = Tempfile.new "compiler_spec_output"
+      tempfile.close
+
+      Crystal::Command.run ["build", "#{__DIR__}/data/compiler_sample", "-o", tempfile.path]
+
+      File.exists?(tempfile.path).should be_true
+
+      `#{tempfile.path}`.should eq("Hello!")
+    end
+  end
 end

--- a/spec/compiler/data/build
+++ b/spec/compiler/data/build
@@ -1,0 +1,1 @@
+puts "this file is never compiled (#1412)"

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -44,40 +44,40 @@ USAGE
     command = options.first?
 
     if command
-      if File.file?(command)
+      case
+      when "init".starts_with?(command)
+        options.shift
+        init options
+      when "build".starts_with?(command)
+        options.shift
+        build options
+      when "deps".starts_with?(command)
+        options.shift
+        deps options
+      when "docs".starts_with?(command)
+        options.shift
+        docs options
+      when "eval".starts_with?(command)
+        options.shift
+        eval options
+      when "run".starts_with?(command)
+        options.shift
         run_command options
+      when "spec/".starts_with?(command)
+        options.shift
+        run_specs options
+      when "tool".starts_with?(command)
+        options.shift
+        tool options
+      when "--help" == command, "-h" == command
+        puts USAGE
+        exit
+      when "--version" == command, "-v" == command
+        puts "Crystal #{Crystal.version_string}"
+        exit
       else
-        case
-        when "init".starts_with?(command)
-          options.shift
-          init options
-        when "build".starts_with?(command)
-          options.shift
-          build options
-        when "deps".starts_with?(command)
-          options.shift
-          deps options
-        when "docs".starts_with?(command)
-          options.shift
-          docs options
-        when "eval".starts_with?(command)
-          options.shift
-          eval options
-        when "run".starts_with?(command)
-          options.shift
+        if File.file?(command)
           run_command options
-        when "spec/".starts_with?(command)
-          options.shift
-          run_specs options
-        when "tool".starts_with?(command)
-          options.shift
-          tool options
-        when "--help" == command, "-h" == command
-          puts USAGE
-          exit
-        when "--version" == command, "-v" == command
-          puts "Crystal #{Crystal.version_string}"
-          exit
         else
           error "unknown command: #{command}"
         end


### PR DESCRIPTION
Please see #1412 

This pull request changes `crystal` command behavior.

Before:

```console
$ echo "p :ok" > build
$ crystal build
:ok
```

After:

```console
$ echo "p :ok" > build
$ crystal build
Usage: crystal build [options] [programfile] [--] [arguments]

...
```