### PR TITLE
Rename IO related classes

### DIFF
--- a/src/concurrent/scheduler.cr
+++ b/src/concurrent/scheduler.cr
@@ -32,11 +32,11 @@ class Scheduler
     event.free
   end
 
-  def self.create_fd_write_event(io : FileDescriptorIO, edge_triggered = false : Bool)
+  def self.create_fd_write_event(io : IO::FileDescriptor, edge_triggered = false : Bool)
     flags = LibEvent2::EventFlags::Write
     flags |= LibEvent2::EventFlags::Persist | LibEvent2::EventFlags::ET if edge_triggered
     event = @@eb.new_event(io.fd, flags, io) do |s, flags, data|
-      fd_io = data as FileDescriptorIO
+      fd_io = data as IO::FileDescriptor
       if flags.includes?(LibEvent2::EventFlags::Write)
         fd_io.resume_write
       elsif flags.includes?(LibEvent2::EventFlags::Timeout)
@@ -47,11 +47,11 @@ class Scheduler
     event
   end
 
-  def self.create_fd_read_event(io : FileDescriptorIO, edge_triggered = false : Bool)
+  def self.create_fd_read_event(io : IO::FileDescriptor, edge_triggered = false : Bool)
     flags = LibEvent2::EventFlags::Read
     flags |= LibEvent2::EventFlags::Persist | LibEvent2::EventFlags::ET if edge_triggered
     event = @@eb.new_event(io.fd, flags, io) do |s, flags, data|
-      fd_io = data as FileDescriptorIO
+      fd_io = data as IO::FileDescriptor
       if flags.includes?(LibEvent2::EventFlags::Read)
         fd_io.resume_read
       elsif flags.includes?(LibEvent2::EventFlags::Timeout)

--- a/src/file.cr
+++ b/src/file.cr
@@ -11,7 +11,7 @@ lib LibC
   R_OK = 1 << 2
 end
 
-class File < FileDescriptorIO
+class File < IO::FileDescriptor
   # The file/directory separator character. '/' in unix, '\\' in windows.
   SEPARATOR = ifdef windows; '\\'; else; '/'; end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -239,8 +239,8 @@ module IO
       raise Errno.new("Could not create pipe")
     end
 
-    r = FileDescriptorIO.new(pipe_fds[0], read_blocking)
-    w = FileDescriptorIO.new(pipe_fds[1], write_blocking)
+    r = IO::FileDescriptor.new(pipe_fds[0], read_blocking)
+    w = IO::FileDescriptor.new(pipe_fds[1], write_blocking)
     r.close_on_exec = true
     w.close_on_exec = true
     w.sync = true

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -1,10 +1,10 @@
-# The BufferedIO mixin enhances the IO module with input/output buffering.
+# The IO::Buffered mixin enhances the IO module with input/output buffering.
 #
 # The buffering behaviour can be turned on/off with the `#sync=` method.
 #
 # Additionally, several methods, like `#gets`, are implemented in a more
 # efficient way.
-module BufferedIO
+module IO::Buffered
   include IO
 
   BUFFER_SIZE = 8192

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -1,6 +1,6 @@
 # An IO over a file descriptor.
-class FileDescriptorIO
-  include BufferedIO
+class IO::FileDescriptor
+  include Buffered
 
   private getter! readers
   private getter! writers
@@ -135,7 +135,7 @@ class FileDescriptorIO
     LibC.isatty(fd) == 1
   end
 
-  def reopen(other : FileDescriptorIO)
+  def reopen(other : IO::FileDescriptor)
     if LibC.dup2(other.fd, self.fd) == -1
       raise Errno.new("Could not reopen file descriptor")
     end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -1,6 +1,6 @@
-STDIN = FileDescriptorIO.new(0, blocking: LibC.isatty(0) == 0)
-STDOUT = (FileDescriptorIO.new(1, blocking: LibC.isatty(1) == 0)).tap { |f| f.flush_on_newline = true }
-STDERR = FileDescriptorIO.new(2, blocking: LibC.isatty(2) == 0)
+STDIN = IO::FileDescriptor.new(0, blocking: LibC.isatty(0) == 0)
+STDOUT = (IO::FileDescriptor.new(1, blocking: LibC.isatty(1) == 0)).tap { |f| f.flush_on_newline = true }
+STDERR = IO::FileDescriptor.new(2, blocking: LibC.isatty(2) == 0)
 
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
 ARGV = (ARGV_UNSAFE + 1).to_slice(ARGC_UNSAFE - 1).map { |c_str| String.new(c_str) }

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -173,7 +173,7 @@ class Process
   end
 
   private def needs_pipe?(io)
-    io.nil? || (io.is_a?(IO) && !io.is_a?(FileDescriptorIO))
+    io.nil? || (io.is_a?(IO) && !io.is_a?(IO::FileDescriptor))
   end
 
   private def copy_io(src, dst, channel, close_src = false, close_dst = false)
@@ -201,7 +201,7 @@ class Process
 
   private def reopen_io(src_io, dst_io, mode)
     case src_io
-    when FileDescriptorIO
+    when IO::FileDescriptor
       src_io.blocking = true
       dst_io.reopen(src_io)
     when true

--- a/src/socket/socket.cr
+++ b/src/socket/socket.cr
@@ -1,6 +1,6 @@
 require "./libc"
 
-class Socket < FileDescriptorIO
+class Socket < IO::FileDescriptor
   class Error < Exception
   end
 

--- a/src/tempfile.cr
+++ b/src/tempfile.cr
@@ -2,7 +2,7 @@ lib LibC
   fun mkstemp(result : Char*) : Int
 end
 
-class Tempfile < FileDescriptorIO
+class Tempfile < IO::FileDescriptor
   def initialize(name)
     if tmpdir = ENV["TMPDIR"]?
       tmpdir = tmpdir + File::SEPARATOR unless tmpdir.ends_with? File::SEPARATOR


### PR DESCRIPTION
* FileDescriptorIO -> IO::FileDescriptor
* BufferedIO -> IO::Buffered

Rationale:

* Group related types together so they're easier discovered in the docs.
* Don't fill up the global namespace if there's no real reason to do so, that is if there's a namespaced place that's equally fine.
* The primary interfaces are File, Socket, STDIN/STDOUT/STDERR, direct access to these is rarer. Also consistency.