### PR TITLE
Rename Channel related classes

### DIFF
--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -65,7 +65,7 @@ class Scheduler
   def self.create_signal_event signal : Signal, chan
     flags = LibEvent2::EventFlags::Signal | LibEvent2::EventFlags::Persist
     event = @@eb.new_event(Int32.new(signal.to_i), flags, chan) do |s, flags, data|
-      ch = data as BufferedChannel(Signal)
+      ch = data as Channel::Buffered(Signal)
       sig = Signal.new(s)
       ch.send sig
       nil

--- a/src/event/signal_child_handler.cr
+++ b/src/event/signal_child_handler.cr
@@ -6,7 +6,7 @@ class Event::SignalChildHandler
     @@instance ||= new
   end
 
-  alias ChanType = BufferedChannel(Process::Status?)
+  alias ChanType = Channel::Buffered(Process::Status?)
 
   def initialize
     @pending = Hash(LibC::PidT, Process::Status).new


### PR DESCRIPTION
* UnbufferedChannel -> Channel::Unbuffered
* BufferedChannel -> Channel::Buffered
* ChannelClosed -> Channel::ClosedError

Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.
* BufferedChannel and UnbufferedChannel can even be seen as internals with their primary public API being Channel.new.