### PR TITLE
HTTP::Headers: Preserve input case, indifferent access between - and _

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -12,6 +12,23 @@ describe HTTP::Headers do
     headers["foo"].should eq("bar")
   end
 
+  it "it allows indifferent access for underscore and dash separated keys" do
+    headers = HTTP::Headers{"foo_Bar": "bar", "Foobar-foo": "baz"}
+    headers["foo-bar"].should eq("bar")
+    headers["foobar_foo"].should eq("baz")
+  end
+
+  it "should retain the input casing" do
+    headers = HTTP::Headers{"FOO_BAR": "bar", "Foobar-foo": "baz"}
+    serialized = String.build do |io|
+      headers.each do |name, values|
+        io << name << ": " << values.first << ";"
+      end
+    end
+
+    serialized.should eq("FOO_BAR: bar;Foobar-foo: baz;")
+  end
+
   it "is gets with []?" do
     headers = HTTP::Headers.new
     headers["foo"]?.should be_nil
@@ -35,7 +52,7 @@ describe HTTP::Headers do
 
   it "fetches with block" do
     headers = HTTP::Headers.new
-    headers.fetch("foo") { |k| "#{k}baz" }.should eq("Foobaz")
+    headers.fetch("foo") { |k| "#{k}baz" }.should eq("foobaz")
 
     headers["Foo"] = "bar"
     headers.fetch("foo") { "baz" }.should eq("bar")
@@ -101,7 +118,7 @@ describe HTTP::Headers do
   end
 
   it "does to_s" do
-    headers = HTTP::Headers{"foo": "bar", "baz": ["a", "b"]}
-    headers.to_s.should eq(%(HTTP::Headers{"Foo" => "bar", "Baz" => ["a", "b"]}))
+    headers = HTTP::Headers{"Foo_quux": "bar", "Baz-Quux": ["a", "b"]}
+    headers.to_s.should eq(%(HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}))
   end
 end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -17,7 +17,7 @@ module HTTP
       request = Request.new "POST", "/", body: "thisisthebody"
       io = StringIO.new
       request.to_io(io)
-      io.to_s.should eq("POST / HTTP/1.1\r\nContent-length: 13\r\n\r\nthisisthebody")
+      io.to_s.should eq("POST / HTTP/1.1\r\nContent-Length: 13\r\n\r\nthisisthebody")
     end
 
     it "parses GET" do

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -105,7 +105,7 @@ module HTTP
       response = Response.new(200, "hello", headers)
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nhello")
+      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello")
     end
 
     it "sets content length from body" do
@@ -117,21 +117,21 @@ module HTTP
       response = Response.not_found
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 404 Not Found\r\nContent-type: text/plain\r\nContent-length: 9\r\n\r\nNot Found")
+      io.to_s.should eq("HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\nNot Found")
     end
 
     it "builds default ok response" do
       response = Response.ok("text/plain", "Hello")
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-type: text/plain\r\nContent-length: 5\r\n\r\nHello")
+      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nHello")
     end
 
     it "builds default error response" do
       response = Response.error("text/plain", "Error!")
       io = StringIO.new
       response.to_io(io)
-      io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-type: text/plain\r\nContent-length: 6\r\n\r\nError!")
+      io.to_s.should eq("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\nContent-Length: 6\r\n\r\nError!")
     end
   end
 end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -21,6 +21,8 @@ struct HTTP::Headers
       cstr2 = key2.to_unsafe
 
       key1.bytesize.times do |i|
+        next if cstr1[i] == cstr2[i] # Optimize the common case
+
         byte1 = normalize_byte(cstr1[i])
         byte2 = normalize_byte(cstr2[i])
 
@@ -29,13 +31,13 @@ struct HTTP::Headers
     end
 
     private def normalize_byte(byte)
-      if 'A' <= byte.chr <= 'Z'
-        byte + 32
-      elsif char == '_'
-        '-'.ord
-      else
-        byte
-      end
+      char = byte.chr
+
+      return byte if 'a' <= char <= 'z' || char == '-' # Optimize the common case
+      return byte + 32 if 'A' <= char <= 'Z'
+      return '-'.ord if char == '_'
+
+      byte
     end
   end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -10,9 +10,9 @@ class HTTP::Request
 
   def initialize(@method : String, @path, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
     if body = @body
-      @headers["Content-length"] = body.bytesize.to_s
+      @headers["Content-Length"] = body.bytesize.to_s
     elsif @method == "POST" || @method == "PUT"
-      @headers["Content-length"] = "0"
+      @headers["Content-Length"] = "0"
     end
   end
 

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -20,7 +20,7 @@ class HTTP::Response
     end
 
     if (body = @body)
-      @headers["Content-length"] = body.bytesize.to_s
+      @headers["Content-Length"] = body.bytesize.to_s
     end
   end
 
@@ -37,26 +37,26 @@ class HTTP::Response
   end
 
   def self.not_found
-    new(404, "Not Found", Headers{"Content-type": "text/plain"})
+    new(404, "Not Found", Headers{"Content-Type": "text/plain"})
   end
 
   def self.ok(content_type, body)
-    new(200, body, Headers{"Content-type": content_type})
+    new(200, body, Headers{"Content-Type": content_type})
   end
 
   def self.error(content_type, body)
-    new(500, body, Headers{"Content-type": content_type})
+    new(500, body, Headers{"Content-Type": content_type})
   end
 
   def self.unauthorized
-    new(401, "Unauthorized", Headers{"Content-type": "text/plain"})
+    new(401, "Unauthorized", Headers{"Content-Type": "text/plain"})
   end
 
   def to_io(io)
     io << @version << " " << @status_code << " " << @status_message << "\r\n"
     HTTP.serialize_headers_and_body(io, @headers, @body)
   end
-  
+
   # :nodoc:
   def consume_body_io
     if io = @body_io
@@ -64,7 +64,7 @@ class HTTP::Response
       @body_io = nil
     end
   end
-  
+
   def self.mandatory_body?(status_code)
     !(status_code / 100 == 1 || status_code == 204 || status_code == 304)
   end


### PR DESCRIPTION
Alternative to #1416

After some optimizations this is almost as fast as #1416 for the common case (storing and accessing `Content-Length`), faster for most other cases and faster than master for any case.

Semantic change: this will merge together headers with the same name that only differ in using `-` vs `_`. Technically these are separate headers, in practice you want indifferent access to both. So the first one appearing will win when it comes to serialization.

Some benchmarks, HeadersMaster is master, HeadersPR is #1416 and HeadersCompare is this PR:

```
Insert Content-Type
 HeadersMaster   1.69M (±15.98%)  1.80× slower
     HeadersPR   2.86M (±17.39%)  1.07× slower
HeadersCompare   3.05M (±19.56%)       fastest
Insert CONTENT-TYPE
 HeadersMaster   1.64M (±19.13%)  1.69× slower
     HeadersPR  520.1k (±23.25%)  5.36× slower
HeadersCompare   2.79M (±18.50%)       fastest
Insert content-type
 HeadersMaster   1.69M (±19.76%)  1.96× slower
     HeadersPR 541.97k (±23.87%)  6.10× slower
HeadersCompare    3.3M (±11.60%)       fastest
Insert Content_Type
 HeadersMaster   1.64M (±16.44%)  1.82× slower
     HeadersPR  553.5k (±19.05%)  5.39× slower
HeadersCompare   2.98M (±18.69%)       fastest
Insert CONTENT_TYPE
 HeadersMaster    1.7M (±14.48%)  1.68× slower
     HeadersPR 574.98k (±16.87%)  4.97× slower
HeadersCompare   2.86M (±21.54%)       fastest
Insert content_type
 HeadersMaster   1.57M (±21.02%)  1.99× slower
     HeadersPR 525.31k (±22.99%)  5.95× slower
HeadersCompare   3.13M (±16.99%)       fastest
Fetch CONTENT-TYPE from HTTP::Headers { "Content-Type" => "bar" }
 HeadersMaster   2.73M (±19.17%)  3.65× slower
     HeadersPR 595.94k (±22.36%) 16.69× slower
HeadersCompare   9.95M (± 5.72%)       fastest
Fetch content-type from HTTP::Headers { "Content-Type" => "bar" }
 HeadersMaster    2.7M (±17.70%)  6.49× slower
     HeadersPR 568.19k (±26.63%) 30.89× slower
HeadersCompare  17.55M (± 3.47%)       fastest
Fetch Content_Type from HTTP::Headers { "Content-Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 638.53k (±20.03%) 27.82× slower
HeadersCompare  17.77M (± 3.57%)       fastest
Fetch CONTENT_TYPE from HTTP::Headers { "Content-Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 625.43k (±22.81%) 14.99× slower
HeadersCompare   9.38M (± 4.55%)       fastest
Fetch content_type from HTTP::Headers { "Content-Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 656.86k (±22.21%) 24.08× slower
HeadersCompare  15.82M (± 2.70%)       fastest
Fetch Content-Type from HTTP::Headers { "Content-Type" => "bar" }
 HeadersMaster   2.36M (±25.62%)  8.11× slower
     HeadersPR   17.9M (± 4.50%)  1.07× slower
HeadersCompare  19.12M (± 3.13%)       fastest
Fetch Content-Type from HTTP::Headers { "CONTENT-TYPE" => "bar" }
 HeadersMaster   2.74M (±16.89%)  6.25× slower
     HeadersPR  17.11M (± 4.30%)       fastest
HeadersCompare  11.17M (± 3.40%)  1.53× slower
Fetch content-type from HTTP::Headers { "CONTENT-TYPE" => "bar" }
 HeadersMaster   2.61M (±17.26%)  3.94× slower
     HeadersPR 696.65k (±16.09%) 14.75× slower
HeadersCompare  10.28M (± 3.33%)       fastest
Fetch Content_Type from HTTP::Headers { "CONTENT-TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 660.81k (±18.19%) 15.53× slower
HeadersCompare  10.27M (± 4.13%)       fastest
Fetch CONTENT_TYPE from HTTP::Headers { "CONTENT-TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 610.72k (±25.72%) 24.76× slower
HeadersCompare  15.12M (± 4.79%)       fastest
Fetch content_type from HTTP::Headers { "CONTENT-TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 640.09k (±23.64%) 14.93× slower
HeadersCompare   9.55M (± 3.54%)       fastest
Fetch CONTENT-TYPE from HTTP::Headers { "CONTENT-TYPE" => "bar" }
 HeadersMaster    2.4M (±17.67%)  7.00× slower
     HeadersPR 665.95k (±19.07%) 25.24× slower
HeadersCompare  16.81M (± 3.66%)       fastest
Fetch Content-Type from HTTP::Headers { "content-type" => "bar" }
 HeadersMaster   2.41M (±24.80%)  7.20× slower
     HeadersPR  17.38M (± 3.14%)       fastest
HeadersCompare  16.96M (± 5.75%)  1.02× slower
Fetch CONTENT-TYPE from HTTP::Headers { "content-type" => "bar" }
 HeadersMaster   2.59M (±23.16%)  3.54× slower
     HeadersPR 685.06k (±17.83%) 13.40× slower
HeadersCompare   9.18M (± 2.92%)       fastest
Fetch Content_Type from HTTP::Headers { "content-type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 630.89k (±21.09%) 24.02× slower
HeadersCompare  15.15M (± 4.31%)       fastest
Fetch CONTENT_TYPE from HTTP::Headers { "content-type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 666.46k (±18.70%) 12.80× slower
HeadersCompare   8.53M (± 4.33%)       fastest
Fetch content_type from HTTP::Headers { "content-type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 611.24k (±22.82%) 30.00× slower
HeadersCompare  18.34M (± 3.92%)       fastest
Fetch content-type from HTTP::Headers { "content-type" => "bar" }
 HeadersMaster   2.65M (±19.22%)  7.31× slower
     HeadersPR 691.26k (±16.60%) 28.01× slower
HeadersCompare  19.36M (± 6.91%)       fastest
Fetch Content-Type from HTTP::Headers { "Content_Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR  17.26M (± 3.47%)  1.06× slower
HeadersCompare  18.22M (± 3.08%)       fastest
Fetch CONTENT-TYPE from HTTP::Headers { "Content_Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 719.83k (±11.05%) 12.79× slower
HeadersCompare    9.2M (± 2.35%)       fastest
Fetch content-type from HTTP::Headers { "Content_Type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 693.31k (±17.06%) 22.84× slower
HeadersCompare  15.84M (± 3.39%)       fastest
Fetch CONTENT_TYPE from HTTP::Headers { "Content_Type" => "bar" }
 HeadersMaster   2.75M (±19.25%)  3.59× slower
     HeadersPR 656.32k (±18.94%) 15.01× slower
HeadersCompare   9.85M (± 5.09%)       fastest
Fetch content_type from HTTP::Headers { "Content_Type" => "bar" }
 HeadersMaster   2.79M (±18.51%)  6.12× slower
     HeadersPR 655.18k (±15.97%) 26.04× slower
HeadersCompare  17.06M (± 4.36%)       fastest
Fetch Content_Type from HTTP::Headers { "Content_Type" => "bar" }
 HeadersMaster   2.39M (±21.84%)  7.87× slower
     HeadersPR 678.44k (±14.05%) 27.71× slower
HeadersCompare   18.8M (± 5.55%)       fastest
Fetch Content-Type from HTTP::Headers { "CONTENT_TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR  17.67M (± 2.19%)       fastest
HeadersCompare   10.8M (± 2.54%)  1.64× slower
Fetch CONTENT-TYPE from HTTP::Headers { "CONTENT_TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 606.86k (±21.74%) 25.93× slower
HeadersCompare  15.74M (± 3.14%)       fastest
Fetch content-type from HTTP::Headers { "CONTENT_TYPE" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 641.74k (±20.19%) 15.20× slower
HeadersCompare   9.75M (± 3.29%)       fastest
Fetch Content_Type from HTTP::Headers { "CONTENT_TYPE" => "bar" }
 HeadersMaster   2.53M (±17.29%)  4.32× slower
     HeadersPR 668.01k (±16.83%) 16.33× slower
HeadersCompare  10.91M (± 6.77%)       fastest

Fetch content_type from HTTP::Headers { "CONTENT_TYPE" => "bar" }
 HeadersMaster   2.57M (±22.43%)  3.94× slower
     HeadersPR 649.41k (±19.81%) 15.56× slower
HeadersCompare  10.11M (± 4.76%)       fastest

Fetch CONTENT_TYPE from HTTP::Headers { "CONTENT_TYPE" => "bar" }
 HeadersMaster   2.58M (±20.48%)  6.49× slower
     HeadersPR 634.95k (±21.47%) 26.41× slower
HeadersCompare  16.77M (± 3.19%)       fastest

Fetch Content-Type from HTTP::Headers { "content_type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR  17.48M (± 3.07%)       fastest
HeadersCompare  15.76M (± 2.91%)  1.11× slower

Fetch CONTENT-TYPE from HTTP::Headers { "content_type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 538.37k (±21.44%) 16.39× slower
HeadersCompare   8.82M (± 3.97%)       fastest

Fetch content-type from HTTP::Headers { "content_type" => "bar" }
Unsupported by HeadersMaster
     HeadersPR 661.04k (±16.49%) 28.77× slower
HeadersCompare  19.02M (± 3.02%)       fastest

Fetch Content_Type from HTTP::Headers { "content_type" => "bar" }
 HeadersMaster   2.28M (±25.69%)  7.51× slower
     HeadersPR 526.65k (±25.17%) 32.44× slower
HeadersCompare  17.08M (± 3.43%)       fastest

Fetch CONTENT_TYPE from HTTP::Headers { "content_type" => "bar" }
 HeadersMaster   2.44M (±20.55%)  3.78× slower
     HeadersPR 597.78k (±24.74%) 15.45× slower
HeadersCompare   9.24M (± 4.77%)       fastest

Fetch content_type from HTTP::Headers { "content_type" => "bar" }
 HeadersMaster   2.42M (±23.68%)  7.92× slower
     HeadersPR 659.33k (±16.96%) 29.10× slower
HeadersCompare  19.19M (± 6.30%)       fastest