### PR TITLE
Rename time related types

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -35,13 +35,13 @@ end
 
 class JSONWithTime
   json_mapping({
-    value: {type: Time, converter: TimeFormat.new("%F %T")},
+    value: {type: Time, converter: Time::Format.new("%F %T")},
   })
 end
 
 class JSONWithNilableTime
   json_mapping({
-    value: {type: Time, converter: TimeFormat.new("%F")},
+    value: {type: Time, converter: Time::Format.new("%F")},
   })
 
   def initialize
@@ -50,7 +50,7 @@ end
 
 class JSONWithNilableTimeEmittingNull
   json_mapping({
-    value: {type: Time, converter: TimeFormat.new("%F"), emit_null: true},
+    value: {type: Time, converter: Time::Format.new("%F"), emit_null: true},
   })
 
   def initialize
@@ -130,7 +130,7 @@ describe "JSON mapping" do
     json.value.should be_false
   end
 
-  it "parses json with TimeFormat converter" do
+  it "parses json with Time::Format converter" do
     json = JSONWithTime.from_json(%({"value": "2014-10-31 23:37:16"}))
     json.value.should be_a(Time)
     json.value.to_s.should eq("2014-10-31 23:37:16")

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -1,36 +1,36 @@
 require "spec"
 
 private def expect_overflow
-  expect_raises ArgumentError, "TimeSpan too big or too small" do
+  expect_raises ArgumentError, "Time::Span too big or too small" do
     yield
   end
 end
 
-describe TimeSpan do
+describe Time::Span do
   it "initializes" do
-    t1 = TimeSpan.new 1234567890
+    t1 = Time::Span.new 1234567890
     t1.to_s.should eq("00:02:03.4567890")
 
-    t1 = TimeSpan.new 1, 2, 3
+    t1 = Time::Span.new 1, 2, 3
     t1.to_s.should eq("01:02:03")
 
-    t1 = TimeSpan.new 1, 2, 3, 4
+    t1 = Time::Span.new 1, 2, 3, 4
     t1.to_s.should eq("1.02:03:04")
 
-    t1 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5
     t1.to_s.should eq("1.02:03:04.0050000")
 
-    t1 = TimeSpan.new -1, 2, -3, 4, -5
+    t1 = Time::Span.new -1, 2, -3, 4, -5
     t1.to_s.should eq("-22:02:56.0050000")
 
-    t1 = TimeSpan.new 0, 25, 0, 0, 0
+    t1 = Time::Span.new 0, 25, 0, 0, 0
     t1.to_s.should eq("1.01:00:00")
   end
 
   it "days overflows" do
     expect_overflow do
-      days = (Int64::MAX / TimeSpan::TicksPerDay).to_i32 + 1
-      TimeSpan.new days, 0, 0, 0, 0
+      days = (Int64::MAX / Time::Span::TicksPerDay).to_i32 + 1
+      Time::Span.new days, 0, 0, 0, 0
     end
   end
 
@@ -87,7 +87,7 @@ describe TimeSpan do
   end
 
   it "negative timespan" do
-    ts = TimeSpan.new -23, -59, -59
+    ts = Time::Span.new -23, -59, -59
     ts.days.should eq(0)
     ts.hours.should eq(-23)
     ts.minutes.should eq(-59)
@@ -97,7 +97,7 @@ describe TimeSpan do
   end
 
   it "test properties" do
-    t1 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1
 
     t1.days.should eq(1)
@@ -114,8 +114,8 @@ describe TimeSpan do
   end
 
   it "test add" do
-    t1 = TimeSpan.new 2, 3, 4, 5, 6
-    t2 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 2, 3, 4, 5, 6
+    t2 = Time::Span.new 1, 2, 3, 4, 5
     t3 = t1 + t2;
 
     t3.days.should eq(3)
@@ -129,13 +129,13 @@ describe TimeSpan do
   end
 
   it "test compare" do
-    t1 = TimeSpan.new -1
-    t2 = TimeSpan.new 1
+    t1 = Time::Span.new -1
+    t2 = Time::Span.new 1
 
     (t1 <=> t2).should eq(-1)
     (t2 <=> t1).should eq(1)
     (t2 <=> t2).should eq(0)
-    (TimeSpan::MinValue <=> TimeSpan::MaxValue).should eq(-1)
+    (Time::Span::MinValue <=> Time::Span::MaxValue).should eq(-1)
 
     (t1 == t2).should be_false
     (t1 > t2).should be_false
@@ -146,8 +146,8 @@ describe TimeSpan do
   end
 
   it "test equals" do
-    t1 = TimeSpan.new 1
-    t2 = TimeSpan.new 2
+    t1 = Time::Span.new 1
+    t2 = Time::Span.new 2
 
     (t1 == t1).should be_true
     (t1 == t2).should be_false
@@ -168,20 +168,20 @@ describe TimeSpan do
   end
 
   it "test negate and duration" do
-    (-TimeSpan.new(12345)).to_s.should eq("-00:00:00.0012345")
-    TimeSpan.new(-12345).duration.to_s.should eq("00:00:00.0012345")
-    TimeSpan.new(-12345).abs.to_s.should eq("00:00:00.0012345")
-    (-TimeSpan.new(77)).to_s.should eq("-00:00:00.0000077")
-    (+TimeSpan.new(77)).to_s.should eq("00:00:00.0000077")
+    (-Time::Span.new(12345)).to_s.should eq("-00:00:00.0012345")
+    Time::Span.new(-12345).duration.to_s.should eq("00:00:00.0012345")
+    Time::Span.new(-12345).abs.to_s.should eq("00:00:00.0012345")
+    (-Time::Span.new(77)).to_s.should eq("-00:00:00.0000077")
+    (+Time::Span.new(77)).to_s.should eq("00:00:00.0000077")
   end
 
   it "test hash code" do
-    TimeSpan.new(77).hash.should eq(77)
+    Time::Span.new(77).hash.should eq(77)
   end
 
   it "test subtract" do
-    t1 = TimeSpan.new 2, 3, 4, 5, 6
-    t2 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 2, 3, 4, 5, 6
+    t2 = Time::Span.new 1, 2, 3, 4, 5
     t3 = t1 - t2
 
     t3.to_s.should eq("1.01:01:01.0010000")
@@ -190,18 +190,18 @@ describe TimeSpan do
   end
 
   it "test to_s" do
-    t1 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1
 
     t1.to_s.should eq("1.02:03:04.0050000")
     t2.to_s.should eq("-1.02:03:04.0050000")
-    TimeSpan::MaxValue.to_s.should eq("10675199.02:48:05.4775807")
-    TimeSpan::MinValue.to_s.should eq("-10675199.02:48:05.4775808")
-    TimeSpan::Zero.to_s.should eq("00:00:00")
+    Time::Span::MaxValue.to_s.should eq("10675199.02:48:05.4775807")
+    Time::Span::MinValue.to_s.should eq("-10675199.02:48:05.4775808")
+    Time::Span::Zero.to_s.should eq("00:00:00")
   end
 
   it "test totals" do
-    t1 = TimeSpan.new 1, 2, 3, 4, 5
+    t1 = Time::Span.new 1, 2, 3, 4, 5
     t1.total_days.should be_close(1.08546, 1e-05)
     t1.total_hours.should be_close(26.0511, 1e-04)
     t1.total_minutes.should be_close(1563.07, 1e-02)

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -70,7 +70,7 @@ describe Time do
 
   it "add" do
     t1 = Time.new TimeSpecTicks[1]
-    span = TimeSpan.new 3, 54, 1
+    span = Time::Span.new 3, 54, 1
     t2 = t1 + span
 
     t2.day.should eq(25)
@@ -88,7 +88,7 @@ describe Time do
     t1 = Time.new TimeSpecTicks[1]
 
     expect_raises ArgumentError do
-      t1 + TimeSpan::MaxValue
+      t1 + Time::Span::MaxValue
     end
   end
 
@@ -96,7 +96,7 @@ describe Time do
     t1 = Time.new TimeSpecTicks[1]
 
     expect_raises ArgumentError do
-      t1 + TimeSpan::MinValue
+      t1 + Time::Span::MinValue
     end
   end
 
@@ -209,12 +209,12 @@ describe Time do
 
   it "gets time of day" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.time_of_day.should eq(TimeSpan.new(21, 18, 13))
+    t.time_of_day.should eq(Time::Span.new(21, 18, 13))
   end
 
   it "gets day of week" do
     t = Time.new 2014, 10, 30, 21, 18, 13
-    t.day_of_week.should eq(DayOfWeek::Thursday)
+    t.day_of_week.should eq(Time::DayOfWeek::Thursday)
   end
 
   it "gets day of year" do
@@ -549,14 +549,14 @@ describe Time do
   end
 
   it "does time span units" do
-    1.millisecond.ticks.should eq(TimeSpan::TicksPerMillisecond)
-    1.milliseconds.ticks.should eq(TimeSpan::TicksPerMillisecond)
-    1.second.ticks.should eq(TimeSpan::TicksPerSecond)
-    1.seconds.ticks.should eq(TimeSpan::TicksPerSecond)
-    1.minute.ticks.should eq(TimeSpan::TicksPerMinute)
-    1.minutes.ticks.should eq(TimeSpan::TicksPerMinute)
-    1.hour.ticks.should eq(TimeSpan::TicksPerHour)
-    1.hours.ticks.should eq(TimeSpan::TicksPerHour)
+    1.millisecond.ticks.should eq(Time::Span::TicksPerMillisecond)
+    1.milliseconds.ticks.should eq(Time::Span::TicksPerMillisecond)
+    1.second.ticks.should eq(Time::Span::TicksPerSecond)
+    1.seconds.ticks.should eq(Time::Span::TicksPerSecond)
+    1.minute.ticks.should eq(Time::Span::TicksPerMinute)
+    1.minutes.ticks.should eq(Time::Span::TicksPerMinute)
+    1.hour.ticks.should eq(Time::Span::TicksPerHour)
+    1.hours.ticks.should eq(Time::Span::TicksPerHour)
     1.week.should eq(7.days)
     2.weeks.should eq(14.days)
   end

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -28,7 +28,7 @@ end
 
 class YAMLWithTime
   yaml_mapping({
-    value: {type: Time, converter: TimeFormat.new("%F %T")},
+    value: {type: Time, converter: Time::Format.new("%F %T")},
   })
 end
 
@@ -87,7 +87,7 @@ describe "YAML mapping" do
     yaml.value.should be_false
   end
 
-  it "parses json with TimeFormat converter" do
+  it "parses json with Time::Format converter" do
     json = YAMLWithTime.from_yaml("---\nvalue: 2014-10-31 23:37:16\n")
     json.value.should eq(Time.new(2014, 10, 31, 23, 37, 16))
   end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -54,11 +54,11 @@ describe "YAML serialization" do
       Tuple(Int32, String, Bool).from_yaml("---\n- 1\n- foo\n- true\n").should eq({1, "foo", true})
     end
 
-    it "does TimeFormat#from_yaml" do
+    it "does Time::Format#from_yaml" do
       pull = YAML::PullParser.new("--- 2014-01-02\n...\n")
       pull.read_stream do
         pull.read_document do
-          TimeFormat.new("%F").from_yaml(pull).should eq(Time.new(2014, 1, 2))
+          Time::Format.new("%F").from_yaml(pull).should eq(Time.new(2014, 1, 2))
         end
       end
     end

--- a/src/benchmark/benchmark.cr
+++ b/src/benchmark/benchmark.cr
@@ -106,7 +106,7 @@ module Benchmark
                      t1.stime  - t0.stime,
                      t1.cutime - t0.cutime,
                      t1.cstime - t0.cstime,
-                     (r1.ticks - r0.ticks).to_f / TimeSpan::TicksPerSecond,
+                     (r1.ticks - r0.ticks).to_f / Time::Span::TicksPerSecond,
                      label)
   end
 
@@ -115,7 +115,7 @@ module Benchmark
   # ```
   # Benchmark.realtime { "a" * 100_000 } #=> 00:00:00.0005840
   # ```
-  def realtime : TimeSpan
+  def realtime : Time::Span
     r0 = Time.now
     yield
     Time.now - r0

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -74,7 +74,7 @@ module Benchmark
         @items.each do |item|
           GC.collect
 
-          measurements = [] of TimeSpan
+          measurements = [] of Time::Span
           target = Time.now + @calculation_time
 
           loop do

--- a/src/concurrent/concurrent.cr
+++ b/src/concurrent/concurrent.cr
@@ -9,7 +9,7 @@ def sleep(seconds : Number)
   Scheduler.sleep(seconds)
 end
 
-def sleep(time : TimeSpan)
+def sleep(time : Time::Span)
   sleep(time.total_seconds)
 end
 

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -109,8 +109,8 @@ class HTTP::Client
     @read_timeout = read_timeout.to_f
   end
 
-  # Set the read timeout with a TimeSpan, to wait when reading before raising an `IO::Timeout`.
-  def read_timeout=(read_timeout : TimeSpan)
+  # Set the read timeout with a Time::Span, to wait when reading before raising an `IO::Timeout`.
+  def read_timeout=(read_timeout : Time::Span)
     self.read_timeout = read_timeout.total_seconds
   end
 

--- a/src/io/file_descriptor_io.cr
+++ b/src/io/file_descriptor_io.cr
@@ -38,7 +38,7 @@ class FileDescriptorIO
   end
 
   # ditto
-  def read_timeout=(read_timeout : TimeSpan)
+  def read_timeout=(read_timeout : Time::Span)
     self.read_timeout = read_timeout.total_seconds
   end
 
@@ -53,7 +53,7 @@ class FileDescriptorIO
   end
 
   # ditto
-  def write_timeout=(write_timeout : TimeSpan)
+  def write_timeout=(write_timeout : Time::Span)
     self.write_timeout = write_timeout.total_seconds
   end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -91,7 +91,7 @@ def Tuple.new(pull : JSON::PullParser)
  {% end %}
 end
 
-struct TimeFormat
+struct Time::Format
   def from_json(pull : JSON::PullParser)
     string = pull.read_string
     parse(string)

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -248,7 +248,7 @@ struct Tuple
   end
 end
 
-struct TimeFormat
+struct Time::Format
   def to_json(value : Time, io : IO)
     format(value).to_json(io)
   end

--- a/src/time/day_of_week.cr
+++ b/src/time/day_of_week.cr
@@ -1,4 +1,4 @@
-enum DayOfWeek
+enum Time::DayOfWeek
   Sunday
   Monday
   Tuesday

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -1,4 +1,4 @@
-struct TimeFormat
+struct Time::Format
   ISO_8601_DATE = new "%F"
 
   class Error < ::Exception

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -1,6 +1,6 @@
 require "./pattern"
 
-struct TimeFormat
+struct Time::Format
   # :nodoc:
   struct Formatter
     include Pattern

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -1,4 +1,4 @@
-struct TimeFormat
+struct Time::Format
   # :nodoc:
   struct Parser
     include Pattern

--- a/src/time/format/pattern.cr
+++ b/src/time/format/pattern.cr
@@ -1,4 +1,4 @@
-struct TimeFormat
+struct Time::Format
   # :nodoc:
   module Pattern
     MONTH_NAMES = %w(January February March April May June July August September October November December)

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -1,6 +1,6 @@
-struct TimeSpan
-  # *Heavily* inspired by Mono's TimeSpan class:
-  # https://github.com/mono/mono/blob/master/mcs/class/corlib/System/TimeSpan.cs
+struct Time::Span
+  # *Heavily* inspired by Mono's Time::Span class:
+  # https://github.com/mono/mono/blob/master/mcs/class/corlib/System/Time::Span.cs
 
   include Comparable(self)
 
@@ -81,7 +81,7 @@ struct TimeSpan
 
     if overflow
       if raise_exception
-        raise ArgumentError.new "TimeSpan too big or too small"
+        raise ArgumentError.new "Time::Span too big or too small"
       end
       return nil
     end
@@ -146,7 +146,7 @@ struct TimeSpan
   end
 
   def abs
-    TimeSpan.new(ticks.abs)
+    Span.new(ticks.abs)
   end
 
   def from_now
@@ -159,17 +159,17 @@ struct TimeSpan
 
   def -(other : self)
     # TODO check overflow
-    TimeSpan.new(ticks - other.ticks)
+    Span.new(ticks - other.ticks)
   end
 
   def -
     # TODO check overflow
-    TimeSpan.new(-ticks)
+    Span.new(-ticks)
   end
 
   def +(other : self)
     # TODO check overflow
-    TimeSpan.new(ticks + other.ticks)
+    Span.new(ticks + other.ticks)
   end
 
   def +
@@ -186,9 +186,9 @@ struct TimeSpan
     end
 
     # We need to take absolute values of all components.
-    # Can't handle negative timespans by negating the TimeSpan
+    # Can't handle negative timespans by negating the Time::Span
     # as a whole. This would lead to an overflow for the
-    # degenerate case `TimeSpan.MinValue`.
+    # degenerate case `Time::Span.MinValue`.
     if days != 0
       io << days.abs
       io << '.'
@@ -228,7 +228,7 @@ struct TimeSpan
     # TODO check infinity and overflow
     value = value * (tick_multiplicator / TicksPerMillisecond)
       val = (value < 0 ? (value - 0.5)  : (value + 0.5)).to_i64 # round away from zero
-    TimeSpan.new(val * TicksPerMillisecond)
+    Span.new(val * TicksPerMillisecond)
   end
 end
 
@@ -238,7 +238,7 @@ struct Int
   end
 
   def weeks
-    TimeSpan.new 7 * self, 0, 0, 0
+    Time::Span.new 7 * self, 0, 0, 0
   end
 
   def day
@@ -246,7 +246,7 @@ struct Int
   end
 
   def days
-    TimeSpan.new self, 0, 0, 0
+    Time::Span.new self, 0, 0, 0
   end
 
   def hour
@@ -254,7 +254,7 @@ struct Int
   end
 
   def hours
-    TimeSpan.new self, 0, 0
+    Time::Span.new self, 0, 0
   end
 
   def minute
@@ -262,7 +262,7 @@ struct Int
   end
 
   def minutes
-    TimeSpan.new 0, self, 0
+    Time::Span.new 0, self, 0
   end
 
   def second
@@ -270,7 +270,7 @@ struct Int
   end
 
   def seconds
-    TimeSpan.new 0, 0, self
+    Time::Span.new 0, 0, self
   end
 
   def millisecond
@@ -278,33 +278,33 @@ struct Int
   end
 
   def milliseconds
-    TimeSpan.new 0, 0, 0, 0, self
+    Time::Span.new 0, 0, 0, 0, self
   end
 end
 
 struct Float
   def days
-    TimeSpan.from self, TimeSpan::TicksPerDay
+    Time::Span.from self, Time::Span::TicksPerDay
   end
 
   def hours
-    TimeSpan.from self, TimeSpan::TicksPerHour
+    Time::Span.from self, Time::Span::TicksPerHour
   end
 
   def minutes
-    TimeSpan.from self, TimeSpan::TicksPerMinute
+    Time::Span.from self, Time::Span::TicksPerMinute
   end
 
   def seconds
-    TimeSpan.from self, TimeSpan::TicksPerSecond
+    Time::Span.from self, Time::Span::TicksPerSecond
   end
 
   def milliseconds
-    TimeSpan.from self, TimeSpan::TicksPerMillisecond
+    Time::Span.from self, Time::Span::TicksPerMillisecond
   end
 end
 
-struct MonthSpan
+struct Time::MonthSpan
   getter value
 
   def initialize(value)
@@ -326,7 +326,7 @@ struct Int
   end
 
   def months
-    MonthSpan.new(self)
+    Time::MonthSpan.new(self)
   end
 
   def year
@@ -334,7 +334,7 @@ struct Int
   end
 
   def years
-    MonthSpan.new(self * 12)
+    Time::MonthSpan.new(self * 12)
   end
 end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -92,7 +92,7 @@ def Tuple.new(pull : YAML::PullParser)
  {% end %}
 end
 
-struct TimeFormat
+struct Time::Format
   def from_yaml(pull : YAML::PullParser)
     string = pull.read_scalar
     parse(string)


### PR DESCRIPTION
* DayOfWeek -> Time::DayOfWeek
* MonthSpan -> Time::MonthSpan
* TimeSpan -> Time::Span
* TimeFormat -> Time::Format

Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.
* TimeSpan and TimeFormat can sort of be considered internals whose public API is on Time and the number primitives.