### PR TITLE
Extract build scripts into a shellscript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 sudo: required
 services:
   - docker
@@ -9,39 +9,11 @@ matrix:
     - env: ARCH=x86_64 ARCH_CMD=linux64
       os: linux
     - os: osx
-before_install: |
-  case $TRAVIS_OS_NAME in
-    linux)
-      docker pull jhass/crystal-build-$ARCH
-      ;;
-    osx)
-      brew update
-      brew tap manastech/crystal
-      ;;
-  esac
-install: |
-  case $TRAVIS_OS_NAME in
-    osx)
-      brew install gmp libevent crystal-lang
-      curl "http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-darwin-x86_64.tar.gz" | tar xz -C /tmp
-      export LIBRARY_PATH="/usr/local/opt/crystal-lang/embedded/lib"
-      export PATH="/tmp/llvm-3.5.0-1/bin:$PATH"
-      ;;
-  esac
-script: |
-  set -e
-  case $TRAVIS_OS_NAME in
-    linux)
-      docker run -v $(pwd):/mnt -w /mnt jhass/crystal-build-$ARCH $ARCH_CMD make crystal spec CRYSTAL_CONFIG_VERSION="ci" LIBRARY_PATH="/opt/crystal/embedded/lib/"
-      docker run -v $(pwd):/mnt -w /mnt jhass/crystal-build-$ARCH $ARCH_CMD /bin/bash -c 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen' CRYSTAL_CONFIG_VERSION="ci" LIBRARY_PATH="/opt/crystal/embedded/lib/"
-      ;;
-    osx)
-      export CRYSTAL_CONFIG_VERSION="ci"
-      export CRYSTAL_CACHE_DIR="/tmp/crystal"
-      make crystal spec
-      find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen
-      ;;
-  esac
+before_install: bin/ci prepare_system
+install: bin/ci prepare_build
+script:
+  - bin/ci with_build_env 'make crystal spec'
+  - bin/ci with_build_env 'find samples -name "*.cr" | xargs -L 1 ./bin/crystal build --no-codegen'
 branches:
   only:
     - master

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+fail() {
+  echo "${@}" >&2
+  exit 1
+}
+
+fail_on_error() {
+  "${@}"
+
+  exit=$?
+  if [ "$exit" -ne "0" ]; then
+    fail "${@} exited with $exit"
+  fi
+
+  return 0
+}
+
+verify_environment() {
+  if [ -z "$TRAVIS_OS_NAME" ]; then
+    fail "\$TRAVIS_OS_NAME is not set or empty."
+  fi
+}
+
+verify_linux_environment() {
+  if [ -z "$ARCH" ]; then
+    fail "\$ARCH is not set or empty."
+  fi
+
+  if [ -z "$ARCH_CMD" ]; then
+    fail "\$ARCH_CMD is not set or empty."
+  fi
+}
+
+on_os() {
+  os="$1"
+  shift
+
+  verify_environment
+
+  if [ "$TRAVIS_OS_NAME" = "$os" ]; then
+    echo "${@}"
+    eval "${@}"
+    return $?
+  else
+    return 0
+  fi
+}
+
+on_linux() {
+  fail_on_error on_os "linux" "${@}"
+}
+
+on_osx() {
+  fail_on_error on_os "osx" "${@}"
+}
+
+prepare_system() {
+  on_osx brew update
+  on_osx brew tap manastech/crystal
+}
+
+prepare_build() {
+  on_linux verify_linux_environment
+
+  on_linux docker pull "jhass/crystal-build-$ARCH"
+
+  on_osx brew install gmp libevent crystal-lang
+  on_osx /bin/bash -c "'curl \"http://crystal-lang.s3.amazonaws.com/llvm/llvm-3.5.0-1-darwin-x86_64.tar.gz\" | tar xz -C /tmp'"
+}
+
+with_build_env() {
+  command="$1"
+
+  on_linux verify_linux_environment
+  on_linux docker run \
+    --rm \
+    -u $(id -u) \
+    -v $(pwd):/mnt \
+    -w /mnt \
+    -e LIBRARY_PATH="/opt/crystal/embedded/lib/" \
+    -e CRYSTAL_CONFIG_VERSION="ci" \
+    "jhass/crystal-build-$ARCH" \
+    "$ARCH_CMD" /bin/bash -c "'$command'"
+
+  on_osx LIBRARY_PATH="/usr/local/opt/crystal-lang/embedded/lib" \
+    PATH="/tmp/llvm-3.5.0-1/bin:\$PATH" \
+    CRYSTAL_CONFIG_VERSION="ci" \
+    CRYSTAL_CACHE_DIR="/tmp/crystal" \
+    /bin/bash -c "'$command'"
+
+}
+
+usage() {
+  echo -e "bin/ci [-h|--help] command [parameter ...]"
+  echo -e ""
+  echo -e "Helper script to prepare and run the testsuite on Travis CI."
+  echo -e ""
+  echo -e "Commands:"
+  echo -e "  prepare_system          setup any necessaries repositories etc."
+  echo -e "  prepare_build           download and extract any dependencies needed for the build"
+  echo -e "  with_build_env command  run command in the build environment"
+  echo -e "  help                    display this"
+  echo -e ""
+}
+
+command="$1"
+shift
+case $command in
+  prepare_system)
+    prepare_system
+    ;;
+  prepare_build)
+    prepare_build
+    ;;
+  with_build_env)
+    target_command="${@}"
+    with_build_env "$target_command"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    if [ -n "$command" ]; then
+      fail "Unknown command $command"
+    else
+      usage
+      exit 1
+    fi
+    ;;
+esac

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -318,9 +318,9 @@ describe "File" do
 
     it "converts a pathname to an absolute pathname, using ~ (home) as base" do
       File.expand_path("~/").should eq(home)
-      File.expand_path("~/..badfilename").should eq("#{home}/..badfilename")
+      File.expand_path("~/..badfilename").should eq(File.join(home, "..badfilename"))
       File.expand_path("..").should eq("/#{base.split("/")[0...-1].join("/")}".gsub(%r{\A//}, "/"))
-      File.expand_path("~/a","~/b").should eq("#{home}/a")
+      File.expand_path("~/a","~/b").should eq(File.join(home, "a"))
       File.expand_path("~").should eq(home)
       File.expand_path("~", "/tmp/gumby/ddd").should eq(home)
       File.expand_path("~/a", "/tmp/gumby/ddd").should eq(File.join([home, "a"]))


### PR DESCRIPTION
* Easier comprehension of the actual build step since this allows building a small "DSL" and syntax highlighting.
* Clear way to fail the build
* DRY up OS selection
* Better introspectable  build due to:
  * Added environment sanity checks
  * Less crowded command executions in .travis.yml
* DRY up command invocation in .travis.yml -> allows to split up build steps and thus get informed about failures in later steps if the previous one fails, easier to expand.
* Fix build, I guess as a side effect of adding `-u $(id -u)` to the docker run command, though I didn't verify it's that or something else.