### PR TITLE
Fixed Array[](start : Int, count : Int)

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -162,6 +162,12 @@ describe "Array" do
       end
     end
 
+    it "raises on negative count on empty Array" do
+      expect_raises ArgumentError, /negative count: -1/ do
+        Array(Int32).new[0,-1]
+      end
+    end
+
     it "gets 0, 0 on empty array" do
       a = [] of Int32
       a[0, 0].should eq(a)

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -122,8 +122,23 @@ describe "Array" do
       [1, 2, 3, 4, 5, 6][-5 ... -2].should eq([2, 3, 4])
     end
 
-    it "gets on empty range" do
+    it "gets on range with start higher than end" do
+      [1, 2, 3][2 .. 1].should eq([] of Int32)
       [1, 2, 3][3 .. 1].should eq([] of Int32)
+      expect_raises IndexError do
+        [1, 2, 3][4 .. 1]
+      end
+    end
+
+    it "gets on range with start higher than negative end" do
+      [1, 2, 3][1 .. -1].should eq([2, 3] of Int32)
+      [1, 2, 3][2 .. -2].should eq([] of Int32)
+    end
+
+    it "raises on index out of bounds with range" do
+      expect_raises IndexError do
+        [1, 2, 3][4 .. 6]
+      end
     end
 
     it "gets with start and count" do
@@ -134,11 +149,11 @@ describe "Array" do
       [1, 2, 3][1, 3].should eq([2, 3])
     end
 
-    it "gets with negative start " do
+    it "gets with negative start" do
       [1, 2, 3, 4, 5, 6][-4, 2].should eq([3, 4])
     end
 
-    it "raises on index out of bounds with range" do
+    it "raises on index out of bounds with start and count" do
       expect_raises IndexError do
         [1, 2, 3][4, 0]
       end

--- a/src/array.cr
+++ b/src/array.cr
@@ -404,19 +404,20 @@ class Array(T)
   # a[5, 1] # => []
   # ```
   def [](start : Int, count : Int)
-    if (start == 0 && size == 0) || (start == size && count >= 0)
+    raise ArgumentError.new "negative count: #{count}" if count < 0
+
+    if start == size
       return Array(T).new
     end
 
     start += size if start < 0
     raise IndexError.new unless 0 <= start <= size
-    raise ArgumentError.new "negative count: #{count}" if count < 0
-
-    count = Math.min(count, size - start)
 
     if count == 0
       return Array(T).new
     end
+
+    count = Math.min(count, size - start)
 
     Array(T).build(count) do |buffer|
       buffer.copy_from(@buffer + start, count)


### PR DESCRIPTION
If we try to convert Ruby `nil`s into Crystal exceptions, then `Array(Int32).new[0,-1]` should raise.
This is fixed by moving to the top of method, that simplifes the next line and allows to move one of `return`s higher.