### PR TITLE
Add installation docs for Arch Linux

### DIFF
--- a/_gitbook/SUMMARY.md
+++ b/_gitbook/SUMMARY.md
@@ -4,6 +4,7 @@
 * [Installation](installation/README.md)
    * [On Debian and Ubuntu](installation/on_debian_and_ubuntu.md)
    * [On RedHat and CentOS](installation/on_redhat_and_centos.md)
+   * [On Arch Linux](installation/on_arch_linux.md)
    * [On Mac OSX using Homebrew](installation/on_mac_osx_using_homebrew.md)
    * [From a tar.gz](installation/from_a_targz.md)
    * [From sources](installation/from_source_repository.md)

--- a/_gitbook/installation/on_arch_linux.md
+++ b/_gitbook/installation/on_arch_linux.md
@@ -1,0 +1,17 @@
+# On Arch Linux
+
+Arch Linux includes the Crystal compiler in the Community repository.
+
+## Install
+
+```
+sudo pacman -S crystal
+```
+
+## Upgrade
+
+When a new Crystal version is released you can upgrade your system using:
+
+```
+sudo pacman -Sy --needed crystal
+```


### PR DESCRIPTION
Arch Linux seems to be shipping the Crystal compiler in the official Community repository (https://www.archlinux.org/packages/community/x86_64/crystal/), this adds a page to the installation documents with the commands needed for installing it.

Is this the correct way to do changes for the docs? It looks to me like Travis is building and pushing the new html files.