### PR TITLE
Add `HTTP::Request#query_params`

### DIFF
--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -1,5 +1,6 @@
 require "./common"
 require "uri"
+require "http/params"
 
 class HTTP::Request
   getter method
@@ -21,7 +22,14 @@ class HTTP::Request
     @cookies ||= Cookies.from_headers(headers)
   end
 
+  # Returns a convenience wrapper around querying and setting query params,
+  # see `HTTP::Params`.
+  def query_params
+    @query_params ||= parse_query_params
+  end
+
   def resource
+    update_uri
     @uri.try(&.full_path) || @resource
   end
 
@@ -56,12 +64,33 @@ class HTTP::Request
   delegate "path=", uri
 
   # Lazily parses request's query component.
-  delegate "query", uri
+  def query
+    update_uri
+    uri.query
+  end
 
   # Sets request's query component.
-  delegate "query=", uri
+  def query=(value)
+    uri.query = value
+    update_query_params
+    value
+  end
 
   private def uri
     (@uri ||= URI.parse(@resource)).not_nil!
+  end
+
+  private def parse_query_params
+    HTTP::Params.parse(uri.query || "")
+  end
+
+  private def update_query_params
+    return unless @query_params
+    @query_params = parse_query_params
+  end
+
+  private def update_uri
+    return unless @query_params
+    uri.query = query_params.to_s
   end
 end


### PR DESCRIPTION
This is part of #1392 

I am creating this PR to collect some feedback. Since this feels far from ideal.

List of things and concerns:

- `#path` actually returns full request uri (`Request-URI` here: http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html). Am I right that this is not correct? For example for `/foo?q=bar`, `path.should eq "/foo"`, not `"/foo?q=bar"`.
- I found out that `HTTP::Request` can be used both ways: as an incoming request for reading, and can be constructed on its own and sent out to `io`.
- Therefore I had to implement some sort of mutable `query_params` (I thought about them as read-only before that). And current implementation is weird: each time you access `#uri`, it will serialize `query_params` and mutate `@uri` before returning it. This is quite unexpected behavior and will lead to performance decreases (probably?).

After thinking about a bit, I come up with idea of having a `Params` struct (Hash wrapper), that will hold reference to `@uri` it belongs to and have `#[]=(k, v)`, that will update `@uri.query` accordingly. That way it might look less weird and will serialize only when params get mutated by user of stdlib. It will look something along these lines:

```crystal
struct Params
  def initialize(@uri)
    @data = parse(@uri.query)
  end

  def []=(key, value)
    @data[key] = value
    @uri.query = serialize(@data)
  end

  forward_missing_to @data
end
```

WDYT?