### PR TITLE
Benchmark::IPS interactive mode

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -5,7 +5,7 @@ describe Benchmark::IPS::Job do
   it "generally works" do
     # test several things to avoid running a benchmark over and over again in
     # the specs
-    j = Benchmark::IPS::Job.new(0.001, 0.001)
+    j = Benchmark::IPS::Job.new(0.001, 0.001, interactive: false)
     a = j.report("a") { sleep 0.001 }
     b = j.report("b") { sleep 0.002 }
 

--- a/src/benchmark/benchmark.cr
+++ b/src/benchmark/benchmark.cr
@@ -87,9 +87,10 @@ module Benchmark
   #
   # The optional parameters `calculation` and `warmup` set the duration of
   # those stages in seconds. For more detail on these stages see
-  # `Benchmark::IPS`.
-  def ips(calculation = 5, warmup = 2)
-    job = IPS::Job.new(calculation, warmup)
+  # `Benchmark::IPS`. When the `interactive` parameter is true, results are
+  # displayed and updated as they are calculated, otherwise all at once.
+  def ips(calculation = 5, warmup = 2, interactive = STDOUT.tty?)
+    job = IPS::Job.new(calculation, warmup, interactive)
     yield job
     job.execute
     job.report


### PR DESCRIPTION
Shows results as soon as they are available, and updates the terminal as
more information comes in.

On for TTYs by default, but can be manually overridden.

While working on the previous patches, it kinda got annoying not seeing anything for a while. The way this works is a maybe a little too cute with an ANSI control code. I'd understand if that's not appropriate for stdlib (I tried getting something similar into postgres but [Tom Lane did not approve](http://www.postgresql.org/message-id/16791.1365120248@sss.pgh.pa.us)).

But it is kinda neat to watch:

![bmips](https://cloud.githubusercontent.com/assets/1973/9774761/71329dd6-56ff-11e5-9e95-3d419c640ea3.gif)
