### PR TITLE
Remove redundant description in docs

### DIFF
--- a/_gitbook/syntax_and_semantics/inheritance.md
+++ b/_gitbook/syntax_and_semantics/inheritance.md
@@ -84,7 +84,7 @@ e.greet 1 # "Hi, this is a number: 1"
 
 ## super
 
-You can invoke a superclass' method using `super`. Without arguments and without parentheses, all of a method's arguments are forwarded to the parent call:
+You can invoke a superclass' method using `super`:
 
 ```crystal
 class Person


### PR DESCRIPTION
Since in the "Inheritance" section of the docs, there described the same thing about `super`'s spec two times in a row, I've removed the first one.

You can invoke a superclass' method using `super`. **Without arguments and without parentheses, all of a method's arguments are forwarded to the parent call:**

```crystal
class Person
  def greet(msg)
    puts "Hello, "#{msg}"
  end
end

class Employee < Person
  def greet(msg)
    super # Same as: super(msg)
    super("another message")
  end
end
```

**Without arguments nor parenthesis, `super` receives the same arguments as the method's arguments.** Otherwise, it receives the arguments you pass to it.
