### PR TITLE
Rename (Un)SignedInt to Int::(Un)Signed

### DIFF
--- a/src/big_int/big_int.cr
+++ b/src/big_int/big_int.cr
@@ -1,8 +1,8 @@
 require "./lib_gmp"
 
 struct BigInt < Int
-  include Comparable(SignedInt)
-  include Comparable(UnsignedInt)
+  include Comparable(Int::Signed)
+  include Comparable(Int::Unsigned)
   include Comparable(BigInt)
 
   def initialize
@@ -13,7 +13,7 @@ struct BigInt < Int
     LibGMP.init_set_str(out @mpz, str, base)
   end
 
-  def initialize(num : SignedInt)
+  def initialize(num : Int::Signed)
     if LibC::Long::MIN <= num <= LibC::Long::MAX
       LibGMP.init_set_si(out @mpz, LibC::Long.new(num))
     else
@@ -21,7 +21,7 @@ struct BigInt < Int
     end
   end
 
-  def initialize(num : UnsignedInt)
+  def initialize(num : Int::Unsigned)
     if num <= LibC::ULong::MAX
       LibGMP.init_set_ui(out @mpz, LibC::ULong.new(num))
     else
@@ -42,7 +42,7 @@ struct BigInt < Int
     LibGMP.cmp(mpz, other)
   end
 
-  def <=>(other : SignedInt)
+  def <=>(other : Int::Signed)
     if LibC::Long::MIN <= other <= LibC::Long::MAX
       LibGMP.cmp_si(mpz, LibC::Long.new(other))
     else
@@ -50,7 +50,7 @@ struct BigInt < Int
     end
   end
 
-  def <=>(other : UnsignedInt)
+  def <=>(other : Int::Unsigned)
     if other <= LibC::ULong::MAX
       LibGMP.cmp_ui(mpz, LibC::ULong.new(other))
     else
@@ -94,11 +94,11 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.mul(mpz, self, other) }
   end
 
-  def *(other : SignedInt)
+  def *(other : Int::Signed)
     BigInt.new { |mpz| LibGMP.mul_si(mpz, self, LibC::Long.new(other)) }
   end
 
-  def *(other : UnsignedInt)
+  def *(other : Int::Unsigned)
     BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, LibC::ULong.new(other)) }
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -113,7 +113,7 @@ module Crystal
       when "-"
         if args.empty?
           num = to_number
-          if num.is_a?(UnsignedInt)
+          if num.is_a?(Int::Unsigned)
             raise "undefined method '-' for unsigned integer literal: #{self}"
           else
             NumberLiteral.new(-num)

--- a/src/int.cr
+++ b/src/int.cr
@@ -56,6 +56,9 @@
 # 0xfe012d # == 16646445
 # ```
 struct Int
+  alias Signed = Int8 | Int16 | Int32 | Int64
+  alias Unsigned = UInt8 | UInt16 | UInt32 | UInt64
+
   def ~
     self ^ -1
   end
@@ -475,6 +478,3 @@ struct UInt64
     self
   end
 end
-
-alias SignedInt = Int8 | Int16 | Int32 | Int64
-alias UnsignedInt = UInt8 | UInt16 | UInt32 | UInt64


### PR DESCRIPTION
Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.