### PR TITLE
Followup for PR #1548 (Dismantle CGI module)

### DIFF
--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -1,4 +1,5 @@
 require "html"
+require "uri"
 require "./item"
 
 class Crystal::Doc::Macro

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -1,4 +1,5 @@
 require "html"
+require "uri"
 require "./item"
 
 class Crystal::Doc::Method

--- a/src/http/http.cr
+++ b/src/http/http.cr
@@ -1,2 +1,2 @@
+require "uri"
 require "./**"
-

--- a/src/oauth/oauth.cr
+++ b/src/oauth/oauth.cr
@@ -1,4 +1,5 @@
 require "http/client"
+require "http/params"
 require "uri"
 require "secure_random"
 require "openssl/hmac"

--- a/src/oauth2/oauth2.cr
+++ b/src/oauth2/oauth2.cr
@@ -1,3 +1,4 @@
 require "http/client"
+require "http/params"
 require "json"
 require "./**"


### PR DESCRIPTION
This PR fixes std libraries that use `URI` and `HTTP::Params` without requiring it. Which currently leads to inability to `require` these libraries without `require`-ing `uri` or `http/params` first.

/cc @jhass 