### PR TITLE
[RFC: HTTP::Request] provide uri component accessors

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -13,6 +13,16 @@ module HTTP
       io.to_s.should eq("GET / HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
     end
 
+    it "serialize GET (with query params)" do
+      headers = HTTP::Headers.new
+      headers["Host"] = "host.example.org"
+      request = Request.new "GET", "/greet?q=hello&name=world", headers
+
+      io = StringIO.new
+      request.to_io(io)
+      io.to_s.should eq("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")
+    end
+
     it "serialize GET (with cookie)" do
       headers = HTTP::Headers.new
       headers["Host"] = "host.example.org"
@@ -63,6 +73,12 @@ module HTTP
       request.headers.should eq({"Host" => "host.example.org"})
     end
 
+    it "parses GET with query params" do
+      request = Request.from_io(StringIO.new("GET /greet?q=hello&name=world HTTP/1.1\r\nHost: host.example.org\r\n\r\n")).not_nil!
+      request.method.should eq("GET")
+      request.path.should eq("/greet")
+      request.headers.should eq({"Host" => "host.example.org"})
+    end
 
     it "parses GET without \\r" do
       request = Request.from_io(StringIO.new("GET / HTTP/1.1\nHost: host.example.org\n\n")).not_nil!
@@ -128,14 +144,63 @@ module HTTP
       end
     end
 
-    describe "#uri" do
-      it "returns parsed URI" do
-        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test#iamafragment HTTP/1.1\r\n\r\n")).not_nil!
-        uri = request.uri
+    describe "#path" do
+      it "returns parsed path" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.path.should eq("/api/v3/some/resource")
+      end
+    end
 
-        uri.path.should eq("/api/v3/some/resource")
-        uri.query.should eq("filter=hello&world=test")
-        uri.fragment.should eq("iamafragment")
+    describe "#path=" do
+      it "sets path" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.path = "/api/v2/greet"
+        request.path.should eq("/api/v2/greet")
+      end
+
+      it "updates @resource" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.path = "/api/v2/greet"
+        request.resource.should eq("/api/v2/greet?filter=hello&world=test")
+      end
+
+      it "updates serialized form" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.path = "/api/v2/greet"
+
+        io = StringIO.new
+        request.to_io(io)
+        io.to_s.should eq("GET /api/v2/greet?filter=hello&world=test HTTP/1.1\r\n\r\n")
+      end
+    end
+
+    describe "#query" do
+      it "returns request's query" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.query.should eq("filter=hello&world=test")
+      end
+    end
+
+    describe "#query=" do
+      it "sets query" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.query = "q=isearchforsomething&locale=de"
+        request.query.should eq("q=isearchforsomething&locale=de")
+      end
+
+      it "updates @resource" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.query = "q=isearchforsomething&locale=de"
+        request.resource.should eq("/api/v3/some/resource?q=isearchforsomething&locale=de")
+      end
+
+      it "updates serialized form" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test HTTP/1.1\r\n\r\n")).not_nil!
+        request.query = "q=isearchforsomething&locale=de"
+
+        io = StringIO.new
+        request.to_io(io)
+        io.to_s.should eq("GET /api/v3/some/resource?q=isearchforsomething&locale=de HTTP/1.1\r\n\r\n")
       end
     end
   end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -127,5 +127,16 @@ module HTTP
         request.keep_alive?.should be_false
       end
     end
+
+    describe "#uri" do
+      it "returns parsed URI" do
+        request = Request.from_io(StringIO.new("GET /api/v3/some/resource?filter=hello&world=test#iamafragment HTTP/1.1\r\n\r\n")).not_nil!
+        uri = request.uri
+
+        uri.path.should eq("/api/v3/some/resource")
+        uri.query.should eq("filter=hello&world=test")
+        uri.fragment.should eq("iamafragment")
+      end
+    end
   end
 end

--- a/src/compiler/crystal/tools/browser.cr
+++ b/src/compiler/crystal/tools/browser.cr
@@ -12,7 +12,7 @@ class Crystal::Browser
     while true
       server.accept do |sock|
         if request = HTTP::Request.from_io(sock)
-          html = browser.handle(request.path)
+          html = browser.handle(request.resource)
 
           response = HTTP::Response.new(200, html, HTTP::Headers{"Content-Type": "text/html"})
           response.to_io sock

--- a/src/compiler/crystal/tools/browser.cr
+++ b/src/compiler/crystal/tools/browser.cr
@@ -12,7 +12,7 @@ class Crystal::Browser
     while true
       server.accept do |sock|
         if request = HTTP::Request.from_io(sock)
-          html = browser.handle(request.resource)
+          html = browser.handle(request.path.not_nil!)
 
           response = HTTP::Response.new(200, html, HTTP::Headers{"Content-Type": "text/html"})
           response.to_io sock

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -23,7 +23,7 @@ class HTTP::Request
   end
 
   def uri
-    URI.parse(@path)
+    (@uri ||= URI.parse(@path)).not_nil!
   end
 
   def keep_alive?

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -3,12 +3,11 @@ require "uri"
 
 class HTTP::Request
   getter method
-  getter path
   getter headers
   getter body
   getter version
 
-  def initialize(@method : String, @path, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
+  def initialize(@method : String, @resource, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
     if body = @body
       @headers["Content-Length"] = body.bytesize.to_s
     elsif @method == "POST" || @method == "PUT"
@@ -22,8 +21,8 @@ class HTTP::Request
     @cookies ||= Cookies.from_headers(headers)
   end
 
-  def uri
-    (@uri ||= URI.parse(@path)).not_nil!
+  def resource
+    @uri.try(&.full_path) || @resource
   end
 
   def keep_alive?
@@ -31,7 +30,7 @@ class HTTP::Request
   end
 
   def to_io(io)
-    io << @method << " " << @path << " " << @version << "\r\n"
+    io << @method << " " << resource << " " << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
     HTTP.serialize_headers_and_body(io, headers, @body, @version)
@@ -41,12 +40,28 @@ class HTTP::Request
     request_line = io.gets
     return unless request_line
 
-    method, path, http_version = request_line.split
+    method, resource, http_version = request_line.split
     HTTP.parse_headers_and_body(io) do |headers, body|
-      return new method, path, headers, body.try &.read, http_version
+      return new method, resource, headers, body.try &.read, http_version
     end
 
     # Unexpected end of http request
     nil
+  end
+
+  # Lazily parses request's path component.
+  delegate "path", uri
+
+  # Sets request's path component.
+  delegate "path=", uri
+
+  # Lazily parses request's query component.
+  delegate "query", uri
+
+  # Sets request's query component.
+  delegate "query=", uri
+
+  private def uri
+    (@uri ||= URI.parse(@resource)).not_nil!
   end
 end

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -5,7 +5,7 @@ class HTTP::LogHandler < HTTP::Handler
     elapsed = Time.now - time
     elapsed_text = elapsed_text(elapsed)
 
-    puts "#{request.method} #{request.path} - #{response.status_code} (#{elapsed_text})"
+    puts "#{request.method} #{request.resource} - #{response.status_code} (#{elapsed_text})"
     response
   end
 

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -5,9 +5,10 @@ class HTTP::StaticFileHandler < HTTP::Handler
   end
 
   def call(request)
-    file_path = @publicdir + request.resource
+    request_path = request.path.not_nil!
+    file_path = @publicdir + request_path
     if Dir.exists?(file_path)
-      HTTP::Response.new(200, directory_listing(request.resource, file_path), HTTP::Headers{"Content-Type": "text/html"})
+      HTTP::Response.new(200, directory_listing(request_path, file_path), HTTP::Headers{"Content-Type": "text/html"})
     elsif File.exists?(file_path)
       HTTP::Response.new(200, File.read(file_path), HTTP::Headers{"Content-Type": mime_type(file_path)})
     else

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -5,9 +5,9 @@ class HTTP::StaticFileHandler < HTTP::Handler
   end
 
   def call(request)
-    file_path = @publicdir + request.path
+    file_path = @publicdir + request.resource
     if Dir.exists?(file_path)
-      HTTP::Response.new(200, directory_listing(request.path, file_path), HTTP::Headers{"Content-Type": "text/html"})
+      HTTP::Response.new(200, directory_listing(request.resource, file_path), HTTP::Headers{"Content-Type": "text/html"})
     elsif File.exists?(file_path)
       HTTP::Response.new(200, File.read(file_path), HTTP::Headers{"Content-Type": mime_type(file_path)})
     else

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -52,7 +52,7 @@ struct OAuth::Signature
         str << ':'
         str << port
       end
-      uri_path = request.uri.path || "/"
+      uri_path = request.path || "/"
       uri_path = "/" if uri_path.empty?
       URI.escape(uri_path, str)
       str << '&'
@@ -73,7 +73,7 @@ struct OAuth::Signature
       params.add key, value
     end
 
-    if query = request.uri.query
+    if query = request.query
       params.add_query query
     end
 

--- a/src/oauth2/access_token/mac.cr
+++ b/src/oauth2/access_token/mac.cr
@@ -20,7 +20,7 @@ class OAuth2::AccessToken::Mac < OAuth2::AccessToken
     ts = Time.now.epoch
     nonce = "#{ts - @issued_at}:#{SecureRandom.hex}"
     method = request.method
-    uri = request.uri.full_path
+    uri = request.resource
     host, port = host_and_port request, ssl
     ext = ""
 


### PR DESCRIPTION
Implements first option from this comment: https://github.com/manastech/crystal/pull/1505#issuecomment-141016552

For simplicity and smallest merge-able step, this does not implement any kind of smart wrapper over `#query`, instead it is just a string like all other components.

WDYT? 

/cc @jhass @asterite @waj 