### PR TITLE
Add missing link to Arch Linux installation

### DIFF
--- a/_gitbook/installation/README.md
+++ b/_gitbook/installation/README.md
@@ -4,6 +4,7 @@ Once you install the compiler using one of the following methods, make sure to r
 
 * [On Debian And Ubuntu](on_debian_and_ubuntu.html)
 * [On RedHat And CentOS](on_redhat_and_centos.html)
+* [On Arch Linux](on_arch_linux.html)
 * [On Mac OSX using Homebrew](on_mac_osx_using_homebrew.html)
 * [From a tar.gz](from_a_targz.html)
 * [From sources](from_source_repository.html)


### PR DESCRIPTION
I forgot to add the link to the Arch Linux installation page on the main Installation page in #1538. Just to have the same navigation options as in the sidebar.