### PR TITLE
Fix the occurences of hierarchy in the docs

### DIFF
--- a/_gitbook/syntax_and_semantics/generics.md
+++ b/_gitbook/syntax_and_semantics/generics.md
@@ -19,7 +19,7 @@ For example, if we take the above code and add this:
 MyBox.new(1)
 ```
 
-and then check what the compiler inferred with `crystal hierarchy file.cr`, we get:
+and then check what the compiler inferred with `crystal tool hierarchy file.cr`, we get:
 
 ```
 +- class MyBox
@@ -74,7 +74,7 @@ box = MyBox(String).new("hello")
 box.value.size #=> 5
 ```
 
-The above now works, because `MyBox` is now not a single type, but a family of types identified with a `T` type: `MyBox(Int32)` is a different type than `MyBox(String)`, and their `@value` variable is not shared. If we run the `hierarchy` command again, we get:
+The above now works, because `MyBox` is now not a single type, but a family of types identified with a `T` type: `MyBox(Int32)` is a different type than `MyBox(String)`, and their `@value` variable is not shared. If we run the `tool hierarchy` command again, we get:
 
 ```
 +- generic class MyBox(T)

--- a/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
+++ b/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
@@ -28,7 +28,7 @@ one.name #=> 1
 one.name + 2 #=> 3
 ```
 
-If you compile the previous programs with the `hierarchy` command, the compiler will show you a hierarchy graph with the types it inferred. In the first case:
+If you compile the previous programs with the `tool hierarchy` command, the compiler will show you a hierarchy graph with the types it inferred. In the first case:
 
 ```
 - class Object
@@ -59,7 +59,7 @@ john = Person.new "John"
 one = Person.new 1
 ```
 
-Invoking the compiler with the `hierarchy` command we get:
+Invoking the compiler with the `tool hierarchy` command we get:
 
 ```
 - class Object

--- a/_gitbook/syntax_and_semantics/virtual_and_abstract_types.md
+++ b/_gitbook/syntax_and_semantics/virtual_and_abstract_types.md
@@ -29,7 +29,7 @@ john = Person.new "John", Dog.new
 peter = Person.new "Peter", Cat.new
 ```
 
-If you compile the above program with the `hierarchy` command you will see this for `Person`:
+If you compile the above program with the `tool hierarchy` command you will see this for `Person`:
 
 ```
 - class Object

--- a/_gitbook/using_the_compiler/README.md
+++ b/_gitbook/using_the_compiler/README.md
@@ -73,16 +73,14 @@ Usage: crystal [command] [switches] [program file] [--] [arguments]
 Command:
     init                     generate new crystal project
     build                    compile program file
-    browser                  open an http server to browse program file
     deps                     install project dependencies
     docs                     generate documentation
-    eval                     eval code
-    hierarchy                show type hierarchy
+    eval                     eval code from args or standard input
     run (default)            compile and run program file
     spec                     compile and run specs (in spec directory)
-    types                    show type of main variables
-    --help                   show this help
-    --version                show version
+    tool                     run a tool
+    --help, -h               show this help
+    --version, -v            show version
 ```
 
 To see the available options for a particuar command, use `--help` after a command:
@@ -101,7 +99,7 @@ Options:
     --link-flags FLAGS               Additional flags to pass to the linker
     --mcpu CPU                       Target specific cpu type
     --no-color                       Disable colored output
-    --no-build                       Disable build output
+    --no-codegen                     Don't do code generation
     -o                               Output filename
     --prelude                        Use given file as prelude
     --release                        Compile in release mode


### PR DESCRIPTION
The command `hierachrchy` has moved to `crystal tool hierarchy`.
Fixed all occurences and fixed also the output when running `crystal`

This closes #1502