### PR TITLE
Fix some typos in toplevel.html

### DIFF
--- a/api/toplevel.html
+++ b/api/toplevel.html
@@ -2163,28 +2163,28 @@
       <li class="entry-summary">
         <a href="#print%28%2Aobjects%3A_%29-class-method" class="signature"><strong>.print</strong>(*objects : _)</a>
         
-          <div class="summary"><p>Prints objects to STDIN.</p></div>
+          <div class="summary"><p>Prints objects to STDOUT.</p></div>
         
       </li>
     
       <li class="entry-summary">
         <a href="#print%21%28%2Aobjects%3A_%29-class-method" class="signature"><strong>.print!</strong>(*objects : _)</a>
         
-          <div class="summary"><p>Prints objects to STDIN and then invokes <code><a href="STDIN.html">STDIN</a>.flush</code>.</p></div>
+          <div class="summary"><p>Prints objects to STDOUT and then invokes <code><a href="STDOUT.html">STDOUT</a>.flush</code>.</p></div>
         
       </li>
     
       <li class="entry-summary">
         <a href="#printf%28format_string%2C%2Aargs%29-class-method" class="signature"><strong>.printf</strong>(format_string, *args)</a>
         
-          <div class="summary"><p>Prints a formatted string to STDIN.</p></div>
+          <div class="summary"><p>Prints a formatted string to STDOUT.</p></div>
         
       </li>
     
       <li class="entry-summary">
         <a href="#printf%28format_string%2Cargs%3AArray%7CTuple%29-class-method" class="signature"><strong>.printf</strong>(format_string, args : Array | Tuple)</a>
         
-          <div class="summary"><p>Prints a formatted string to STDIN.</p></div>
+          <div class="summary"><p>Prints a formatted string to STDOUT.</p></div>
         
       </li>
     


### PR DESCRIPTION
Fixed some typos in docs in `toplevel.html`. Probably the same should be done for comments in `kernel.cr`.