### PR TITLE
Add IO#write(Enumerable(UInt8))

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -373,6 +373,18 @@ describe IO do
       io.read.should eq("ab")
     end
 
+    it "writes a tuple of bytes" do
+      io = SimpleStringIO.new
+      io.write({'a'.ord.to_u8, 'b'.ord.to_u8})
+      io.read.should eq("ab")
+    end
+
+    it "writes a collection of bytes" do
+      io = SimpleStringIO.new
+      io.write Set {'a'.ord.to_u8, 'b'.ord.to_u8 }
+      io.read.should eq("ab")
+    end
+
     it "writes with printf" do
       io = SimpleStringIO.new
       io.printf "Hello %d", 123

--- a/src/io.cr
+++ b/src/io.cr
@@ -622,6 +622,13 @@ module IO
     write Slice.new(array.buffer, array.size)
   end
 
+  # Writes the bytes in the given enumerable to this IO.
+  def write(bytes : Enumerable(UInt8))
+    bytes.each do |byte|
+      write_byte byte
+    end
+  end
+
   # Writes a single byte into this IO.
   #
   # ```


### PR DESCRIPTION
Allows writing for example tuples of bytes, or sets. Sadly not iterators since classes including Iterator(T) which includes Enumerable(T)  somehow doesn't pass the type restriction, but it'll work once that's fixed.