### PR TITLE
Add an example to symbols that starts with numbers

### DIFF
--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -4,6 +4,7 @@
 # ```
 # :hello
 # :welcome
+# :"123"
 # :"symbol with spaces"
 # ```
 #


### PR DESCRIPTION
Symbols that start with numbers are required to add quotes around the value