### PR TITLE
Benchmark::IPS bugfix and better comparison alignment

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -58,6 +58,8 @@ private def h_mean(mean)
 end
 
 describe Benchmark::IPS::Entry, "#human_mean" do
+  assert { h_mean(0.12345678901234).should eq("  0.12 ") }
+
   assert { h_mean(1.23456789012345).should eq("  1.23 ") }
   assert { h_mean(12.3456789012345).should eq(" 12.35 ") }
   assert { h_mean(123.456789012345).should eq("123.46 ") }

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -38,19 +38,14 @@ module Benchmark
 
       def report
         max_label = @items.max_of &.label.size
+        max_compare = @items.max_of &.human_compare.size
 
         @items.each do |item|
-          if item.slower == 1.0
-            compare = "      fastest"
-          else
-            compare = sprintf "%5.2f× slower", item.slower
-          end
-
           printf "%s %s (±%5.2f%%) %s\n",
             item.label.rjust(max_label),
             item.human_mean,
             item.relative_stddev,
-            compare
+            item.human_compare.rjust(max_compare)
         end
       end
 
@@ -95,7 +90,7 @@ module Benchmark
           final_time = Time.now
 
           ips = measurements.map { |m| item.cycles.to_f / m.total_seconds }
-          item.calculate_stats(ips)# = Stats.new(ips)
+          item.calculate_stats(ips)
         end
       end
 
@@ -161,7 +156,7 @@ module Benchmark
 
       def human_mean
         pair = case Math.log10(mean)
-               when 0..3
+               when -1..3
                  {mean, ' '}
                when 3..6
                  {mean/1_000, 'k'}
@@ -171,6 +166,14 @@ module Benchmark
                  {mean/1_000_000_000, 'G'}
                end
         "#{pair[0].round(2).to_s.rjust(6)}#{pair[1]}"
+      end
+
+      def human_compare
+        if slower == 1.0
+          "fastest"
+        else
+          sprintf "%5.2f× slower", slower
+        end
       end
     end
   end


### PR DESCRIPTION
- means < 1 were not reported correctly
- pre calculate alignment for the comparison section, so it's always
  aligned

related to #1405
