### PR TITLE
Rename MatchData to Regex::MatchData

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -1,16 +1,16 @@
 require "spec"
 
-describe "MatchData" do
+describe "Regex::MatchData" do
   it "does inspect" do
-    /f(o)(x)/.match("the fox").inspect.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /f(o)(x)?/.match("the fort").inspect.should eq(%(#<MatchData "fo" 1:"o" 2:nil>))
-    /fox/.match("the fox").inspect.should eq(%(#<MatchData "fox">))
+    /f(o)(x)/.match("the fox").inspect.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
+    /f(o)(x)?/.match("the fort").inspect.should eq(%(#<Regex::MatchData "fo" 1:"o" 2:nil>))
+    /fox/.match("the fox").inspect.should eq(%(#<Regex::MatchData "fox">))
   end
 
   it "does to_s" do
-    /f(o)(x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" 1:"o" 2:"x">))
-    /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<MatchData "fox" lettero:"o" letterx:"x">))
-    /fox/.match("the fox").to_s.should eq(%(#<MatchData "fox">))
+    /f(o)(x)/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox" 1:"o" 2:"x">))
+    /f(?<lettero>o)(?<letterx>x)/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox" lettero:"o" letterx:"x">))
+    /fox/.match("the fox").to_s.should eq(%(#<Regex::MatchData "fox">))
   end
 
   describe "#[]" do

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -70,8 +70,8 @@ module Enumerable(T)
 
   # Returns an array with the results of running the block against each element of the collection, removing `nil` values.
   #
-  #     ["Alice", "Bob"].map { |name| name.match(/^A./) }         #=> [#<MatchData "Al">, nil]
-  #     ["Alice", "Bob"].compact_map { |name| name.match(/^A./) } #=> [#<MatchData "Al">]
+  #     ["Alice", "Bob"].map { |name| name.match(/^A./) }         #=> [#<Regex::MatchData "Al">, nil]
+  #     ["Alice", "Bob"].compact_map { |name| name.match(/^A./) } #=> [#<Regex::MatchData "Al">]
   #
   def compact_map
     ary = [] of typeof((yield first).not_nil!)

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -1,10 +1,10 @@
-# `MatchData` is the type of the special variable `$~`, and is the type
+# `Regex::MatchData` is the type of the special variable `$~`, and is the type
 # returned by `Regex#match` and `String#match`. It encapsulates all the
 # results of a regular expression match.
 #
 # `Regex#match` and `String#match` can return `nil`, to represent an
 # unsuccessful match, but there are overloads of both methods that accept a
-# block. These overloads are convenient to access the `MatchData` of a
+# block. These overloads are convenient to access the `Regex::MatchData` of a
 # successful match, since the block argument can't be `nil`.
 #
 # ```
@@ -17,212 +17,214 @@
 # end
 # ```
 #
-# Many `MatchData` methods deal with capture groups, and accept an integer
+# Many `Regex::MatchData` methods deal with capture groups, and accept an integer
 # argument to select the desired capture group. Capture groups are numbered
 # starting from `1`, so that `0` can be used to refer to the entire regular
 # expression without needing to capture it explicitly.
-class MatchData
-  # Returns the original regular expression.
-  #
-  # ```
-  # "Crystal".match(/[p-s]/) { |md| md.regex } #=> /[p-s]/
-  # ```
-  getter regex
+class Regex
+  class MatchData
+    # Returns the original regular expression.
+    #
+    # ```
+    # "Crystal".match(/[p-s]/) { |md| md.regex } #=> /[p-s]/
+    # ```
+    getter regex
 
-  # Returns the number of capture groups, including named capture groups.
-  #
-  # ```
-  # "Crystal".match(/[p-s]/) { |md| md.size }          #=> 0
-  # "Crystal".match(/r(ys)/) { |md| md.size }          #=> 1
-  # "Crystal".match(/r(ys)(?<ok>ta)/) { |md| md.size } #=> 2
-  # ```
-  getter size
+    # Returns the number of capture groups, including named capture groups.
+    #
+    # ```
+    # "Crystal".match(/[p-s]/) { |md| md.size }          #=> 0
+    # "Crystal".match(/r(ys)/) { |md| md.size }          #=> 1
+    # "Crystal".match(/r(ys)(?<ok>ta)/) { |md| md.size } #=> 2
+    # ```
+    getter size
 
-  # Returns the original string.
-  #
-  # ```
-  # "Crystal".match(/[p-s]/) { |md| md.string } #=> "Crystal"
-  # ```
-  getter string
+    # Returns the original string.
+    #
+    # ```
+    # "Crystal".match(/[p-s]/) { |md| md.string } #=> "Crystal"
+    # ```
+    getter string
 
-  # :nodoc:
-  def initialize(@regex, @code, @string, @pos, @ovector, @size)
-  end
-
-  # Return the position of the first character of the `n`th match.
-  #
-  # When `n` is `0` or not given, uses the match of the entire `Regex`.
-  # Otherwise, uses the match of the `n`th capture group.
-  #
-  # ```
-  # "Crystal".match(/r/) { |md| md.begin(0) }       #=> 1
-  # "Crystal".match(/r(ys)/) { |md| md.begin(1) }   #=> 2
-  # "クリスタル".match(/リ(ス)/) { |md| md.begin(0) } #=> 1
-  # ```
-  def begin(n = 0)
-    byte_index_to_char_index byte_begin(n)
-  end
-
-  # Return the position of the next character after the match.
-  #
-  # When `n` is `0` or not given, uses the match of the entire `Regex`.
-  # Otherwise, uses the match of the `n`th capture group.
-  #
-  # ```
-  # "Crystal".match(/r/) { |md| md.end(0) }       #=> 2
-  # "Crystal".match(/r(ys)/) { |md| md.end(1) }   #=> 4
-  # "クリスタル".match(/リ(ス)/) { |md| md.end(0) } #=> 3
-  # ```
-  def end(n = 0)
-    byte_index_to_char_index byte_end(n)
-  end
-
-  # Return the position of the first byte of the `n`th match.
-  #
-  # When `n` is `0` or not given, uses the match of the entire `Regex`.
-  # Otherwise, uses the match of the `n`th capture group.
-  #
-  # ```
-  # "Crystal".match(/r/) { |md| md.byte_begin(0) }       #=> 1
-  # "Crystal".match(/r(ys)/) { |md| md.byte_begin(1) }   #=> 4
-  # "クリスタル".match(/リ(ス)/) { |md| md.byte_begin(0) } #=> 3
-  # ```
-  def byte_begin(n = 0)
-    check_index_out_of_bounds n
-    @ovector[n * 2]
-  end
-
-  # Return the position of the next byte after the match.
-  #
-  # When `n` is `0` or not given, uses the match of the entire `Regex`.
-  # Otherwise, uses the match of the `n`th capture group.
-  #
-  # ```
-  # "Crystal".match(/r/) { |md| md.byte_end(0) }       #=> 2
-  # "Crystal".match(/r(ys)/) { |md| md.byte_end(1) }   #=> 4
-  # "クリスタル".match(/リ(ス)/) { |md| md.byte_end(0) } #=> 9
-  # ```
-  def byte_end(n = 0)
-    check_index_out_of_bounds n
-    @ovector[n * 2 + 1]
-  end
-
-  # Returns the match of the `n`th capture group, or `nil` if there isn't
-  # an `n`th capture group.
-  #
-  # When `n` is `0`, returns the match for the entire `Regex`.
-  #
-  # ```
-  # "Crystal".match(/r(ys)/) { |md| md[0]? } #=> "rys"
-  # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
-  # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> nil
-  # ```
-  def []?(n)
-    return unless valid_group?(n)
-
-    start = @ovector[n * 2]
-    finish = @ovector[n * 2 + 1]
-    return if start < 0
-    @string.byte_slice(start, finish - start)
-  end
-
-  # Returns the match of the `n`th capture group, or raises an `IndexError`
-  # if there is no `n`th capture group.
-  #
-  # ```
-  # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
-  # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> raises IndexError
-  # ```
-  def [](n)
-    check_index_out_of_bounds n
-
-    self[n]?.not_nil!
-  end
-
-  # Returns the match of the capture group named by `group_name`, or
-  # `nil` if there is no such named capture group.
-  #
-  # ```
-  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"]? } #=> "ys"
-  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"]? } #=> nil
-  # ```
-  def []?(group_name : String)
-    ret = LibPCRE.get_stringnumber(@code, group_name)
-    return if ret < 0
-    self[ret]?
-  end
-
-  # Returns the match of the capture group named by `group_name`, or
-  # raises an `ArgumentError` if there is no such named capture group.
-  #
-  # ```
-  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"] } #=> "ys"
-  # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"] } #=> raises ArgumentError
-  # ```
-  def [](group_name : String)
-    match = self[group_name]?
-    unless match
-      raise ArgumentError.new("Match group named '#{group_name}' does not exist")
+    # :nodoc:
+    def initialize(@regex, @code, @string, @pos, @ovector, @size)
     end
-    match
-  end
 
-  # Returns the part of the original string before the match. If the match
-  # starts at the start of the string, returns the empty string.
-  #
-  # ```
-  # "Crystal".match(/yst/) { |md| md.pre_match } #=> "Cr"
-  # ```
-  def pre_match
-    @string.byte_slice(0, byte_begin(0))
-  end
+    # Return the position of the first character of the `n`th match.
+    #
+    # When `n` is `0` or not given, uses the match of the entire `Regex`.
+    # Otherwise, uses the match of the `n`th capture group.
+    #
+    # ```
+    # "Crystal".match(/r/) { |md| md.begin(0) }       #=> 1
+    # "Crystal".match(/r(ys)/) { |md| md.begin(1) }   #=> 2
+    # "クリスタル".match(/リ(ス)/) { |md| md.begin(0) } #=> 1
+    # ```
+    def begin(n = 0)
+      byte_index_to_char_index byte_begin(n)
+    end
 
-  # Returns the part of the original string after the match. If the match ends
-  # at the end of the string, returns the empty string.
-  #
-  # ```
-  # "Crystal".match(/yst/) { |md| md.post_match } #=> "al"
-  # ```
-  def post_match
-    @string.byte_slice(byte_end(0))
-  end
+    # Return the position of the next character after the match.
+    #
+    # When `n` is `0` or not given, uses the match of the entire `Regex`.
+    # Otherwise, uses the match of the `n`th capture group.
+    #
+    # ```
+    # "Crystal".match(/r/) { |md| md.end(0) }       #=> 2
+    # "Crystal".match(/r(ys)/) { |md| md.end(1) }   #=> 4
+    # "クリスタル".match(/リ(ス)/) { |md| md.end(0) } #=> 3
+    # ```
+    def end(n = 0)
+      byte_index_to_char_index byte_end(n)
+    end
 
-  def inspect(io : IO)
-    to_s(io)
-  end
+    # Return the position of the first byte of the `n`th match.
+    #
+    # When `n` is `0` or not given, uses the match of the entire `Regex`.
+    # Otherwise, uses the match of the `n`th capture group.
+    #
+    # ```
+    # "Crystal".match(/r/) { |md| md.byte_begin(0) }       #=> 1
+    # "Crystal".match(/r(ys)/) { |md| md.byte_begin(1) }   #=> 4
+    # "クリスタル".match(/リ(ス)/) { |md| md.byte_begin(0) } #=> 3
+    # ```
+    def byte_begin(n = 0)
+      check_index_out_of_bounds n
+      @ovector[n * 2]
+    end
 
-  def to_s(io : IO)
-    name_table = @regex.name_table
+    # Return the position of the next byte after the match.
+    #
+    # When `n` is `0` or not given, uses the match of the entire `Regex`.
+    # Otherwise, uses the match of the `n`th capture group.
+    #
+    # ```
+    # "Crystal".match(/r/) { |md| md.byte_end(0) }       #=> 2
+    # "Crystal".match(/r(ys)/) { |md| md.byte_end(1) }   #=> 4
+    # "クリスタル".match(/リ(ス)/) { |md| md.byte_end(0) } #=> 9
+    # ```
+    def byte_end(n = 0)
+      check_index_out_of_bounds n
+      @ovector[n * 2 + 1]
+    end
 
-    io << "#<MatchData "
-    self[0].inspect(io)
-    if size > 0
-      io << " "
-      size.times do |i|
-        io << " " if i > 0
-        io << name_table.fetch(i + 1) { i + 1 }
-        io << ":"
-        self[i + 1]?.inspect(io)
+    # Returns the match of the `n`th capture group, or `nil` if there isn't
+    # an `n`th capture group.
+    #
+    # When `n` is `0`, returns the match for the entire `Regex`.
+    #
+    # ```
+    # "Crystal".match(/r(ys)/) { |md| md[0]? } #=> "rys"
+    # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
+    # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> nil
+    # ```
+    def []?(n)
+      return unless valid_group?(n)
+
+      start = @ovector[n * 2]
+      finish = @ovector[n * 2 + 1]
+      return if start < 0
+      @string.byte_slice(start, finish - start)
+    end
+
+    # Returns the match of the `n`th capture group, or raises an `IndexError`
+    # if there is no `n`th capture group.
+    #
+    # ```
+    # "Crystal".match(/r(ys)/) { |md| md[1]? } #=> "ys"
+    # "Crystal".match(/r(ys)/) { |md| md[2]? } #=> raises IndexError
+    # ```
+    def [](n)
+      check_index_out_of_bounds n
+
+      self[n]?.not_nil!
+    end
+
+    # Returns the match of the capture group named by `group_name`, or
+    # `nil` if there is no such named capture group.
+    #
+    # ```
+    # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"]? } #=> "ys"
+    # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"]? } #=> nil
+    # ```
+    def []?(group_name : String)
+      ret = LibPCRE.get_stringnumber(@code, group_name)
+      return if ret < 0
+      self[ret]?
+    end
+
+    # Returns the match of the capture group named by `group_name`, or
+    # raises an `ArgumentError` if there is no such named capture group.
+    #
+    # ```
+    # "Crystal".match(/r(?<ok>ys)/) { |md| md["ok"] } #=> "ys"
+    # "Crystal".match(/r(?<ok>ys)/) { |md| md["ng"] } #=> raises ArgumentError
+    # ```
+    def [](group_name : String)
+      match = self[group_name]?
+      unless match
+        raise ArgumentError.new("Match group named '#{group_name}' does not exist")
       end
+      match
     end
-    io << ">"
-  end
 
-  private def byte_index_to_char_index(index)
-    reader = CharReader.new(@string)
-    i = 0
-    reader.each do |char|
-      break if reader.pos == index
-      i += 1
+    # Returns the part of the original string before the match. If the match
+    # starts at the start of the string, returns the empty string.
+    #
+    # ```
+    # "Crystal".match(/yst/) { |md| md.pre_match } #=> "Cr"
+    # ```
+    def pre_match
+      @string.byte_slice(0, byte_begin(0))
     end
-    i
-  end
 
-  private def check_index_out_of_bounds(index)
-    raise IndexError.new unless valid_group?(index)
-  end
+    # Returns the part of the original string after the match. If the match ends
+    # at the end of the string, returns the empty string.
+    #
+    # ```
+    # "Crystal".match(/yst/) { |md| md.post_match } #=> "al"
+    # ```
+    def post_match
+      @string.byte_slice(byte_end(0))
+    end
 
-  private def valid_group?(index)
-    index <= @size
+    def inspect(io : IO)
+      to_s(io)
+    end
+
+    def to_s(io : IO)
+      name_table = @regex.name_table
+
+      io << "#<Regex::MatchData "
+      self[0].inspect(io)
+      if size > 0
+        io << " "
+        size.times do |i|
+          io << " " if i > 0
+          io << name_table.fetch(i + 1) { i + 1 }
+          io << ":"
+          self[i + 1]?.inspect(io)
+        end
+      end
+      io << ">"
+    end
+
+    private def byte_index_to_char_index(index)
+      reader = CharReader.new(@string)
+      i = 0
+      reader.each do |char|
+        break if reader.pos == index
+        i += 1
+      end
+      i
+    end
+
+    private def check_index_out_of_bounds(index)
+      raise IndexError.new unless valid_group?(index)
+    end
+
+    private def valid_group?(index)
+      index <= @size
+    end
   end
 end

--- a/src/regex/regex.cr
+++ b/src/regex/regex.cr
@@ -9,7 +9,7 @@ require "./*"
 #
 # ```
 # /hay/ =~ "haystack"   #=> 0
-# /y/.match("haystack") #=> #<MatchData "y">
+# /y/.match("haystack") #=> #<Regex::MatchData "y">
 # ```
 #
 # Interpolation works in regular expression literals just as it does in string
@@ -19,7 +19,7 @@ require "./*"
 #
 # ```
 # x = "a"
-# /#{x}/.match("asdf") #=> #<MatchData "a">
+# /#{x}/.match("asdf") #=> #<Regex::MatchData "a">
 # x = "("
 # /#{x}/ #=> ArgumentError
 # ```
@@ -39,12 +39,12 @@ require "./*"
 # Here `"haystack"` contains the pattern `/hay/`, so it matches:
 #
 # ```
-# /hay/.match("haystack")    #=> #<MatchData "hay">
+# /hay/.match("haystack")    #=> #<Regex::MatchData "hay">
 # ```
 #
 # Regex methods that perform a match usually return a truthy value if there was
 # a match and `nil` if there was no match. After performing a match, the
-# special variable `$~` will be an instance of `MatchData` if it matched, `nil`
+# special variable `$~` will be an instance of `Regex::MatchData` if it matched, `nil`
 # otherwise.
 #
 # When matching a regular expression using `=~` (either `String#=~` or
@@ -54,20 +54,20 @@ require "./*"
 # ```
 # /stack/ =~ "haystack"  #=> 3
 # "haystack" =~ /stack/  #=> 3
-# $~                     #=> #<MatchData "stack">
+# $~                     #=> #<Regex::MatchData "stack">
 # /needle/ =~ "haystack" #=> nil
 # "haystack" =~ /needle/ #=> nil
 # $~                     #=> nil
 # ```
 #
 # When matching a regular expression using `#match` (either `String#match` or
-# `Regex#match`), the returned value will be a `MatchData` if the expression
+# `Regex#match`), the returned value will be a `Regex::MatchData` if the expression
 # matched, `nil` otherwise.
 #
 # ```
-# /hay/.match("haystack")    #=> #<MatchData "hay">
-# "haystack".match(/hay/)    #=> #<MatchData "hay">
-# $~                         #=> #<MatchData "hay">
+# /hay/.match("haystack")    #=> #<Regex::MatchData "hay">
+# "haystack".match(/hay/)    #=> #<Regex::MatchData "hay">
+# $~                         #=> #<Regex::MatchData "hay">
 # /needle/.match("haystack") #=> nil
 # "haystack".match(/needle/) #=> nil
 # $~                         #=> nil
@@ -101,9 +101,9 @@ require "./*"
 # each capture group can be extracted on a successful match:
 #
 # ```
-# /a(sd)f/.match("_asdf_")  #=> #<MatchData "asdf" 1:"sd">
+# /a(sd)f/.match("_asdf_")  #=> #<Regex::MatchData "asdf" 1:"sd">
 # /a(sd)f/.match("_asdf_") { |md| md[1] } } #=> "sd"
-# /a(?<grp>sd)f/.match("_asdf_") #=> #<MatchData "asdf" grp:"sd">
+# /a(?<grp>sd)f/.match("_asdf_") #=> #<Regex::MatchData "asdf" grp:"sd">
 # /a(?<grp>sd)f/.match("_asdf_") { |md| md["grp"] } } #=> "sd"
 # ```
 #
@@ -120,17 +120,17 @@ require "./*"
 # (`?`) (zero or one).
 #
 # ```
-# /fo*/.match("_f_")         #=> #<MatchData "f">
+# /fo*/.match("_f_")         #=> #<Regex::MatchData "f">
 # /fo+/.match("_f_")         #=> nil
-# /fo*/.match("_foo_")       #=> #<MatchData "foo">
+# /fo*/.match("_foo_")       #=> #<Regex::MatchData "foo">
 # /fo{3,}/.match("_foo_")    #=> nil
-# /fo{1,3}/.match("_foo_")   #=> #<MatchData "foo">
-# /fo*/.match("_foo_")       #=> #<MatchData "foo">
-# /fo*/.match("_foooooooo_") #=> #<MatchData "foooooooo">
+# /fo{1,3}/.match("_foo_")   #=> #<Regex::MatchData "foo">
+# /fo*/.match("_foo_")       #=> #<Regex::MatchData "foo">
+# /fo*/.match("_foooooooo_") #=> #<Regex::MatchData "foooooooo">
 # /fo{,3}/.match("_foooo_")  #=> nil
-# /f(op)*/.match("fopopo")   #=> #<MatchData "fopop" 1: "op">
-# /foo?bar/.match("foobar")  #=> #<MatchData "foobar">
-# /foo?bar/.match("fobar")   #=> #<MatchData "fobar">
+# /f(op)*/.match("fopopo")   #=> #<Regex::MatchData "fopop" 1: "op">
+# /foo?bar/.match("foobar")  #=> #<Regex::MatchData "foobar">
+# /foo?bar/.match("fobar")   #=> #<Regex::MatchData "fobar">
 # ```
 #
 # Alternatives can be separated using a
@@ -143,17 +143,17 @@ require "./*"
 # enclosed in square brackets (`[]`):
 #
 # ```
-# /foo|bar/.match("foo")     #=> #<MatchData "foo">
-# /foo|bar/.match("bar")     #=> #<MatchData "bar">
-# /_(x|y)_/.match("_x_")     #=> #<MatchData "_x_" 1: "x">
-# /_(x|y)_/.match("_y_")     #=> #<MatchData "_y_" 1: "y">
+# /foo|bar/.match("foo")     #=> #<Regex::MatchData "foo">
+# /foo|bar/.match("bar")     #=> #<Regex::MatchData "bar">
+# /_(x|y)_/.match("_x_")     #=> #<Regex::MatchData "_x_" 1: "x">
+# /_(x|y)_/.match("_y_")     #=> #<Regex::MatchData "_y_" 1: "y">
 # /_(x|y)_/.match("_(x|y)_") #=> nil
 # /_(x|y)_/.match("_(x|y)_") #=> nil
-# /_._/.match("_x_")         #=> #<MatchData "_x_">
-# /_[xyz]_/.match("_x_")     #=> #<MatchData "_x_">
-# /_[a-z]_/.match("_x_")     #=> #<MatchData "_x_">
+# /_._/.match("_x_")         #=> #<Regex::MatchData "_x_">
+# /_[xyz]_/.match("_x_")     #=> #<Regex::MatchData "_x_">
+# /_[a-z]_/.match("_x_")     #=> #<Regex::MatchData "_x_">
 # /_[^a-z]_/.match("_x_")    #=> nil
-# /_[^a-wy-z]_/.match("_x_") #=> #<MatchData "_x_">
+# /_[^a-wy-z]_/.match("_x_") #=> #<Regex::MatchData "_x_">
 # ```
 #
 # Regular expressions can be defined with these 3
@@ -277,11 +277,11 @@ class Regex
   #
   # ```
   # re = Regex.union([/skiing/i, "sledding"])
-  # re.match("Skiing")   #=> #<MatchData "Skiing">
-  # re.match("sledding") #=> #<MatchData "sledding">
+  # re.match("Skiing")   #=> #<Regex::MatchData "Skiing">
+  # re.match("sledding") #=> #<Regex::MatchData "sledding">
   # re = Regex.union({/skiing/i, "sledding"})
-  # re.match("Skiing")   #=> #<MatchData "Skiing">
-  # re.match("sledding") #=> #<MatchData "sledding">
+  # re.match("Skiing")   #=> #<Regex::MatchData "Skiing">
+  # re.match("sledding") #=> #<Regex::MatchData "sledding">
   # ```
   def self.union(patterns : Enumerable(Regex | String))
     new patterns.map { |pattern| union_part pattern }.join("|")
@@ -295,8 +295,8 @@ class Regex
   #
   # ```
   # re = Regex.union(/skiing/i, "sledding")
-  # re.match("Skiing")   #=> #<MatchData "Skiing">
-  # re.match("sledding") #=> #<MatchData "sledding">
+  # re.match("Skiing")   #=> #<Regex::MatchData "Skiing">
+  # re.match("sledding") #=> #<Regex::MatchData "sledding">
   # ```
   def self.union(*patterns : Regex | String)
     union patterns
@@ -318,8 +318,8 @@ class Regex
   #
   # ```
   # re = /skiing/i + /sledding/
-  # re.match("Skiing")   #=> #<MatchData "Skiing">
-  # re.match("sledding") #=> #<MatchData "sledding">
+  # re.match("Skiing")   #=> #<Regex::MatchData "Skiing">
+  # re.match("sledding") #=> #<Regex::MatchData "sledding">
   # ```
   def +(other)
     Regex.union(self, other)
@@ -338,7 +338,7 @@ class Regex
 
   # Case equality. This is equivalent to `#match` or `#=~` but only returns
   # `true` or `false`. Used in `case` expressions. The special variable
-  # `$~` will contain a `MatchData` if there was a match, `nil` otherwise.
+  # `$~` will contain a `Regex::MatchData` if there was a match, `nil` otherwise.
   #
   # ```
   # a = "HELLO"
@@ -360,7 +360,7 @@ class Regex
 
   # Match. Matches a regular expression against `other` and returns
   # the starting position of the match if `other` is a matching String,
-  # otherwise `nil`. `$~` will contain a MatchData if there was a match,
+  # otherwise `nil`. `$~` will contain a Regex::MatchData if there was a match,
   # `nil` otherwise.
   #
   # ```
@@ -401,7 +401,7 @@ class Regex
 
   # Match at character index. Matches a regular expression against String
   # `str`. Starts at the character index given by `pos` if given, otherwise at
-  # the start of `str`. Returns a `MatchData` if `str` matched, otherwise
+  # the start of `str`. Returns a `Regex::MatchData` if `str` matched, otherwise
   # `nil`. `$~` will contain the same value that was returned.
   #
   # ```
@@ -421,7 +421,7 @@ class Regex
 
   # Match at byte index. Matches a regular expression against String
   # `str`. Starts at the byte index given by `pos` if given, otherwise at
-  # the start of `str`. Returns a MatchData if `str` matched, otherwise
+  # the start of `str`. Returns a Regex::MatchData if `str` matched, otherwise
   # `nil`. `$~` will contain the same value that was returned.
   #
   # ```
@@ -483,7 +483,7 @@ class Regex
   # ```
   # re = /A*/i                 #=> /A*/i
   # re.to_s                    #=> "(?i-msx:A*)"
-  # "Crystal".match(/t#{re}l/) #=> #<MatchData "tal">
+  # "Crystal".match(/t#{re}l/) #=> #<Regex::MatchData "tal">
   # re = /A*/                  #=> "(?-imsx:A*)"
   # "Crystal".match(/t#{re}l/) #=> nil
   # ```

--- a/src/string.cr
+++ b/src/string.cr
@@ -2044,7 +2044,7 @@ class String
   end
 
   def scan(pattern : Regex)
-    matches = [] of MatchData
+    matches = [] of Regex::MatchData
     scan(pattern) do |match|
       matches << match
     end


### PR DESCRIPTION
Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.
* Constructing a MatchData can sort of be considered internal API with its public API on String and Regex, that is you'll rarely reference `Regex::MatchData` in user code.