### PR TITLE
Fix type grammar Int32Ptr example

### DIFF
--- a/_gitbook/syntax_and_semantics/type_grammar.md
+++ b/_gitbook/syntax_and_semantics/type_grammar.md
@@ -56,7 +56,7 @@ alias Int32Ptr = Int32*
 is the same as:
 
 ```crystal
-alias Int32 = Pointer(Int32)
+alias Int32Ptr = Pointer(Int32)
 ```
 
 In regular code, `Int32*` means invoking the `*` method on `Int32`.


### PR DESCRIPTION
It seems this alias should be names `Int32Ptr`, just like in the example above it.