### PR TITLE
File#truncate

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -455,6 +455,45 @@ describe "File" do
     file.gets_to_end.should eq(content)
   end
 
+  describe "truncate" do
+    it "truncates" do
+      filename = "#{__DIR__}/data/temp_write.txt"
+      File.write(filename, "0123456789")
+      File.open(filename, "r+") do |f|
+        f.gets_to_end.should eq("0123456789")
+        f.rewind
+        f.puts("333")
+        f.truncate(4)
+      end
+
+      File.read(filename).should eq("333\n")
+      File.delete filename
+    end
+
+    it "truncates completely when no size is passed" do
+      filename = "#{__DIR__}/data/temp_write.txt"
+      File.write(filename, "0123456789")
+      File.open(filename, "r+") do |f|
+        f.puts("333")
+        f.truncate
+      end
+
+      File.read(filename).should eq("")
+      File.delete filename
+    end
+
+    it "requires a file opened for writing" do
+      filename = "#{__DIR__}/data/temp_write.txt"
+      File.write(filename, "0123456789")
+      File.open(filename, "r") do |f|
+        expect_raises(Errno) do
+          f.truncate(4)
+        end
+      end
+      File.delete filename
+    end
+  end
+
   describe "flock" do
     it "exlusively locks a file" do
       File.open(__FILE__) do |file1|

--- a/src/file.cr
+++ b/src/file.cr
@@ -4,6 +4,7 @@ lib LibC
   fun rename(oldname : Char*, newname : Char*) : Int
   fun symlink(oldpath : Char*, newpath : Char*) : Int
   fun unlink(filename : Char*) : Int
+  fun ftruncate(fd : Int, size : OffT) : Int
 
   F_OK = 0
   X_OK = 1 << 0
@@ -462,6 +463,16 @@ class File < IO::FileDescriptor
 
   def size
     stat.size
+  end
+
+  # Truncates the file to the specified size. Requires a write file descriptor
+  def truncate(size = 0)
+    flush
+    code = LibC.ftruncate(fd, size)
+    if code != 0
+      raise Errno.new("Error truncating file '#{path}'")
+    end
+    code
   end
 
   def to_s(io)


### PR DESCRIPTION
This PR implements `File#truncate`, a direct mapping to the `ftruncate` system call, and equivalent to [Ruby's method](http://www.rubydoc.info/stdlib/core/File#truncate-instance_method). The spec shows a use case that comes to mind: opening a file with `r+`, reading it complete, and then overwriting it completely (if the new content is shorter than the old, we need to truncate).