### PR TITLE
Allow HTTP::Response created with a body_io to be sent as chunked

### DIFF
--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -83,11 +83,6 @@ module HTTP
       end
     end
 
-    it "sets content length even without body" do
-      response = Response.new(200)
-      response.headers["Content-Length"].should eq("0")
-    end
-
     it "doesn't sets content length for 1xx, 204 or 304" do
       [100, 101, 204, 304].each do |status|
         response = Response.new(status)
@@ -143,7 +138,16 @@ module HTTP
 
     it "sets content length from body" do
       response = Response.new(200, "hello")
-      response.headers["Content-Length"].should eq("5")
+      io = StringIO.new
+      response.to_io(io)
+      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello")
+    end
+
+    it "sets content length even without body" do
+      response = Response.new(200)
+      io = StringIO.new
+      response.to_io(io)
+      io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
     end
 
     it "serialize as chunked with body_io" do

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -146,6 +146,20 @@ module HTTP
       response.headers["Content-Length"].should eq("5")
     end
 
+    it "serialize as chunked with body_io" do
+      response = Response.new(200, body_io: StringIO.new("hello"))
+      io = StringIO.new
+      response.to_io(io)
+      io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n")
+    end
+
+    it "serialize as not chunked with body_io if HTTP/1.0" do
+      response = Response.new(200, version: "HTTP/1.0", body_io: StringIO.new("hello"))
+      io = StringIO.new
+      response.to_io(io)
+      io.to_s.should eq("HTTP/1.0 200 OK\r\nContent-Length: 5\r\n\r\nhello")
+    end
+
     it "builds default not found" do
       response = Response.not_found
       io = StringIO.new

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -72,12 +72,26 @@ module HTTP
     end
   end
 
-  def self.serialize_headers_and_body(io, headers, body)
-    if headers
-      headers.each do |name, values|
-        values.each do |value|
-          io << name << ": " << value << "\r\n"
+  def self.serialize_headers_and_body(io, headers, body, version)
+    # prepare either chunked response headers if protocol supports it
+    # or consume the io to get the Content-Length header
+    if body
+      if body.is_a?(IO)
+        if Response.supports_chunked?(version)
+          headers["Transfer-Encoding"] = "chunked"
+        else
+          body = body.read
         end
+      end
+
+      unless body.is_a?(IO)
+        headers["Content-Length"] = body.bytesize.to_s
+      end
+    end
+
+    headers.each do |name, values|
+      values.each do |value|
+        io << name << ": " << value << "\r\n"
       end
     end
 
@@ -85,15 +99,13 @@ module HTTP
 
     if body
       if body.is_a?(IO)
-        if headers["Transfer-Encoding"] == "chunked"
-          buf = Slice(UInt8).new(8192)
-          while (buf_length = body.read(buf)) > 0
-            io << buf_length.to_s(16) << "\r\n"
-            io.write(buf[0, buf_length])
-            io << "\r\n"
-          end
-          io << "0\r\n\r\n"
+        buf = Slice(UInt8).new(8192)
+        while (buf_length = body.read(buf)) > 0
+          io << buf_length.to_s(16) << "\r\n"
+          io.write(buf[0, buf_length])
+          io << "\r\n"
         end
+        io << "0\r\n\r\n"
       else
         io << body
       end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -1,6 +1,8 @@
 module HTTP
   # :nodoc:
   abstract class Content
+    include IO
+
     def close
       buffer :: UInt8[1024]
       while read(buffer.to_slice) > 0
@@ -10,8 +12,6 @@ module HTTP
 
   # :nodoc:
   class FixedLengthContent < Content
-    include IO
-
     def initialize(@io, size)
       @remaining = size
     end
@@ -30,8 +30,6 @@ module HTTP
 
   # :nodoc:
   class UnknownLengthContent < Content
-    include IO
-
     def initialize(@io)
     end
 
@@ -46,8 +44,6 @@ module HTTP
 
   # :nodoc:
   class ChunkedContent < Content
-    include IO
-
     def initialize(@io)
       @chunk_remaining = io.gets.not_nil!.to_i(16)
     end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -34,7 +34,7 @@ class HTTP::Request
     io << @method << " " << @path << " " << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
-    HTTP.serialize_headers_and_body(io, headers, @body)
+    HTTP.serialize_headers_and_body(io, headers, @body, @version)
   end
 
   def self.from_io(io)


### PR DESCRIPTION
Intermediate task needed for deflate, gzip support :-)

Some issues/doubts worth to mention.
  *  A `for_sending` argument was added to `Response` in order to avoid some headers/processing tweaks when the response is not for sending to a client.
    * I moved the Content-Length. Otherwise the response header was overwritten
  * A default chunk size of 8K is used. Not sure what would be a good default or if it should be customizable
  * The chunk size is not enforced. Should it be buffered beforehand to enforce it? I don't think so.
  * Chunk mode is used on HTTP/1.1 and is fallback to full response with Content-Length when HTTP/1.0 is used.