### PR TITLE
Split BufferedIO in to Reader/Writer/Seeker modules.

### DIFF
--- a/spec/std/io/buffered_io_spec.cr
+++ b/spec/std/io/buffered_io_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
 
 class BufferedIOWrapper(T)
-  include BufferedIO
+  include IO::Buffered::Common
+  include IO::Buffered::Reader
+  include IO::Buffered::Writer
+  include IO::Buffered::Seeker
 
   getter called_unbuffered_read
 
@@ -100,14 +103,14 @@ describe "BufferedIO" do
   end
 
   it "does gets with char and limit when not found in buffer" do
-    io = BufferedIOWrapper.new(StringIO.new(("a" * (BufferedIO::BUFFER_SIZE + 10)) + "b"))
+    io = BufferedIOWrapper.new(StringIO.new(("a" * (IO::Buffered::Common::BUFFER_SIZE + 10)) + "b"))
     io.gets('b', 2).should eq("aa")
   end
 
   it "does gets with char and limit when not found in buffer (2)" do
-    base = "a" * (BufferedIO::BUFFER_SIZE + 10)
+    base = "a" * (IO::Buffered::Common::BUFFER_SIZE + 10)
     io = BufferedIOWrapper.new(StringIO.new(base + "aabaaa"))
-    io.gets('b', BufferedIO::BUFFER_SIZE + 11).should eq(base + "a")
+    io.gets('b', IO::Buffered::Common::BUFFER_SIZE + 11).should eq(base + "a")
   end
 
   it "raises if invoking gets with negative limit" do

--- a/src/io.cr
+++ b/src/io.cr
@@ -825,5 +825,5 @@ module IO
   end
 end
 
-require "./io/*"
+require "./io/**"
 

--- a/src/io/buffered/common.cr
+++ b/src/io/buffered/common.cr
@@ -1,0 +1,28 @@
+# The BufferedIO mixin enhances the IO module with input/output buffering.
+#
+# The buffering behaviour can be turned on/off with the `#sync=` method.
+#
+# Additionally, several methods, like `#gets`, are implemented in a more
+# efficient way.
+module IO::Buffered::Common
+  include IO
+
+  BUFFER_SIZE = 8192
+
+  # Due to https://github.com/manastech/crystal/issues/456 this
+  # initialization logic must be copied in the included type's
+  # initialize method:
+  #
+  # def initialize
+  #   @out_count = 0
+  # end
+
+  # Closes the wrapped IO.
+  abstract def unbuffered_close
+
+  # Flushes and closes the underlying IO.
+  def close
+    flush if responds_to?(:flush) && @out_count > 0
+    unbuffered_close
+  end
+end

--- a/src/io/buffered/reader.cr
+++ b/src/io/buffered/reader.cr
@@ -1,13 +1,9 @@
-# The BufferedIO mixin enhances the IO module with input/output buffering.
-#
-# The buffering behaviour can be turned on/off with the `#sync=` method.
+# The BufferedIO mixin enhances the IO module with input buffering.
 #
 # Additionally, several methods, like `#gets`, are implemented in a more
 # efficient way.
-module BufferedIO
-  include IO
-
-  BUFFER_SIZE = 8192
+module IO::Buffered::Reader
+  BUFFER_SIZE = IO::Buffered::Common::BUFFER_SIZE
 
   # Due to https://github.com/manastech/crystal/issues/456 this
   # initialization logic must be copied in the included type's
@@ -15,25 +11,13 @@ module BufferedIO
   #
   # def initialize
   #   @in_buffer_rem = Slice.new(Pointer(UInt8).null, 0)
-  #   @out_count = 0
-  #   @sync = false
-  #   @flush_on_newline = false
   # end
 
   # Reads at most *slice.size* bytes from the wrapped IO into *slice*. Returns the number of bytes read.
   abstract def unbuffered_read(slice : Slice(UInt8))
 
-  # Writes at most *slice.size* bytes from *slice* into the wrapped IO. Returns the number of bytes written.
-  abstract def unbuffered_write(slice : Slice(UInt8))
-
-  # Flushes the wrapped IO.
-  abstract def unbuffered_flush
-
   # Closes the wrapped IO.
   abstract def unbuffered_close
-
-  # Rewinds the wrapped IO.
-  abstract def unbuffered_rewind
 
   # :nodoc:
   def gets(delimiter : Char, limit : Int)
@@ -188,100 +172,6 @@ module BufferedIO
     super
   end
 
-  # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Slice(UInt8))
-    count = slice.size
-
-    if sync?
-      return unbuffered_write(slice).to_i
-    end
-
-    if flush_on_newline?
-      index = slice[0, count.to_i32].rindex('\n'.ord.to_u8)
-      if index
-        flush
-        index += 1
-        unbuffered_write slice[0, index]
-        slice += index
-        count -= index
-      end
-    end
-
-    if count >= BUFFER_SIZE
-      flush
-      unbuffered_write slice[0, count]
-      return
-    end
-
-    if count > BUFFER_SIZE - @out_count
-      flush
-    end
-
-    slice.copy_to(out_buffer + @out_count, count)
-    @out_count += count
-  end
-
-  # :nodoc:
-  def write_byte(byte : UInt8)
-    if sync?
-      return super
-    end
-
-    if @out_count >= BUFFER_SIZE
-      flush
-    end
-    out_buffer[@out_count] = byte
-    @out_count += 1
-
-    if flush_on_newline? && byte === '\n'
-      flush
-    end
-  end
-
-  # Turns on/off flushing the underlying IO when a newline is written.
-  def flush_on_newline=(flush_on_newline)
-    @flush_on_newline = !!flush_on_newline
-  end
-
-  # Determines if this IO flushes automatically when a newline is written.
-  def flush_on_newline?
-    @flush_on_newline
-  end
-
-  # Turns on/off IO buffering. When `sync` is set to `true`, no buffering
-  # will be done (that is, writing to this IO is immediately synced to the
-  # underlying IO).
-  def sync=(sync)
-    # TODO: maybe instead of `sync=` we should rename this to `buffer=`,
-    # because otherwise you have to think in a reversed way.
-    flush if sync && !@sync
-    @sync = !!sync
-  end
-
-  # Determines if this IO does buffering. If `true`, no buffering is done.
-  def sync?
-    @sync
-  end
-
-  # Flushes any buffered data and the underlying IO.
-  def flush
-    unbuffered_write(Slice.new(out_buffer, @out_count)) if @out_count > 0
-    unbuffered_flush
-    @out_count = 0
-  end
-
-  # Flushes and closes the underlying IO.
-  def close
-    flush if @out_count > 0
-    unbuffered_close
-  end
-
-  # Rewinds the underlying IO.
-  def rewind
-    unbuffered_rewind
-    @in_buffer_rem = Slice.new(Pointer(UInt8).null, 0)
-  end
-
   private def fill_buffer
     in_buffer = in_buffer()
     size = unbuffered_read(Slice.new(in_buffer, BUFFER_SIZE)).to_i
@@ -290,9 +180,5 @@ module BufferedIO
 
   private def in_buffer
     @in_buffer ||= GC.malloc_atomic(BUFFER_SIZE.to_u32) as UInt8*
-  end
-
-  private def out_buffer
-    @out_buffer ||= GC.malloc_atomic(BUFFER_SIZE.to_u32) as UInt8*
   end
 end

--- a/src/io/buffered/seeker.cr
+++ b/src/io/buffered/seeker.cr
@@ -1,0 +1,11 @@
+# The BufferedIO mixin enhances the IO module with seek support for input/output buffering.
+module IO::Buffered::Seeker
+  # Rewinds the wrapped IO.
+  abstract def unbuffered_rewind
+
+  # Rewinds the underlying IO.
+  def rewind
+    unbuffered_rewind
+    @in_buffer_rem = Slice.new(Pointer(UInt8).null, 0)
+  end
+end

--- a/src/io/buffered/writer.cr
+++ b/src/io/buffered/writer.cr
@@ -1,0 +1,108 @@
+# The BufferedIO mixin enhances the IO module with output buffering.
+#
+# The buffering behaviour can be turned on/off with the `#sync=` method.
+module IO::Buffered::Writer
+  BUFFER_SIZE = IO::Buffered::Common::BUFFER_SIZE
+
+  # Due to https://github.com/manastech/crystal/issues/456 this
+  # initialization logic must be copied in the included type's
+  # initialize method:
+  #
+  # def initialize
+  #   @out_count = 0
+  #   @sync = false
+  #   @flush_on_newline = false
+  # end
+
+  # Writes at most *slice.size* bytes from *slice* into the wrapped IO. Returns the number of bytes written.
+  abstract def unbuffered_write(slice : Slice(UInt8))
+
+  # Flushes the wrapped IO.
+  abstract def unbuffered_flush
+
+  # Buffered implementation of `IO#write(slice)`.
+  def write(slice : Slice(UInt8))
+    count = slice.size
+
+    if sync?
+      return unbuffered_write(slice).to_i
+    end
+
+    if flush_on_newline?
+      index = slice[0, count.to_i32].rindex('\n'.ord.to_u8)
+      if index
+        flush
+        index += 1
+        unbuffered_write slice[0, index]
+        slice += index
+        count -= index
+      end
+    end
+
+    if count >= BUFFER_SIZE
+      flush
+      unbuffered_write slice[0, count]
+      return
+    end
+
+    if count > BUFFER_SIZE - @out_count
+      flush
+    end
+
+    slice.copy_to(out_buffer + @out_count, count)
+    @out_count += count
+  end
+
+  # :nodoc:
+  def write_byte(byte : UInt8)
+    if sync?
+      return super
+    end
+
+    if @out_count >= BUFFER_SIZE
+      flush
+    end
+    out_buffer[@out_count] = byte
+    @out_count += 1
+
+    if flush_on_newline? && byte === '\n'
+      flush
+    end
+  end
+
+  # Turns on/off flushing the underlying IO when a newline is written.
+  def flush_on_newline=(flush_on_newline)
+    @flush_on_newline = !!flush_on_newline
+  end
+
+  # Determines if this IO flushes automatically when a newline is written.
+  def flush_on_newline?
+    @flush_on_newline
+  end
+
+  # Turns on/off IO buffering. When `sync` is set to `true`, no buffering
+  # will be done (that is, writing to this IO is immediately synced to the
+  # underlying IO).
+  def sync=(sync)
+    # TODO: maybe instead of `sync=` we should rename this to `buffer=`,
+    # because otherwise you have to think in a reversed way.
+    flush if sync && !@sync
+    @sync = !!sync
+  end
+
+  # Determines if this IO does buffering. If `true`, no buffering is done.
+  def sync?
+    @sync
+  end
+
+  # Flushes any buffered data and the underlying IO.
+  def flush
+    unbuffered_write(Slice.new(out_buffer, @out_count)) if @out_count > 0
+    unbuffered_flush
+    @out_count = 0
+  end
+
+  private def out_buffer
+    @out_buffer ||= GC.malloc_atomic(BUFFER_SIZE.to_u32) as UInt8*
+  end
+end

--- a/src/io/file_descriptor_io.cr
+++ b/src/io/file_descriptor_io.cr
@@ -1,6 +1,11 @@
+require "./buffered/*"
+
 # An IO over a file descriptor.
 class FileDescriptorIO
-  include BufferedIO
+  include IO::Buffered::Common
+  include IO::Buffered::Reader
+  include IO::Buffered::Writer
+  include IO::Buffered::Seeker
 
   private getter! readers
   private getter! writers


### PR DESCRIPTION
This is the first PR in a series for adding type safety to IO methods.  Individual IO's that only support read or write will be of a Reader or Writer class turning runtime errors in to compiler errors.  (STDIN.write won't compile)

There is one still one issue with including modules.  I would like [Reader, Writer, Seeker] to include Common but .close (from Common) stops working when doing so.

Is there a way to include a module once?