### PR TITLE
Add future {} and lazy {} macros to make concurrency easier.

### DIFF
--- a/spec/std/concurrent/future_spec.cr
+++ b/spec/std/concurrent/future_spec.cr
@@ -1,0 +1,109 @@
+require "spec"
+
+describe Concurrent::Future do
+  describe "delay" do
+    it "computes a value" do
+      chan = Channel(Int32).new(1)
+
+      d = delay(0.05) { chan.receive }
+      d.delayed?.should be_true
+
+      chan.send 3
+
+      d.get.should eq(3)
+      d.completed?.should be_true
+    end
+
+    it "cancels" do
+      d = delay(1) { 42 }
+      d.delayed?.should be_true
+
+      d.cancel
+      d.canceled?.should be_true
+
+      expect_raises(Concurrent::CanceledError) { d.get }
+    end
+
+    it "raises" do
+      d = delay(0.001) { raise IndexError.new("test error") }
+
+      expect_raises(IndexError) { d.get }
+      d.completed?.should be_true
+    end
+  end
+
+  describe "future" do
+    it "computes a value" do
+      chan = Channel(Int32).new(1)
+
+      f = future { chan.receive }
+      f.running?.should be_true
+
+      chan.send 42
+      Scheduler.yield
+      f.completed?.should be_true
+
+      f.get.should eq(42)
+      f.completed?.should be_true
+    end
+
+    it "can't cancel a completed computation" do
+      f = future { 42 }
+      f.running?.should be_true
+
+      f.get.should eq(42)
+      f.completed?.should be_true
+
+      f.cancel
+      f.canceled?.should be_false
+    end
+
+    it "raises" do
+      f = future { raise IndexError.new("test error") }
+      f.running?.should be_true
+
+      Scheduler.yield
+      f.completed?.should be_true
+
+      expect_raises(IndexError) { f.get }
+      f.completed?.should be_true
+    end
+  end
+
+  describe "lazy" do
+    it "computes a value" do
+      chan = Channel(Int32).new(1)
+
+      f = lazy { chan.receive }
+      f.idle?.should be_true
+
+      chan.send 42
+      Scheduler.yield
+      f.idle?.should be_true
+
+      f.get.should eq(42)
+      f.completed?.should be_true
+    end
+
+    it "cancels" do
+      l = lazy { 42 }
+      l.idle?.should be_true
+
+      l.cancel
+      l.canceled?.should be_true
+
+      expect_raises(Concurrent::CanceledError) { l.get }
+    end
+
+    it "raises" do
+      f = lazy { raise IndexError.new("test error") }
+      f.idle?.should be_true
+
+      Scheduler.yield
+      f.idle?.should be_true
+
+      expect_raises(IndexError) { f.get }
+      f.completed?.should be_true
+    end
+  end
+end

--- a/src/concurrent/error.cr
+++ b/src/concurrent/error.cr
@@ -1,0 +1,3 @@
+module Concurrent
+  class CanceledError < Exception; end
+end

--- a/src/concurrent/future.cr
+++ b/src/concurrent/future.cr
@@ -1,0 +1,143 @@
+# :nodoc:
+class Concurrent::Future(R)
+  enum State
+    Idle
+    Delayed
+    Running
+    Completed
+    Canceled
+  end
+
+  def initialize run_immediately = true, delay = 0 : Number, &@block : -> R
+    @state = State::Idle
+    @value = nil
+    @error = nil
+    @channel = Channel(Nil).new
+    @delay = delay
+    @cancel_msg = nil
+
+    spawn_compute if run_immediately
+  end
+
+  def get
+    wait
+    value_or_raise
+  end
+
+  def success?
+    completed? && !@error
+  end
+
+  def failure?
+    completed? && @error
+  end
+
+  def canceled?
+    @state == State::Canceled
+  end
+
+  def completed?
+    @state == State::Completed
+  end
+
+  def running?
+    @state == State::Running
+  end
+
+  def delayed?
+    @state == State::Delayed
+  end
+
+  def idle?
+    @state == State::Idle
+  end
+
+  def cancel msg = "Future canceled, you reached the [End of Time]"
+    return if @state >= State::Completed
+    @state = State::Canceled
+    @cancel_msg = msg
+    @channel.close
+    nil
+  end
+
+  private def spawn_compute
+    return if @state >= State::Delayed
+
+    delay = @delay
+    @state = delay > 0 ? State::Delayed : State::Running
+
+    spawn do
+      if delay > 0
+        sleep delay
+        return if @state >= State::Canceled
+        @state = State::Running
+      end
+
+      begin
+        @value = @block.call
+      rescue ex
+        @error = ex
+      ensure
+        @channel.close
+        @state = State::Completed
+      end
+    end
+  end
+
+  private def wait
+    return if @state >= State::Completed
+    spawn_compute
+    @channel.receive?
+  end
+
+  private def value_or_raise
+    raise Concurrent::CanceledError.new(@cancel_msg) if @state == State::Canceled
+
+    value = @value
+    if value.is_a?(R)
+      value
+    elsif error = @error
+      raise error
+    else
+      raise "compiler bug"
+    end
+  end
+end
+
+
+# Spawns a `Fiber` to compute *&block* in the background after *delay* has elapsed.
+# Access to get is synchronized between fibers.  *&block* is only called once.
+# May be canceled before *&block* is called by calling `cancel`.
+# ```
+# d = delay(1) { Process.kill(Process.pid) }
+# long_operation
+# d.cancel
+# ```
+def delay(delay, &block : -> R)
+  Concurrent::Future.new delay: delay, &block
+end
+
+
+# Spawns a `Fiber` to compute *&block* in the background.
+# Access to get is synchronized between fibers.  *&block* is only called once.
+# ```
+# f = future { http_request }
+# ... other actions ...
+# f.get #=> String
+# ```
+def future(&exp : -> R)
+  Concurrent::Future.new &exp
+end
+
+
+# Conditionally spawns a `Fiber` to run *&block* in the background.
+# Access to get is synchronized between fibers.  *&block* is only called once.
+# *&block* doesn't run by default, only when `get` is called.
+# ```
+# l = lazy { expensive_computation }
+# spawn { maybe_use_computation(l) }
+# spawn { maybe_use_computation(l) }
+# ```
+def lazy &block : -> R
+  Concurrent::Future.new run_immediately: false, &block
+end


### PR DESCRIPTION
`future` and `lazy` should replace a number of common usage patterns that manually use spawn and channels to concurrently compute values.  Both macros are intended to increase code readability and reduce bugs.
