### PR TITLE
added open timeout to http client

### DIFF
--- a/spec/std/http/client_spec.cr
+++ b/spec/std/http/client_spec.cr
@@ -22,6 +22,14 @@ module HTTP
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get("http://www.example.com"))
 
+    server = HTTP::Server.new(8081) do |req|
+      sleep 0.5
+      HTTP::Response.ok("text/plain", "OK")
+    end
+    spawn do
+      server.listen
+    end
+
     it "raises if URI is missing scheme" do
       expect_raises(ArgumentError) do
         HTTP::Client.get "www.example.com"
@@ -29,24 +37,22 @@ module HTTP
     end
 
     it "tests read_timeout" do
-      server = HTTP::Server.new(8081) do |req|
-        sleep 0.5
-        HTTP::Response.ok("text/plain", "OK")
-      end
-      spawn do
-        server.listen
-      end
-
       client = Client.new("localhost", 8081)
-      client.read_timeout = 1.second
+      client.read_timeout = 1
       client.get("/")
 
       expect_raises(IO::Timeout, "read timed out") do
         client.read_timeout = 0.0001
         client.get("/")
       end
-
-      server.close
     end
+
+    it "tests connect_timeout" do
+      client = Client.new("localhost", 8081)
+      client.connect_timeout = 1.second
+      client.get("/")
+    end
+
+    server.close
   end
 end

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -105,13 +105,63 @@ class HTTP::Client
   end
 
   # Set the number of seconds to wait when reading before raising an `IO::Timeout`.
+  #
+  # ```
+  # client = HTTP::Client.new("example.org")
+  # client.read_timeout = 1.5
+  # begin
+  #   response = client.get("/")
+  # rescue IO::Timeout
+  #   puts "Timeout!"
+  # end
+  # ```
   def read_timeout=(read_timeout : Number)
     @read_timeout = read_timeout.to_f
   end
 
-  # Set the read timeout with a Time::Span, to wait when reading before raising an `IO::Timeout`.
+  # Set the read timeout with a `Time::Span`, to wait when reading before raising an `IO::Timeout`.
+  #
+  # ```
+  # client = HTTP::Client.new("example.org")
+  # client.read_timeout = 5.minutes
+  # begin
+  #   response = client.get("/")
+  # rescue IO::Timeout
+  #   puts "Timeout!"
+  # end
+  # ```
   def read_timeout=(read_timeout : Time::Span)
     self.read_timeout = read_timeout.total_seconds
+  end
+
+  # Set the number of seconds to wait when connecting, before raising an `IO::Timeout`.
+  #
+  # ```
+  # client = HTTP::Client.new("example.org")
+  # client.connect_timeout = 1.5
+  # begin
+  #   response = client.get("/")
+  # rescue IO::Timeout
+  #   puts "Timeout!"
+  # end
+  # ```
+  def connect_timeout=(connect_timeout : Number)
+    @connect_timeout = connect_timeout.to_f
+  end
+
+  # Set the open timeout with a `Time::Span` to wait when connecting, before raising an `IO::Timeout`.
+  #
+  # ```
+  # client = HTTP::Client.new("example.org")
+  # client.connect_timeout = 5.minutes
+  # begin
+  #   response = client.get("/")
+  # rescue IO::Timeout
+  #   puts "Timeout!"
+  # end
+  # ```
+  def connect_timeout=(connect_timeout : Time::Span)
+    self.connect_timeout = connect_timeout.total_seconds
   end
 
   # Sets a callback to execute before each request. This is usually
@@ -336,7 +386,7 @@ class HTTP::Client
   end
 
   private def socket
-    socket = @socket ||= TCPSocket.new @host, @port
+    socket = @socket ||= TCPSocket.new @host, @port, nil, @connect_timeout
     socket.read_timeout = @read_timeout if @read_timeout
     socket.sync = false
     if @ssl


### PR DESCRIPTION
I've added the open timeout. Not sure how to test the unhappy flow. If it's required let me know how to test it and I will add it :)

Also continuing from the discussion in my previous PR, I'm not sure about the write timeout and when that would occur.  Also couldn't find it in the Ruby Net::HTTP client, not that we should really lead from that example though ;)