### PR TITLE
Add `Array#flatten!`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1401,4 +1401,11 @@ describe "Array" do
   it "flattens" do
     [[1, 'a'], [[[[true], "hi"]]]].flatten.should eq([1, 'a', true, "hi"])
   end
+
+  it "flatten!" do
+    ary = [1,'a',true,"foo", [2, 'b'], [[[[false], "hello"]]]]
+    expect = [1, 'a', true, "foo", 2, 'b', false, "hello"]
+    ary.flatten!.should eq(expect)
+    ary.should eq(expect)
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -992,6 +992,19 @@ class Array(T)
     FlattenHelper(typeof(FlattenHelper.element_type(self))).flatten(self)
   end
 
+  # Removes `Array#flatten` elements from `self`. Returns `self`.
+  #
+  # ```
+  # s = [1, [2]]
+  # s.flatten!                 #=> [1,2]
+  # s                          #=> [1,2]
+  # [1,['1']].flatten!         #=> Gives compile error because the array doesn't accept Char type.
+  # ```
+  def flatten!
+    ary = FlattenHelper(typeof(FlattenHelper.element_type(self))).flatten(self)
+    replace ary
+  end
+
   def repeated_combinations(size = self.size : Int)
     ary = [] of Array(T)
     each_repeated_combination(size) do |a|


### PR DESCRIPTION
Add `Array#flatten!`.

```
ary = [1,[2]]
ary.flatten!         #=> [1,2]
ary                     #=> [1,2]
[1,['2']].flatten!   #=>Gives compile error because the array doesn't accept Char type.
```