### PR TITLE
add TypeCastError for runtime casting exceptions

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -39,7 +39,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from union to single type raises" do
+  it "casts from union to single type raises TypeCastError" do
     run(%(
       require "prelude"
 
@@ -48,7 +48,7 @@ describe "Code gen: cast" do
         a as Char
         false
       rescue ex
-        ex.message == "cast to Char failed"
+        (ex.message == "cast to Char failed") && (ex.class == TypeCastError)
       end
       )).to_b.should be_true
   end
@@ -63,7 +63,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from union to another union raises" do
+  it "casts from union to another union raises TypeCastError" do
     run(%(
       require "prelude"
 
@@ -72,7 +72,7 @@ describe "Code gen: cast" do
         a as Float64 | Char
         false
       rescue ex
-        ex.message == "cast to (Float64 | Char) failed"
+        (ex.message == "cast to (Float64 | Char) failed") && (ex.class == TypeCastError)
       end
       )).to_b.should be_true
   end
@@ -99,7 +99,7 @@ describe "Code gen: cast" do
       )).to_i.should eq(1)
   end
 
-  it "casts from virtual to single type raises" do
+  it "casts from virtual to single type raises TypeCastError" do
     run(%(
       require "prelude"
 
@@ -120,7 +120,7 @@ describe "Code gen: cast" do
         a as CastSpecBaz
         false
       rescue ex
-        ex.message == "cast to CastSpecBaz failed"
+        (ex.message == "cast to CastSpecBaz failed") && (ex.class == TypeCastError)
       end
       )).to_b.should be_true
   end
@@ -178,7 +178,7 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
-  it "casts from nilable to nil raises" do
+  it "casts from nilable to nil raises TypeCastError" do
     run(%(
       require "prelude"
 
@@ -187,7 +187,7 @@ describe "Code gen: cast" do
         a as Nil
         false
       rescue ex
-        ex.message.includes? "cast to Nil failed"
+        (ex.message.includes? "cast to Nil failed") && (ex.class == TypeCastError)
       end
       )).to_b.should be_true
   end
@@ -202,7 +202,7 @@ describe "Code gen: cast" do
       )).to_b.should be_false
   end
 
-  it "casts from nilable to reference raises" do
+  it "casts from nilable to reference raises TypeCastError" do
     run(%(
       require "prelude"
 
@@ -211,7 +211,7 @@ describe "Code gen: cast" do
         a as Reference
         false
       rescue ex
-        ex.message == "cast to Reference failed"
+        (ex.message == "cast to Reference failed") && (ex.class == TypeCastError)
       end
       )).to_b.should be_true
   end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -880,7 +880,9 @@ module Crystal
     end
 
     def type_cast_exception_call(to_type)
-      call = Call.global("raise", StringLiteral.new("cast to #{to_type} failed"))
+      ex = Call.new(Path.global("TypeCastError"), "new", StringLiteral.new("cast to #{to_type} failed"))
+      call = Call.global("raise", ex)
+
       @mod.infer_type_intermediate call
       call
     end

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -157,6 +157,17 @@ class ArgumentError < Exception
   end
 end
 
+# Raised when the type cast failed.
+#
+# ```
+# [1, "hi"][1] as Int32 #=> TypeCastError: cast to Int32 failed
+# ```
+class TypeCastError < Exception
+  def initialize(message = "Type Cast error")
+    super(message)
+  end
+end
+
 class DomainError < Exception
   def initialize(message = "Argument out of domain")
     super(message)


### PR DESCRIPTION
This fixes #1427 I think,

```
crystal ➤ crystal eval '[1,"hi"][1] as Int32'                                                                                                                                                        git:casting-exception
cast to Int32 failed (Exception)
*Exception#initialize<Exception, String, Nil>:Array(String) +14 [4334090974]
*Exception::new<String>:Exception +89 [4334090921]
*raise<String>:NoReturn +6 [4334082534]
__crystal_main +887 [4334082343]
main +32 [4334088720]

crystal ➤ bin/crystal eval '[1,"hi"][1] as Int32' 
Using compiled compiler at .build/crystal
cast to Int32 failed (TypeCastError)
*Exception@Exception#initialize<TypeCastError, String>:Array(String) +33 [4511086529]
*TypeCastError#initialize<TypeCastError, String>:Array(String) +9 [4511086489]
*TypeCastError::new<String>:TypeCastError +84 [4511086452]
__crystal_main +916 [4511055156]
main +32 [4511061760]
```
but I couldn't get specs to work

``` crystal
# tmp/expec.cr
require "spec"
describe "casting" do
   it "has its own exception class for runtime cast errors" do
    expect_raises do #TypeCastError, "cast to Int32 failed" do
      [1, "hi"][1] as Int32
   end
  end
end
```

```
crystal ➤ crystal tmp/exspec.cr
/usr/local/bin/crystal: line 6: 49128 Segmentation fault: 11  "$INSTALL_DIR/embedded/bin/crystal" "$@"

crystal ➤ bin/crystal tmp/exspec.cr 
Using compiled compiler at .build/crystal
Assertion failed: (C->getType()->isPtrOrPtrVectorTy() && "Non-pointer type for constant GetElementPtr expression"), function getGetElementPtr, file /tmp/llvm20150726-78491-1dqz88o/llvm-3.6.2.src/lib/IR/Constants.cpp, li
ne 2005.
[1]    49142 abort      bin/crystal tmp/exspec.cr 
```

