### PR TITLE
Rename the cast class method to new

### DIFF
--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -167,7 +167,7 @@ describe "Code gen: fun" do
       end
 
       ary = [3, 1, 4, 2]
-      LibC.qsort((ary.buffer as Void*), LibC::SizeT.cast(ary.size), LibC::SizeT.cast(sizeof(Int32)), ->(a : Void*, b : Void*) {
+      LibC.qsort((ary.buffer as Void*), LibC::SizeT.new(ary.size), LibC::SizeT.new(sizeof(Int32)), ->(a : Void*, b : Void*) {
         a = a as Int32*
         b = b as Int32*
         a.value <=> b.value

--- a/spec/std/big_int_spec.cr
+++ b/spec/std/big_int_spec.cr
@@ -152,16 +152,6 @@ describe "BigInt" do
     a.to_s(32).should eq(d)
   end
 
-  it "casts other ints and strings" do
-    a = BigInt.new(123456)
-    b = BigInt.cast(123456)
-    a.should eq(b)
-
-    a = BigInt.new("123456789012345678901234567890")
-    b = BigInt.cast("123456789012345678901234567890")
-    a.should eq(b)
-  end
-
   it "can use Number::[]" do
     a = BigInt[146, "3464", 97, "545"]
     b = [BigInt.new(146), BigInt.new(3464), BigInt.new(97), BigInt.new(545)]

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -95,11 +95,11 @@ describe "Float" do
   end
 
   it "casts" do
-    Float32.cast(1_f64).should be_a(Float32)
-    Float32.cast(1_f64).should eq(1)
+    Float32.new(1_f64).should be_a(Float32)
+    Float32.new(1_f64).should eq(1)
 
-    Float64.cast(1_f32).should be_a(Float64)
-    Float64.cast(1_f32).should eq(1)
+    Float64.new(1_f32).should be_a(Float64)
+    Float64.new(1_f32).should eq(1)
   end
 
   it "does nan?" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -242,29 +242,29 @@ describe "Int" do
   end
 
   it "casts" do
-    Int8.cast(1).should be_a(Int8)
-    Int8.cast(1).should eq(1)
+    Int8.new(1).should be_a(Int8)
+    Int8.new(1).should eq(1)
 
-    Int16.cast(1).should be_a(Int16)
-    Int16.cast(1).should eq(1)
+    Int16.new(1).should be_a(Int16)
+    Int16.new(1).should eq(1)
 
-    Int32.cast(1).should be_a(Int32)
-    Int32.cast(1).should eq(1)
+    Int32.new(1).should be_a(Int32)
+    Int32.new(1).should eq(1)
 
-    Int64.cast(1).should be_a(Int64)
-    Int64.cast(1).should eq(1)
+    Int64.new(1).should be_a(Int64)
+    Int64.new(1).should eq(1)
 
-    UInt8.cast(1).should be_a(UInt8)
-    UInt8.cast(1).should eq(1)
+    UInt8.new(1).should be_a(UInt8)
+    UInt8.new(1).should eq(1)
 
-    UInt16.cast(1).should be_a(UInt16)
-    UInt16.cast(1).should eq(1)
+    UInt16.new(1).should be_a(UInt16)
+    UInt16.new(1).should eq(1)
 
-    UInt32.cast(1).should be_a(UInt32)
-    UInt32.cast(1).should eq(1)
+    UInt32.new(1).should be_a(UInt32)
+    UInt32.new(1).should eq(1)
 
-    UInt64.cast(1).should be_a(UInt64)
-    UInt64.cast(1).should eq(1)
+    UInt64.new(1).should be_a(UInt64)
+    UInt64.new(1).should eq(1)
   end
 
   it "raises when divides by zero" do

--- a/src/big_int/big_int.cr
+++ b/src/big_int/big_int.cr
@@ -15,7 +15,7 @@ struct BigInt < Int
 
   def initialize(num : SignedInt)
     if LibC::Long::MIN <= num <= LibC::Long::MAX
-      LibGMP.init_set_si(out @mpz, LibC::Long.cast(num))
+      LibGMP.init_set_si(out @mpz, LibC::Long.new(num))
     else
       LibGMP.init_set_str(out @mpz, num.to_s, 10)
     end
@@ -23,7 +23,7 @@ struct BigInt < Int
 
   def initialize(num : UnsignedInt)
     if num <= LibC::ULong::MAX
-      LibGMP.init_set_ui(out @mpz, LibC::ULong.cast(num))
+      LibGMP.init_set_ui(out @mpz, LibC::ULong.new(num))
     else
       LibGMP.init_set_str(out @mpz, num.to_s, 10)
     end
@@ -38,17 +38,13 @@ struct BigInt < Int
     new(mpz)
   end
 
-  def self.cast(value)
-    value.to_big_i
-  end
-
   def <=>(other : BigInt)
     LibGMP.cmp(mpz, other)
   end
 
   def <=>(other : SignedInt)
     if LibC::Long::MIN <= other <= LibC::Long::MAX
-      LibGMP.cmp_si(mpz, LibC::Long.cast(other))
+      LibGMP.cmp_si(mpz, LibC::Long.new(other))
     else
       self <=> BigInt.new(other)
     end
@@ -56,7 +52,7 @@ struct BigInt < Int
 
   def <=>(other : UnsignedInt)
     if other <= LibC::ULong::MAX
-      LibGMP.cmp_ui(mpz, LibC::ULong.cast(other))
+      LibGMP.cmp_ui(mpz, LibC::ULong.new(other))
     else
       self <=> BigInt.new(other)
     end
@@ -70,7 +66,7 @@ struct BigInt < Int
     if other < 0
       self - other.abs
     else
-      BigInt.new { |mpz| LibGMP.add_ui(mpz, self, LibC::ULong.cast(other)) }
+      BigInt.new { |mpz| LibGMP.add_ui(mpz, self, LibC::ULong.new(other)) }
     end
   end
 
@@ -82,7 +78,7 @@ struct BigInt < Int
     if other < 0
       self + other.abs
     else
-      BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, LibC::ULong.cast(other)) }
+      BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, LibC::ULong.new(other)) }
     end
   end
 
@@ -99,11 +95,11 @@ struct BigInt < Int
   end
 
   def *(other : SignedInt)
-    BigInt.new { |mpz| LibGMP.mul_si(mpz, self, LibC::Long.cast(other)) }
+    BigInt.new { |mpz| LibGMP.mul_si(mpz, self, LibC::Long.new(other)) }
   end
 
   def *(other : UnsignedInt)
-    BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, LibC::ULong.cast(other)) }
+    BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, LibC::ULong.new(other)) }
   end
 
   def /(other : BigInt)
@@ -118,7 +114,7 @@ struct BigInt < Int
     if other < 0
       -(self / other.abs)
     else
-      BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, LibC::ULong.cast(other)) }
+      BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, LibC::ULong.new(other)) }
     end
   end
 
@@ -131,7 +127,7 @@ struct BigInt < Int
   def %(other : Int)
     check_division_by_zero other
 
-    BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, LibC::ULong.cast(other.abs)) }
+    BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, LibC::ULong.new(other.abs)) }
   end
 
   def ~
@@ -151,11 +147,11 @@ struct BigInt < Int
   end
 
   def >>(other : Int)
-    BigInt.new { |mpz| LibGMP.fdiv_q_2exp(mpz, self, LibGMP::BitcntT.cast(other)) }
+    BigInt.new { |mpz| LibGMP.fdiv_q_2exp(mpz, self, LibGMP::BitcntT.new(other)) }
   end
 
   def <<(other : Int)
-    BigInt.new { |mpz| LibGMP.mul_2exp(mpz, self, LibGMP::BitcntT.cast(other)) }
+    BigInt.new { |mpz| LibGMP.mul_2exp(mpz, self, LibGMP::BitcntT.new(other)) }
   end
 
   def inspect

--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -64,7 +64,7 @@ class Scheduler
 
   def self.create_signal_event signal : Signal, chan
     flags = LibEvent2::EventFlags::Signal | LibEvent2::EventFlags::Persist
-    event = @@eb.new_event(Int32.cast(signal.to_i), flags, chan) do |s, flags, data|
+    event = @@eb.new_event(Int32.new(signal.to_i), flags, chan) do |s, flags, data|
       ch = data as BufferedChannel(Signal)
       sig = Signal.new(s)
       ch.send sig

--- a/src/curses/window.cr
+++ b/src/curses/window.cr
@@ -7,7 +7,7 @@ struct Curses::Window
   end
 
   def box(vert : Char, hor : Char)
-    LibCurses.box self, LibCurses::Chtype.cast(vert.ord), LibCurses::Chtype.cast(hor.ord)
+    LibCurses.box self, LibCurses::Chtype.new(vert.ord), LibCurses::Chtype.new(hor.ord)
   end
 
   def setpos(x, y)

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -292,7 +292,7 @@ class Dir
   end
 
   def self.mkdir(path, mode=0o777)
-    if LibC.mkdir(path, LibC::ModeT.cast(mode)) == -1
+    if LibC.mkdir(path, LibC::ModeT.new(mode)) == -1
       raise Errno.new("Unable to create directory '#{path}'")
     end
     0

--- a/src/event/event.cr
+++ b/src/event/event.cr
@@ -38,16 +38,16 @@ module Event
 
     private def to_timeval(time : Int)
       t :: LibC::TimeVal
-      t.tv_sec = typeof(t.tv_sec).cast(time)
-      t.tv_usec = typeof(t.tv_usec).cast(0)
+      t.tv_sec = typeof(t.tv_sec).new(time)
+      t.tv_usec = typeof(t.tv_usec).new(0)
       t
     end
 
     private def to_timeval(time : Float)
       t :: LibC::TimeVal
 
-      seconds = typeof(t.tv_sec).cast(time)
-      useconds = typeof(t.tv_usec).cast((time - seconds) * 1e6)
+      seconds = typeof(t.tv_sec).new(time)
+      useconds = typeof(t.tv_usec).new((time - seconds) * 1e6)
 
       t.tv_sec = seconds
       t.tv_usec = useconds

--- a/src/fiber/fiber.cr
+++ b/src/fiber/fiber.cr
@@ -45,10 +45,10 @@ class Fiber
   end
 
   protected def self.allocate_stack
-    @@stack_pool.pop? || LibC.mmap(nil, LibC::SizeT.cast(Fiber::STACK_SIZE),
+    @@stack_pool.pop? || LibC.mmap(nil, LibC::SizeT.new(Fiber::STACK_SIZE),
       LibC::PROT_READ | LibC::PROT_WRITE,
       LibC::MAP_PRIVATE | LibC::MAP_ANON,
-      -1, LibC::SSizeT.cast(0)).tap do |pointer|
+      -1, LibC::SSizeT.new(0)).tap do |pointer|
         raise Errno.new("Cannot allocate new fiber stack") if pointer == LibC::MAP_FAILED
       end
   end
@@ -58,7 +58,7 @@ class Fiber
     free_count = @@stack_pool.size > 1 ? @@stack_pool.size / 2 : 1
     free_count.times do
       stack = @@stack_pool.pop
-      LibC.munmap(stack, LibC::SizeT.cast(Fiber::STACK_SIZE))
+      LibC.munmap(stack, LibC::SizeT.new(Fiber::STACK_SIZE))
     end
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -88,7 +88,7 @@ class File < FileDescriptorIO
     check_open
 
     flush
-    seek_value = LibC.lseek(@fd, LibC::OffT.cast(offset), whence.to_i)
+    seek_value = LibC.lseek(@fd, LibC::OffT.new(offset), whence.to_i)
     if seek_value == -1
       raise Errno.new "Unable to seek"
     end

--- a/src/float.cr
+++ b/src/float.cr
@@ -169,7 +169,7 @@ struct Float64
 
   def to_s
     String.new(22) do |buffer|
-      LibC.snprintf(buffer, LibC::SizeT.cast(22), "%g", self)
+      LibC.snprintf(buffer, LibC::SizeT.new(22), "%g", self)
       len = LibC.strlen(buffer)
       {len, len}
     end
@@ -177,7 +177,7 @@ struct Float64
 
   def to_s(io : IO)
     chars = StaticArray(UInt8, 22).new(0_u8)
-    LibC.snprintf(chars, LibC::SizeT.cast(22), "%g", self)
+    LibC.snprintf(chars, LibC::SizeT.new(22), "%g", self)
     io.write chars.to_slice[0, LibC.strlen(chars.buffer).to_i]
   end
 

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -45,17 +45,17 @@ end
 
 # :nodoc:
 fun __crystal_malloc(size : UInt32) : Void*
-  LibGC.malloc(LibC::SizeT.cast(size))
+  LibGC.malloc(LibC::SizeT.new(size))
 end
 
 # :nodoc:
 fun __crystal_malloc_atomic(size : UInt32) : Void*
-  LibGC.malloc_atomic(LibC::SizeT.cast(size))
+  LibGC.malloc_atomic(LibC::SizeT.new(size))
 end
 
 # :nodoc:
 fun __crystal_realloc(ptr : Void*, size : UInt32) : Void*
-  LibGC.realloc(ptr, LibC::SizeT.cast(size))
+  LibGC.realloc(ptr, LibC::SizeT.new(size))
 end
 
 module GC

--- a/src/gc/null.cr
+++ b/src/gc/null.cr
@@ -1,16 +1,16 @@
 # :nodoc:
 fun __crystal_malloc(size : UInt32) : Void*
-  LibC.malloc(LibC::SizeT.cast(size))
+  LibC.malloc(LibC::SizeT.new(size))
 end
 
 # :nodoc:
 fun __crystal_malloc_atomic(size : UInt32) : Void*
-  LibC.malloc(LibC::SizeT.cast(size))
+  LibC.malloc(LibC::SizeT.new(size))
 end
 
 # :nodoc:
 fun __crystal_realloc(ptr : Void*, size : UInt32) : Void*
-  LibC.realloc(ptr, LibC::SizeT.cast(size))
+  LibC.realloc(ptr, LibC::SizeT.new(size))
 end
 
 module GC

--- a/src/io.cr
+++ b/src/io.cr
@@ -160,7 +160,7 @@ module IO
     error_fdset = FdSet.from_ios(error_ios)
 
     if timeout_sec
-      sec = LibC::TimeT.cast(timeout_sec)
+      sec = LibC::TimeT.new(timeout_sec)
 
       if timeout_sec.is_a? Float
         usec = (timeout_sec-sec) * 10e6
@@ -170,7 +170,7 @@ module IO
 
       timeout = LibC::TimeVal.new
       timeout.tv_sec = sec
-      timeout.tv_usec = LibC::UsecT.cast(usec)
+      timeout.tv_usec = LibC::UsecT.new(usec)
       timeout_ptr = pointerof(timeout)
     else
       timeout_ptr = Pointer(LibC::TimeVal).null

--- a/src/io/file_descriptor_io.cr
+++ b/src/io/file_descriptor_io.cr
@@ -153,7 +153,7 @@ class FileDescriptorIO
   private def unbuffered_read(slice : Slice(UInt8))
     count = slice.size
     loop do
-      bytes_read = LibC.read(@fd, slice.pointer(count), LibC::SizeT.cast(count))
+      bytes_read = LibC.read(@fd, slice.pointer(count), LibC::SizeT.new(count))
       if bytes_read != -1
         return bytes_read
       end
@@ -172,7 +172,7 @@ class FileDescriptorIO
     count = slice.size
     total = count
     loop do
-      bytes_written = LibC.write(@fd, slice.pointer(count), LibC::SizeT.cast(count))
+      bytes_written = LibC.write(@fd, slice.pointer(count), LibC::SizeT.new(count))
       if bytes_written != -1
         count -= bytes_written
         return total if count == 0

--- a/src/libc.cr
+++ b/src/libc.cr
@@ -59,7 +59,7 @@ lib LibC
     MAP_ANON = 0x0020
   end
 
-  MAP_FAILED = Pointer(Void).new(SizeT.cast(-1))
+  MAP_FAILED = Pointer(Void).new(SizeT.new(-1))
 
   fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : SSizeT) : Void*
   fun munmap(addr : Void*, len : SizeT)
@@ -77,45 +77,45 @@ lib LibC
   end
 end
 
-# These cast definitions are here because they are required before defining
+# These new definitions are here because they are required before defining
 # all of Number, Int, etc., functionality (for example in GC)
 
-def Int8.cast(value)
+def Int8.new(value)
   value.to_i8
 end
 
-def Int16.cast(value)
+def Int16.new(value)
   value.to_i16
 end
 
-def Int32.cast(value)
+def Int32.new(value)
   value.to_i32
 end
 
-def Int64.cast(value)
+def Int64.new(value)
   value.to_i64
 end
 
-def UInt8.cast(value)
+def UInt8.new(value)
   value.to_u8
 end
 
-def UInt16.cast(value)
+def UInt16.new(value)
   value.to_u16
 end
 
-def UInt32.cast(value)
+def UInt32.new(value)
   value.to_u32
 end
 
-def UInt64.cast(value)
+def UInt64.new(value)
   value.to_u64
 end
 
-def Float32.cast(value)
+def Float32.new(value)
   value.to_f32
 end
 
-def Float64.cast(value)
+def Float64.new(value)
   value.to_f64
 end

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -12,7 +12,7 @@ struct LLVM::DIBuilder
   end
 
   def get_or_create_type_array(types : Array(LibLLVMExt::Metadata))
-    LibLLVMExt.di_builder_get_or_create_type_array(self, types.buffer, LibC::SizeT.cast(types.size))
+    LibLLVMExt.di_builder_get_or_create_type_array(self, types.buffer, LibC::SizeT.new(types.size))
   end
 
   def create_subroutine_type(file, parameter_types)
@@ -29,8 +29,8 @@ struct LLVM::DIBuilder
 
   def create_function(scope, name, linkage_name, file, line, composite_type, is_local_to_unit, is_definition,
                       scope_line, flags, is_optimized, func)
-    LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, LibC::UInt.cast(line), composite_type, is_local_to_unit, is_definition,
-                                          LibC::UInt.cast(scope_line), flags, is_optimized, func)
+    LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, LibC::UInt.new(line), composite_type, is_local_to_unit, is_definition,
+                                          LibC::UInt.new(scope_line), flags, is_optimized, func)
   end
 
   def finalize

--- a/src/matrix.cr
+++ b/src/matrix.cr
@@ -221,7 +221,7 @@ class Matrix(T)
     pos = -1
     @rows.times do |i|
       other.column_count.times do |j|
-        matrix[pos += 1] = typeof(self[0] * other[0]).cast((0...@columns).inject(0) do |memo, k|
+        matrix[pos += 1] = typeof(self[0] * other[0]).new((0...@columns).inject(0) do |memo, k|
           memo + at(i, k) * other[k, j]
         end)
       end

--- a/src/number.cr
+++ b/src/number.cr
@@ -3,7 +3,7 @@ struct Number
   include Comparable(Number)
 
   def self.zero
-    cast(0)
+    new(0)
   end
 
   # Returns self.
@@ -24,7 +24,7 @@ struct Number
   def self.[](*nums)
     Array(self).build(nums.size) do |buffer|
       nums.each_with_index do |num, i|
-        buffer[i] = cast(num)
+        buffer[i] = new(num)
       end
       nums.size
     end
@@ -161,7 +161,7 @@ struct Number
       base ** (((Math.log2(self.abs)) / (Math.log2(base)) - digits + 1).floor)
     end
 
-    self.class.cast((x / y).round * y)
+    self.class.new((x / y).round * y)
   end
 
   # Rounds this number to a given precision in decimal digits.
@@ -172,7 +172,7 @@ struct Number
   def round(digits, base = 10)
     x = self.to_f
     y = base ** digits
-    self.class.cast((x * y).round / y)
+    self.class.new((x * y).round / y)
   end
 
   # :nodoc:

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -31,7 +31,7 @@ struct OpenSSL::BIO
         STDERR.puts "WARNING: Unsupported BIO ctrl call (#{cmd})"
         0
       end
-      LibCrypto::Long.cast(val)
+      LibCrypto::Long.new(val)
     end
 
     crystal_bio.create = LibCrypto::BioMethodCreate.new do |bio|

--- a/src/openssl/hmac.cr
+++ b/src/openssl/hmac.cr
@@ -19,7 +19,7 @@ class OpenSSL::HMAC
     key_slice = key.to_slice
     data_slice = data.to_slice
     buffer = Slice(UInt8).new(128)
-    LibCrypto.hmac(evp, key_slice, key_slice.size, data_slice, LibC::SizeT.cast(data_slice.size), buffer, out buffer_len)
+    LibCrypto.hmac(evp, key_slice, key_slice.size, data_slice, LibC::SizeT.new(data_slice.size), buffer, out buffer_len)
     buffer[0, buffer_len.to_i]
   end
 

--- a/src/openssl/md5.cr
+++ b/src/openssl/md5.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 class OpenSSL::MD5
   def self.hash(data : String)
-    hash(data.cstr, LibC::SizeT.cast(data.bytesize))
+    hash(data.cstr, LibC::SizeT.new(data.bytesize))
   end
 
   def self.hash(data : UInt8*, bytesize : LibC::SizeT)

--- a/src/openssl/sha1.cr
+++ b/src/openssl/sha1.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 class OpenSSL::SHA1
   def self.hash(data : String)
-    hash(data.cstr, LibC::SizeT.cast(data.bytesize))
+    hash(data.cstr, LibC::SizeT.new(data.bytesize))
   end
 
   def self.hash(data : UInt8*, bytesize : LibC::SizeT)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -240,7 +240,7 @@ struct Pointer(T)
   # ptr1.memcmp(ptr1, 4) #=> 0
   # ```
   def memcmp(other : Pointer(T), count : Int)
-    LibC.memcmp(self as Void*, (other as Void*), LibC::SizeT.cast(count * sizeof(T)))
+    LibC.memcmp(self as Void*, (other as Void*), LibC::SizeT.new(count * sizeof(T)))
   end
 
   # Swaps the contents pointed at the offsets `i` and `j`.

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -105,8 +105,8 @@ fun __crystal_personality(version : Int32, actions : Int32, exception_class : UI
         end
 
         if (actions & LibABI::UA_HANDLER_FRAME) > 0
-          LibABI.unwind_set_gr(context, LibABI::EH_REGISTER_0, LibC::SizeT.cast(exception_object.address))
-          LibABI.unwind_set_gr(context, LibABI::EH_REGISTER_1, LibC::SizeT.cast(exception_object.value.exception_type_id))
+          LibABI.unwind_set_gr(context, LibABI::EH_REGISTER_0, LibC::SizeT.new(exception_object.address))
+          LibABI.unwind_set_gr(context, LibABI::EH_REGISTER_1, LibC::SizeT.new(exception_object.value.exception_type_id))
           LibABI.unwind_set_ip(context, start + cs_addr)
           # puts "install"
           return LibABI::URC_INSTALL_CONTEXT

--- a/src/readline.cr
+++ b/src/readline.cr
@@ -16,7 +16,7 @@ lib LibReadline
 end
 
 private def malloc_match(match)
-  match_ptr = LibC.malloc(LibC::SizeT.cast(match.bytesize) + 1) as UInt8*
+  match_ptr = LibC.malloc(LibC::SizeT.new(match.bytesize) + 1) as UInt8*
   match_ptr.copy_from(match.to_unsafe, match.bytesize)
   match_ptr[match.bytesize] = 0_u8
   match_ptr
@@ -31,9 +31,9 @@ module Readline
   KeyBindingHandler = ->(count : LibReadline::Int, key : LibReadline::Int) do
     if (handlers = @@key_bind_handlers) && handlers[key.to_i32]?
       res = handlers[key].call(count.to_i32, key.to_i32)
-      LibReadline::Int.cast(res)
+      LibReadline::Int.new(res)
     else
-      LibReadline::Int.cast(1)
+      LibReadline::Int.new(1)
     end
   end
 
@@ -68,14 +68,14 @@ module Readline
     handlers[c.ord] = f
     @@key_bind_handlers = handlers
 
-    res = LibReadline.rl_bind_key(LibReadline::Int.cast(c.ord), KeyBindingHandler).to_i32
+    res = LibReadline.rl_bind_key(LibReadline::Int.new(c.ord), KeyBindingHandler).to_i32
     raise ArgumentError.new "invalid key: '#{c.inspect}'" unless res == 0
   end
 
   def unbind_key(c : Char)
     if (handlers = @@key_bind_handlers) && handlers[c.ord]?
       handlers.delete(c.ord)
-      res = LibReadline.rl_unbind_key(LibReadline::Int.cast(c.ord)).to_i32
+      res = LibReadline.rl_unbind_key(LibReadline::Int.new(c.ord)).to_i32
       raise Exception.new "error unbinding key: '#{c.inspect}'" unless res == 0
     else
       raise KeyError.new "key not bound: '#{c.inspect}'"
@@ -83,7 +83,7 @@ module Readline
   end
 
   def done
-    LibReadline.rl_done != LibReadline::Int.cast(0)
+    LibReadline.rl_done != LibReadline::Int.new(0)
   end
 
   def done=(val : Bool)
@@ -129,7 +129,7 @@ module Readline
 
     # We *must* to create the results using malloc (readline later frees that).
     # We create an extra result for the first element.
-    result = LibC.malloc(LibC::SizeT.cast(sizeof(UInt8*)) * (matches.size + 2)) as UInt8**
+    result = LibC.malloc(LibC::SizeT.new(sizeof(UInt8*)) * (matches.size + 2)) as UInt8**
     matches.each_with_index do |match, i|
       result[i + 1] = malloc_match(match)
     end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -246,7 +246,7 @@ struct Slice(T)
 
   def ==(other : self)
     return false if bytesize != other.bytesize
-    sz = LibC::SizeT.cast(bytesize)
+    sz = LibC::SizeT.new(bytesize)
     return LibC.memcmp(to_unsafe as Void*, other.to_unsafe as Void*, sz) == 0
   end
 

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -2,7 +2,7 @@ class IPSocket < Socket
   macro sockname(name, method)
     def {{name.id}}
       addr :: LibC::SockAddrIn6
-      addrlen = LibC::SocklenT.cast(sizeof(LibC::SockAddrIn6))
+      addrlen = LibC::SocklenT.new(sizeof(LibC::SockAddrIn6))
 
       if LibC.{{method.id}}(fd, pointerof(addr) as LibC::SockAddr*, pointerof(addrlen)) != 0
         raise Errno.new("{{method.id}}")
@@ -16,7 +16,7 @@ class IPSocket < Socket
         result_addr = (pointerof(addr) as LibC::SockAddrIn*).value
       end
 
-      Addr.new(family_name, LibC.htons(LibC::UInt16T.cast(result_addr.port)).to_u16, Socket.inet_ntop(result_addr))
+      Addr.new(family_name, LibC.htons(LibC::UInt16T.new(result_addr.port)).to_u16, Socket.inet_ntop(result_addr))
     end
   end
 

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -40,7 +40,7 @@ class Socket < FileDescriptorIO
   end
 
   protected def create_socket(family, stype, protocol = 0)
-    sock = LibC.socket(LibC::Int.cast(family), stype, protocol)
+    sock = LibC.socket(LibC::Int.new(family), stype, protocol)
     raise Errno.new("Error opening socket") if sock <= 0
     init_close_on_exec sock
     sock
@@ -88,7 +88,7 @@ class Socket < FileDescriptorIO
 
   # returns the modified optval
   def getsockopt optname, optval, level = LibC::SOL_SOCKET
-    optsize = LibC::SocklenT.cast(sizeof(typeof(optval)))
+    optsize = LibC::SocklenT.new(sizeof(typeof(optval)))
     ret = LibC.getsockopt(fd, level, optname, (pointerof(optval) as Void*), pointerof(optsize))
     raise Errno.new("getsockopt") if ret == -1
     optval
@@ -96,7 +96,7 @@ class Socket < FileDescriptorIO
 
   # optval is restricted to Int32 until sizeof works on variables
   def setsockopt optname, optval : Int32, level = LibC::SOL_SOCKET
-    optsize = LibC::SocklenT.cast(sizeof(typeof(optval)))
+    optsize = LibC::SocklenT.new(sizeof(typeof(optval)))
     ret = LibC.setsockopt(fd, level, optname, (pointerof(optval) as Void*), optsize)
     raise Errno.new("setsockopt") if ret == -1
     ret
@@ -105,14 +105,14 @@ class Socket < FileDescriptorIO
   def self.inet_ntop(sa : LibC::SockAddrIn6)
     ip_address = GC.malloc_atomic(LibC::INET6_ADDRSTRLEN.to_u32) as UInt8*
     addr = sa.addr
-    LibC.inet_ntop(LibC::AF_INET6, pointerof(addr) as Void*, ip_address, LibC::SocklenT.cast(LibC::INET6_ADDRSTRLEN))
+    LibC.inet_ntop(LibC::AF_INET6, pointerof(addr) as Void*, ip_address, LibC::SocklenT.new(LibC::INET6_ADDRSTRLEN))
     String.new(ip_address)
   end
 
   def self.inet_ntop(sa : LibC::SockAddrIn)
     ip_address = GC.malloc_atomic(LibC::INET_ADDRSTRLEN.to_u32) as UInt8*
     addr = sa.addr
-    LibC.inet_ntop(LibC::AF_INET, pointerof(addr) as Void*, ip_address, LibC::SocklenT.cast(LibC::INET_ADDRSTRLEN))
+    LibC.inet_ntop(LibC::AF_INET, pointerof(addr) as Void*, ip_address, LibC::SocklenT.new(LibC::INET_ADDRSTRLEN))
     String.new(ip_address)
   end
 

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -50,7 +50,7 @@ class TCPServer < TCPSocket
   def accept
     loop do
       client_addr :: LibC::SockAddrIn6
-      client_addr_len = LibC::SocklenT.cast(sizeof(LibC::SockAddrIn6))
+      client_addr_len = LibC::SocklenT.new(sizeof(LibC::SockAddrIn6))
       client_fd = LibC.accept(fd, pointerof(client_addr) as LibC::SockAddr*, pointerof(client_addr_len))
       if client_fd == -1
         if LibC.errno == Errno::EAGAIN

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -7,12 +7,12 @@ class UNIXServer < UNIXSocket
     sock = create_socket(LibC::AF_UNIX, socktype.value, 0)
 
     addr = LibC::SockAddrUn.new
-    addr.family = typeof(addr.family).cast(LibC::AF_UNIX)
+    addr.family = typeof(addr.family).new(LibC::AF_UNIX)
     if path.bytesize + 1 > addr.path.size
       raise "Path size exceeds the maximum size of #{addr.path.size - 1} bytes"
     end
     addr.path.buffer.copy_from(path.cstr, path.bytesize + 1)
-    if LibC.bind(sock, (pointerof(addr) as LibC::SockAddr*), LibC::SocklenT.cast(sizeof(LibC::SockAddrUn))) != 0
+    if LibC.bind(sock, (pointerof(addr) as LibC::SockAddr*), LibC::SocklenT.new(sizeof(LibC::SockAddrUn))) != 0
       LibC.close(sock)
       raise Errno.new("Error binding UNIX server at #{path}")
     end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -5,12 +5,12 @@ class UNIXSocket < Socket
     sock = create_socket(LibC::AF_UNIX, socktype.value, 0)
 
     addr = LibC::SockAddrUn.new
-    addr.family = typeof(addr.family).cast(LibC::AF_UNIX)
+    addr.family = typeof(addr.family).new(LibC::AF_UNIX)
     if path.bytesize + 1 > addr.path.size
       raise "Path size exceeds the maximum size of #{addr.path.size - 1} bytes"
     end
     addr.path.buffer.copy_from(path.cstr, path.bytesize + 1)
-    if LibC.connect(sock, (pointerof(addr) as LibC::SockAddr*), LibC::SocklenT.cast(sizeof(LibC::SockAddrUn))) != 0
+    if LibC.connect(sock, (pointerof(addr) as LibC::SockAddr*), LibC::SocklenT.new(sizeof(LibC::SockAddrUn))) != 0
       LibC.close(sock)
       raise Errno.new("Error connecting to '#{path}'")
     end

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -223,7 +223,7 @@ struct String::Formatter
 
       len = flags.width + (flags.precision || 0) + 23
       temp_buf = temp_buf(len)
-      count = LibC.snprintf(temp_buf, LibC::SizeT.cast(len), format_buf, float)
+      count = LibC.snprintf(temp_buf, LibC::SizeT.new(len), format_buf, float)
 
       @io.write Slice.new(temp_buf, count)
     else

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -4,7 +4,7 @@ class YAML::PullParser
     @event = LibYAML::Event.new
 
     LibYAML.yaml_parser_initialize(@parser)
-    LibYAML.yaml_parser_set_input_string(@parser, content, LibC::SizeT.cast(content.bytesize))
+    LibYAML.yaml_parser_set_input_string(@parser, content, LibC::SizeT.new(content.bytesize))
 
     read_next
     parse_exception "Expected STREAM_START" unless kind == LibYAML::EventType::STREAM_START


### PR DESCRIPTION
My main motivation is that with this we can quite clearly define the term cast as reinterpretation of data in the language, since this removes the only usage of the term for (potential) conversion.