### PR TITLE
add Class#cast macro for runtime "as" casting

### DIFF
--- a/spec/std/class_spec.cr
+++ b/spec/std/class_spec.cr
@@ -1,11 +1,22 @@
 require "spec"
 
-describe Class do
+describe Class, "#===" do
   it "does ===" do
     (Int32 === 1).should be_true
     (Int32 === 1.5).should be_false
     (Array === [1]).should be_true
     (Array(Int32) === [1]).should be_true
     (Array(Int32) === ['a']).should be_false
+  end
+end
+
+describe Class, ".cast" do
+  it "casts, allowing the class to be passed in at runtime" do
+    ar = [99, "something"]
+    cl = {Int32, String}
+    casted = {cl[0].cast(ar[0]), cl[1].cast(ar[1])}
+    casted.should eq({99, "something"})
+    typeof(casted[0]).should eq(Int32)
+    typeof(casted[1]).should eq(String)
   end
 end

--- a/src/class.cr
+++ b/src/class.cr
@@ -24,6 +24,22 @@ class Class
     {{ @type.name.stringify }}
   end
 
+  # Casts `other` to this class.
+  #
+  # This is the same as using `as`, but allows the class to be passed around as
+  # an argument. See the [documentation on
+  # as](//crystal-lang.org/docs/syntax_and_semantics/as.html) for more
+  # information.
+  #
+  #     klass = Int32
+  #     number = [99, "str"][0]
+  #     typeof(number)             # => (String | Int32)
+  #     typeof(klass.cast(number)) # => Int32
+  #
+  macro def cast(other) : self
+    other as self
+  end
+
   def to_s(io)
     io << name
   end


### PR DESCRIPTION
[This technique is used](https://github.com/will/crystal-pg/blob/master/src/pg/result.cr#L75) in crystal-pg in order to transform an array of union-typed values into a tuple of single typed values.

I held off on submitting this because in crystal-pg I call it `as_cast`, which isn't a great name. With `cast` gone now, perhaps this can take that name.