### PR TITLE
More JSON error messages

### DIFF
--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -12,7 +12,9 @@ module Crystal
 
     abstract def to_s_with_source(source, io)
 
-    abstract def to_json(io)
+    def to_json(io)
+      io.json_array { |ar| json_obj(ar) }
+    end
 
     def true_filename(filename=@filename) : String
       if filename.is_a? VirtualFile
@@ -80,9 +82,9 @@ module Crystal
       @filename || @line
     end
 
-    def to_json(io)
-      {file: true_filename, line: @line_number, column: @column_number,
-       size: @size, message: @message}.to_json(io)
+    def json_obj(ar)
+      ar << {file: true_filename, line: @line_number, column: @column_number,
+             size: @size, message: @message}
     end
 
     def append_to_s(source, io)
@@ -167,12 +169,11 @@ module Crystal
       new message, nil, 0, nil, 0
     end
 
-    def to_json(io)
-      if (inner = @inner) && !inner.is_a? MethodTraceException
-        inner.to_json(io)
-      else
-        {file: true_filename, line: @line, column: @column,
-         size: @size, message: deepest_error_message || @message}.to_json(io)
+    def json_obj(ar)
+      ar << {file: true_filename, line: @line, column: @column,
+             size: @size, message: @message}
+      if inner = @inner
+        inner.json_obj(ar)
       end
     end
 
@@ -276,8 +277,7 @@ module Crystal
       true
     end
 
-    def to_json(io)
-      nil.to_json(io)
+    def json_obj(ar)
     end
 
     def to_s_with_source(source, io)

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -13,7 +13,7 @@ module Crystal
     abstract def to_s_with_source(source, io)
 
     def to_json(io)
-      io.json_array { |ar| json_obj(ar) }
+      io.json_array { |ar| json_obj(ar, io) }
     end
 
     def true_filename(filename=@filename) : String
@@ -82,9 +82,16 @@ module Crystal
       @filename || @line
     end
 
-    def json_obj(ar)
-      ar << {file: true_filename, line: @line_number, column: @column_number,
-             size: @size, message: @message}
+    def json_obj(ar, io)
+      ar.push do
+        io.json_object do |obj|
+          obj.field "file", true_filename
+          obj.field "line", @line_number
+          obj.field "column", @column_number
+          obj.field "size", @size
+          obj.field "message", @message
+        end
+      end
     end
 
     def append_to_s(source, io)
@@ -169,11 +176,18 @@ module Crystal
       new message, nil, 0, nil, 0
     end
 
-    def json_obj(ar)
-      ar << {file: true_filename, line: @line, column: @column,
-             size: @size, message: @message}
+    def json_obj(ar, io)
+      ar.push do
+        io.json_object do |obj|
+          obj.field "file", true_filename
+          obj.field "line", @line
+          obj.field "column", @column
+          obj.field "size", @size
+          obj.field "message", @message
+        end
+      end
       if inner = @inner
-        inner.json_obj(ar)
+        inner.json_obj(ar, io)
       end
     end
 
@@ -277,7 +291,7 @@ module Crystal
       true
     end
 
-    def json_obj(ar)
+    def json_obj(ar, io)
     end
 
     def to_s_with_source(source, io)


### PR DESCRIPTION
<s>So...odd thing. It kind of works. But it does this:

```json
[{"file":"/media/ryan/stuff/crystal/x.cr","line":2,"column":4,"size":1,"message":"no overload matches 'Int32#+' with types String\nOverloads are:\n - Int32#+(other : Int8)\n - Int32#+(other : Int16)\n - Int32#+(other : Int32)\n - Int32#+(other : Int64)\n - Int32#+(other : UInt8)\n - Int32#+(other : UInt16)\n - Int32#+(other : UInt32)\n - Int32#+(other : UInt64)\n - Int32#+(other : Float32)\n - Int32#+(other : Float64)\n - Int32#+()"}{"file":"/media/ryan/stuff/crystal/x.cr","line":10,"column":1,"size":1,"message":"instantiating 'x(Array(Int32)?)'"}]
```

Notice that there's no comma.

But it'll work soon! Just give me a few more moments. :)</s> Now it works. Somehow. :/
