### PR TITLE
Simplify Int#bit implementation and spec edge cases

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -132,6 +132,10 @@ describe "Int" do
     assert { 5.bit(1).should eq(0) }
     assert { 5.bit(2).should eq(1) }
     assert { 5.bit(3).should eq(0) }
+    assert { 0.bit(63).should eq(0) }
+    assert { Int64::MAX.bit(63).should eq(0) }
+    assert { UInt64::MAX.bit(63).should eq(1) }
+    assert { UInt64::MAX.bit(64).should eq(0) }
   end
 
   describe "divmod" do

--- a/src/int.cr
+++ b/src/int.cr
@@ -172,7 +172,7 @@ struct Int
   end
 
   def bit(bit)
-    self & (1 << bit) == 0 ? 0 : 1
+    self >> bit & 1
   end
 
   def gcd(other : Int)

--- a/src/int.cr
+++ b/src/int.cr
@@ -171,6 +171,15 @@ struct Int
     self === char.ord
   end
 
+  # Returns this number's *bit*th bit, starting with the least-significant.
+  #
+  # ```
+  # 11.bit(0) #=> 1
+  # 11.bit(1) #=> 1
+  # 11.bit(2) #=> 0
+  # 11.bit(3) #=> 1
+  # 11.bit(4) #=> 0
+  # ```
   def bit(bit)
     self >> bit & 1
   end


### PR DESCRIPTION
This simplifies the `Int#bit` implementation and specs a few edge cases.

[This](https://github.com/manastech/crystal/pull/1194#issuecomment-131616838) kept me wondering, so I did the following benchmark:

```crystal
require "benchmark"
Benchmark.ips do |x|
  x.report("current")  { rand(0...UInt64::MAX) & (1 << rand(0...64)) == 0 ? 0 : 1 }
  x.report("proposed") { rand(0...UInt64::MAX) >> rand(0...64) & 1                }
end
```

With the following results (after building with `--release` and running ten consecutive times):

```
 current   31.8M (± 0.41%)  1.03× slower
proposed  32.62M (± 1.69%)       fastest
 current  31.83M (± 0.48%)  1.03× slower
proposed  32.67M (± 0.49%)       fastest
 current   30.1M (± 6.52%)  1.08× slower
proposed  32.63M (± 0.54%)       fastest
 current  31.78M (± 0.52%)  1.02× slower
proposed  32.26M (± 0.67%)       fastest
 current  31.75M (± 0.75%)  1.03× slower
proposed  32.57M (± 1.46%)       fastest
 current  31.75M (± 0.66%)  1.02× slower
proposed  32.53M (± 1.60%)       fastest
 current  31.88M (± 0.89%)  1.03× slower
proposed  32.69M (± 0.59%)       fastest
 current  31.83M (± 0.44%)  1.03× slower
proposed  32.64M (± 0.47%)       fastest
 current  31.76M (± 0.51%)  1.02× slower
proposed  32.35M (± 0.94%)       fastest
 current  31.75M (± 1.44%)  1.03× slower
proposed  32.67M (± 0.41%)       fastest
```

To the best of my reading of the above this change gives a ~3% improvement while also improving readability – but do feel free to correct me, I am very bad at statistics.