### PR TITLE
Correctly handle signal exits in crystal run

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -313,11 +313,20 @@ USAGE
       File.delete output_filename
     end
 
-    if status.exit_status == 11
-      puts "Program exited because of a segmentation fault: 11"
-    end
+    if status.normal_exit?
+      exit status.exit_code
+    else
+      case status.exit_signal
+      when Signal::KILL
+        STDERR.puts "Program was killed"
+      when Signal::SEGV
+        STDERR.puts "Program exited because of a segmentation fault (11)"
+      else
+        STDERR.puts "Program received and didn't handle signal #{status.exit_signal} (#{status.exit_signal.value})"
+      end
 
-    exit status.exit_code
+      exit 1
+    end
   end
 
   private def self.tempfile(basename)

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -5,12 +5,38 @@ class Process::Status
   def initialize(@exit_status)
   end
 
-  def exit_code
-    @exit_status >> 8
+  # Returns `true` if the process was terminated by a signal.
+  def signal_exit?
+    #define __WIFSIGNALED(status) (((signed char) (((status) & 0x7f) + 1) >> 1) > 0)
+    ((LibC::SChar.new(@exit_status & 0x7f) + 1) >> 1) > 0
   end
 
+  # Returns `true` if the process terminated normally.
+  def normal_exit?
+    #define __WIFEXITED(status) (__WTERMSIG(status) == 0)
+    signal_code == 0
+  end
+
+  # If `signal_exit?` is `true`, returns the *Signal* the process
+  # received and didn't handle. Will raise if `signal_exit?` is `false`.
+  def exit_signal
+    Signal.from_value(signal_code)
+  end
+
+  # If `normal_exit?` is `true`, returns the exit code of the process.
+  def exit_code
+    #define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
+    (@exit_status & 0xff00) >> 8
+  end
+
+  # Returns `true` if the process exited normally with an exit code of 0.
   def success?
-    exit_code == 0
+    normal_exit? && exit_code == 0
+  end
+
+  private def signal_code
+    #define __WTERMSIG(status) ((status) & 0x7f)
+    @exit_status & 0x7f
   end
 end
 


### PR DESCRIPTION
Before merging this we need someone to crosscheck if this is portable to OS X or if the signal is derived differently from the exit status there.

Easiest is probably just get a compiler with this branch, then using it check if `bin/crystal eval "Pointer(UInt8).null.value"` produces the right output, as well as `bin/crystal eval "sleep 3600"` and then sending the launched child process signal 9 and 15.

