### PR TITLE
Rename a couple exceptions

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -212,7 +212,7 @@ describe "Enumerable" do
     end
 
     it "raises if enumerable empty" do
-      expect_raises EmptyEnumerable do
+      expect_raises Enumerable::EmptyError do
         (1...1).first
       end
     end
@@ -325,7 +325,7 @@ describe "Enumerable" do
     assert { [1, 2, 3].inject(10) { |memo, i| memo + i }.should eq(16) }
 
     it "raises if empty" do
-      expect_raises EmptyEnumerable do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).inject { |memo, i| memo + i }
       end
     end
@@ -382,7 +382,7 @@ describe "Enumerable" do
     assert { [1, 2, 3].max.should eq(3) }
 
     it "raises if empty" do
-      expect_raises EmptyEnumerable do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).max
       end
     end
@@ -418,7 +418,7 @@ describe "Enumerable" do
     assert { [1, 2, 3].min.should eq(1) }
 
     it "raises if empty" do
-      expect_raises EmptyEnumerable do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).min
       end
     end
@@ -454,7 +454,7 @@ describe "Enumerable" do
     assert { [1, 2, 3].minmax.should eq({1, 3}) }
 
     it "raises if empty" do
-      expect_raises EmptyEnumerable do
+      expect_raises Enumerable::EmptyError do
         ([] of Int32).minmax
       end
     end

--- a/spec/std/socket_spec.cr
+++ b/spec/std/socket_spec.cr
@@ -155,7 +155,7 @@ describe "TCPSocket" do
   end
 
   it "fails when host doesn't exist" do
-    expect_raises(SocketError, /^getaddrinfo: (.+ not known|no address .+|Non-recoverable failure in name resolution)$/i) do
+    expect_raises(Socket::Error, /^getaddrinfo: (.+ not known|no address .+|Non-recoverable failure in name resolution)$/i) do
       TCPSocket.new("localhostttttt", 12345)
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -222,10 +222,10 @@ module Enumerable(T)
     if_none
   end
 
-  # Returns the first element in the collection. Raises `EmptyEnumerable` if the collection is empty.
+  # Returns the first element in the collection. Raises `Enumerable::EmptyError` if the collection is empty.
   def first
     each { |e| return e }
-    raise EmptyEnumerable.new
+    raise Enumerable::EmptyError.new
   end
 
   # Returns the first element in the collection. When the collection is empty, returns `nil`.
@@ -384,7 +384,7 @@ module Enumerable(T)
       found = true
     end
 
-    found ? memo : raise EmptyEnumerable.new
+    found ? memo : raise Enumerable::EmptyError.new
   end
 
   # Just like the other variant, but you can set the initial value of the accumulator.
@@ -477,7 +477,7 @@ module Enumerable(T)
   #     [1, 2, 3].max         #=> 3
   #     ["Alice", "Bob"].max  #=> "Bob"
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def max
     max_by &.itself
   end
@@ -493,10 +493,10 @@ module Enumerable(T)
   #
   #     ["Alice", "Bob"].max_by { |name| name.size }  #=> "Alice"
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def max_by(&block : T -> U)
     found, value = max_by_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 
@@ -529,7 +529,7 @@ module Enumerable(T)
   #
   def max_of(&block : T -> U)
     found, value = max_of_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 
@@ -561,7 +561,7 @@ module Enumerable(T)
   #     [1, 2, 3].min         #=> 1
   #     ["Alice", "Bob"].min  #=> "Alice"
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def min
     min_by &.itself
   end
@@ -577,10 +577,10 @@ module Enumerable(T)
   #
   #     ["Alice", "Bob"].min_by { |name| name.size }  #=> "Bob"
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def min_by(&block : T -> U)
     found, value = min_by_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 
@@ -613,7 +613,7 @@ module Enumerable(T)
   #
   def min_of(&block : T -> U)
     found, value = min_of_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 
@@ -642,7 +642,7 @@ module Enumerable(T)
   #
   #     [1, 2, 3].minmax  #=> {1, 3}
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def minmax
     minmax_by &.itself
   end
@@ -656,10 +656,10 @@ module Enumerable(T)
   #
   #     ["Alice", "Bob", "Carl"].minmax_by { |name| name.size }  #=> {"Bob", "Alice"}
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def minmax_by(&block : T -> U)
     found, value = minmax_by_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 
@@ -697,10 +697,10 @@ module Enumerable(T)
   #
   #     ["Alice", "Bob", "Carl"].minmax_of { |name| name.size }  #=> {3, 5}
   #
-  # Raises `EmptyEnumerable` if the collection is empty.
+  # Raises `Enumerable::EmptyError` if the collection is empty.
   def minmax_of(&block : T -> U)
     found, value = minmax_of_internal {|value| yield value }
-    raise EmptyEnumerable.new unless found
+    raise Enumerable::EmptyError.new unless found
     value
   end
 

--- a/src/exception.cr
+++ b/src/exception.cr
@@ -128,9 +128,11 @@ class Exception
   end
 end
 
-class EmptyEnumerable < Exception
-  def initialize(message = "Empty enumerable")
-    super(message)
+module Enumerable(T)
+  class EmptyError < Exception
+    def initialize(message = "Empty enumerable")
+      super(message)
+    end
   end
 end
 
@@ -164,12 +166,6 @@ end
 # ```
 class TypeCastError < Exception
   def initialize(message = "Type Cast error")
-    super(message)
-  end
-end
-
-class DomainError < Exception
-  def initialize(message = "Argument out of domain")
     super(message)
   end
 end

--- a/src/number.cr
+++ b/src/number.cr
@@ -144,7 +144,7 @@ struct Number
   # ```
   def significant(digits, base = 10)
     if digits < 0
-      raise DomainError.new "digits should be non-negative"
+      raise ArgumentError.new "digits should be non-negative"
     end
 
     x = self.to_f

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -88,13 +88,13 @@ class IPSocket < Socket
         LibEvent2.evutil_freeaddrinfo value
       end
     elsif value.is_a?(Int)
-      raise SocketError.new("getaddrinfo: #{String.new(LibC.gai_strerror(value))}")
+      raise Socket::Error.new("getaddrinfo: #{String.new(LibC.gai_strerror(value))}")
     else
       raise "unknown type #{value.inspect}"
     end
 
     # shouldn't raise
-    raise SocketError.new("getaddrinfo: unspecified error") unless success
+    raise Socket::Error.new("getaddrinfo: unspecified error") unless success
   end
 
   private def dns_timeout dns_base, req, timeout

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -1,9 +1,9 @@
 require "./libc"
 
-class SocketError < Exception
-end
-
 class Socket < FileDescriptorIO
+  class Error < Exception
+  end
+
   enum Type
     STREAM = LibC::SOCK_STREAM
     DGRAM  = LibC::SOCK_DGRAM


### PR DESCRIPTION
* EmptyEnumerable -> Enumerable::EmptyError
* SocketError -> Socket::Error
* Dropped DomainError and replace its only usage with ArgumentError

Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.
* DomainError is just silly, it's only used once and that usage is actually even clearer with being an ArgumentError