### PR TITLE
Add HTTP::Params class - convenient wrapper over raw http params

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -71,6 +71,19 @@ module HTTP
       end
     end
 
+    describe "#has_key?(name)" do
+      it "returns true if param with provided name exists" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.has_key?("foo").should eq(true)
+        params.has_key?("baz").should eq(true)
+      end
+
+      it "return false if param with provided name does not exist" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.has_key?("non_existent_param").should eq(false)
+      end
+    end
+
     describe "#[]=(name, value)" do
       it "sets first value for provided param name" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")

--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -18,7 +18,7 @@ module HTTP
         from, to = tuple
 
         it "parses #{from}" do
-          Params.parse(from).should eq(to)
+          Params.parse(from).should eq(Params.new(to))
         end
       end
     end
@@ -45,6 +45,168 @@ module HTTP
           end
 
           encoded.should eq(to)
+        end
+      end
+    end
+
+    describe "#to_s" do
+      it "serializes params to http form" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.to_s.should eq("foo=bar&foo=baz&baz=qux")
+      end
+    end
+
+    describe "#[](name)" do
+      it "returns first value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params["foo"].should eq("bar")
+        params["baz"].should eq("qux")
+      end
+
+      it "raises KeyError when there is no such param" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        expect_raises KeyError do
+          params["non_existent_param"]
+        end
+      end
+    end
+
+    describe "#[]=(name, value)" do
+      it "sets first value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params["foo"] = "notfoo"
+        params.fetch_all("foo").should eq(["notfoo", "baz"])
+      end
+
+      it "adds new name => value pair if there is no such param" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params["non_existent_param"] = "test"
+        params.fetch_all("non_existent_param").should eq(["test"])
+      end
+    end
+
+    describe "#fetch(name)" do
+      it "returns first value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.fetch("foo").should eq("bar")
+        params.fetch("baz").should eq("qux")
+      end
+
+      it "raises KeyError when there is no such param" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        expect_raises KeyError do
+          params.fetch("non_existent_param")
+        end
+      end
+    end
+
+    describe "#fetch(name, default)" do
+      it "returns first value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.fetch("foo", "aDefault").should eq("bar")
+        params.fetch("baz", "aDefault").should eq("qux")
+      end
+
+      it "return default value when there is no such param" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.fetch("non_existent_param", "aDefault").should eq("aDefault")
+      end
+    end
+
+    describe "#fetch(name, &block)" do
+      it "returns first value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.fetch("foo") { "fromBlock" }.should eq("bar")
+        params.fetch("baz") { "fromBlock" }.should eq("qux")
+      end
+
+      it "return default value when there is no such param" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.fetch("non_existent_param") { "fromBlock" }.should eq("fromBlock")
+      end
+    end
+
+    describe "#fetch_all(name)" do
+      it "fetches list of all values for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux&iamempty")
+        params.fetch_all("foo").should eq(["bar", "baz"])
+        params.fetch_all("baz").should eq(["qux"])
+        params.fetch_all("iamempty").should eq([""])
+        params.fetch_all("non_existent_param").should eq([] of String)
+      end
+    end
+
+    describe "#add(name, value)" do
+      it "appends new value for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux&iamempty")
+
+        params.add("foo", "zeit")
+        params.fetch_all("foo").should eq(["bar", "baz", "zeit"])
+
+        params.add("baz", "exit")
+        params.fetch_all("baz").should eq(["qux", "exit"])
+
+        params.add("iamempty", "not_empty_anymore")
+        params.fetch_all("iamempty").should eq(["not_empty_anymore"])
+
+        params.add("non_existent_param", "something")
+        params.fetch_all("non_existent_param").should eq(["something"])
+      end
+    end
+
+    describe "#set_all(name, values)" do
+      it "sets values for provided param name" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+
+        params.set_all("baz", ["hello", "world"])
+        params.fetch_all("baz").should eq(["hello", "world"])
+
+        params.set_all("foo", ["something"])
+        params.fetch_all("foo").should eq(["something"])
+
+        params.set_all("non_existent_param", ["something", "else"])
+        params.fetch_all("non_existent_param").should eq(["something", "else"])
+      end
+    end
+
+    describe "#each" do
+      it "calls provided proc for each name, value pair, including multiple values per one param name" do
+        received = [] of {String, String}
+
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params.each do |name, value|
+          received << {name, value}
+        end
+
+        received.should eq([
+          {"foo", "bar"},
+          {"foo", "baz"},
+          {"baz", "qux"},
+        ])
+      end
+    end
+
+    describe "#delete" do
+      it "deletes first value for provided param name and returns it" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+
+        params.delete("foo").should eq("bar")
+        params.fetch_all("foo").should eq(["baz"])
+
+        params.delete("baz").should eq("qux")
+        expect_raises KeyError do
+          params.fetch("baz")
+        end
+      end
+    end
+
+    describe "#delete_all" do
+      it "deletes all values for provided param name and returns them" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+
+        params.delete_all("foo").should eq(["bar", "baz"])
+        expect_raises KeyError do
+          params.fetch("foo")
         end
       end
     end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -240,29 +240,27 @@ module HTTP
     # params.to_s     # => "item=keychain&item=keynote&email=john@example.org"
     # ```
     def to_s(io)
-      io << HTTP::Params.build do |builder|
-        each do |name, value|
-          builder.add(name, value)
-        end
+      builder = Builder.new(io)
+      each do |name, value|
+        builder.add(name, value)
       end
     end
 
     # :nodoc:
     struct Builder
-      def initialize
-        @string = StringIO.new
+      def initialize(@io = StringIO.new)
       end
 
       def add(key, value)
-        @string << '&' unless @string.empty?
-        URI.escape key, @string
-        @string << '='
-        URI.escape value, @string if value
+        @io << '&' unless @io.empty?
+        URI.escape key, @io
+        @io << '='
+        URI.escape value, @io if value
         self
       end
 
       def to_s(io)
-        io << @string.to_s
+        io << @io.to_s
       end
     end
   end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -249,11 +249,15 @@ module HTTP
 
     # :nodoc:
     struct Builder
+      @io :: IO
+
       def initialize(@io = StringIO.new)
+        @first = true
       end
 
       def add(key, value)
-        @io << '&' unless @io.empty?
+        @io << '&' unless @first
+        @first = false
         URI.escape key, @io
         @io << '='
         URI.escape value, @io if value

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -5,7 +5,8 @@ module HTTP
   struct Params
     # Parses an HTTP query string into a `HTTP::Params`
     #
-    #     HTTP::Params.parse("foo=bar&foo=baz&qux=zoo") #=> {"foo" => ["bar", "baz"], "qux" => ["zoo"]}
+    #     HTTP::Params.parse("foo=bar&foo=baz&qux=zoo") 
+    #     #=> #<HTTP::Params @raw_params = {"foo" => ["bar", "baz"], "qux" => ["zoo"]}>
     def self.parse(query : String)
       parsed = {} of String => Array(String)
       parse(query) do |key, value|
@@ -151,7 +152,7 @@ module HTTP
     end
 
     # Returns first value for specified param name. Fallbacks to return value
-    # of provided block.
+    # of provided block when there is no such param.
     #
     # ```
     # params.fetch("email") { raise InvalidUser("email is missing") }    # InvalidUser "email is missing"
@@ -178,7 +179,7 @@ module HTTP
     # Sets all values for specified param name at once.
     #
     # ```
-    # params.set_add("item", ["keychain", "keynote"])
+    # params.set_all("item", ["keychain", "keynote"])
     # params.fetch_all("item")        # => ["keychain", "keynote"]
     # ```
     def set_all(name, values)
@@ -227,7 +228,7 @@ module HTTP
     # values.
     #
     # ```
-    # params.delete_all("comments")
+    # params.delete_all("comments")   # => ["hello, world!", ":+1:"]
     # params.has_key?("comments")     # => false
     # ```
     def delete_all(name)

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -95,6 +95,14 @@ module HTTP
       raw_params[name].first
     end
 
+    # Returns true if param with provided name exists.
+    #
+    # ```
+    # params.has_key?("email")       # => true
+    # params.has_key?("garbage")     # => false
+    # ```
+    delegate has_key?, raw_params
+
     # Sets first value for specified param name.
     def []=(name, value)
       raw_params[name] ||= [""]

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -2,7 +2,7 @@ require "uri"
 
 module HTTP
   # Represents a collection of http parameters and their respective values.
-  class Params
+  struct Params
     # Parses an HTTP query string into a `HTTP::Params`
     #
     #     HTTP::Params.parse("foo=bar&foo=baz&qux=zoo") #=> {"foo" => ["bar", "baz"], "qux" => ["zoo"]}

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -1,8 +1,8 @@
 require "uri"
 
 module HTTP
-  module Params
-    # Parses an HTTP query string into a `Hash(String, Array(String))`
+  class Params
+    # Parses an HTTP query string into a `HTTP::Params`
     #
     #     HTTP::Params.parse("foo=bar&foo=baz&qux=zoo") #=> {"foo" => ["bar", "baz"], "qux" => ["zoo"]}
     def self.parse(query : String)
@@ -11,7 +11,7 @@ module HTTP
         ary = parsed[key] ||= [] of String
         ary.push value
       end
-      parsed
+      Params.new(parsed)
     end
 
     # Parses an HTTP query and yields each key-value pair
@@ -78,6 +78,96 @@ module HTTP
       form_builder.to_s
     end
 
+    protected getter raw_params
+    def initialize(@raw_params)
+    end
+
+    def ==(other : self)
+      self.raw_params == other.raw_params
+    end
+
+    def ==(other)
+      false
+    end
+
+    # Returns first value for specified param name.
+    def [](name)
+      raw_params[name].first
+    end
+
+    # Sets first value for specified param name.
+    def []=(name, value)
+      raw_params[name] ||= [""]
+      raw_params[name][0] = value
+    end
+
+    # Returns all values for specified param name.
+    def fetch_all(name)
+      raw_params.fetch(name) { [] of String }
+    end
+
+    # Returns first value for specified param name.
+    def fetch(name)
+      raw_params.fetch(name).first
+    end
+
+    # Returns first value for specified param name. Fallbacks to provided
+    # default value when there is no such param.
+    def fetch(name, default)
+      raw_params.fetch(name, [default]).first
+    end
+
+    # Returns first value for specified param name. Fallbacks to return value
+    # of provided block.
+    def fetch(name, &block : -> String)
+      raw_params.fetch(name) { [block.call] }.first
+    end
+
+    # Appends new value for specified param name. Creates param when there was
+    # no such param.
+    def add(name, value)
+      raw_params[name] ||= [] of String
+      raw_params[name] = [] of String if raw_params[name] == [""]
+      raw_params[name] << value
+    end
+
+    # Sets all values for specified param name at once.
+    def set_all(name, values)
+      raw_params[name] = values
+    end
+
+    # Allows to iterate over all name-value pairs.
+    def each
+      raw_params.each do |name, values|
+        values.each do |value|
+          yield(name, value)
+        end
+      end
+    end
+
+    # Deletes first value for provided param name. If there are no values left,
+    # deletes param itself. Returns deleted value.
+    def delete(name)
+      value = raw_params[name].shift
+      raw_params.delete(name) if raw_params[name].size == 0
+      value
+    end
+
+    # Deletes all values for provided param name. Returns array of deleted
+    # values.
+    def delete_all(name)
+      raw_params.delete(name)
+    end
+
+    # Serializes to string representation as http url encoded form
+    def to_s(io)
+      io << HTTP::Params.build do |builder|
+        each do |name, value|
+          builder.add(name, value)
+        end
+      end
+    end
+
     # :nodoc:
     struct Builder
       def initialize
@@ -92,8 +182,8 @@ module HTTP
         self
       end
 
-      def to_s
-        @string.to_s
+      def to_s(io)
+        io << @string.to_s
       end
     end
   end

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -1,6 +1,7 @@
 require "uri"
 
 module HTTP
+  # Represents a collection of http parameters and their respective values.
   class Params
     # Parses an HTTP query string into a `HTTP::Params`
     #
@@ -91,6 +92,11 @@ module HTTP
     end
 
     # Returns first value for specified param name.
+    #
+    # ```
+    # params["email"]                # => "john@example.org"
+    # params["non_existent_param"]   # KeyError
+    # ```
     def [](name)
       raw_params[name].first
     end
@@ -104,35 +110,63 @@ module HTTP
     delegate has_key?, raw_params
 
     # Sets first value for specified param name.
+    #
+    # ```
+    # params["item"] = "pencil"
+    # ```
     def []=(name, value)
       raw_params[name] ||= [""]
       raw_params[name][0] = value
     end
 
     # Returns all values for specified param name.
+    #
+    # ```
+    # params.fetch_all("item")       # => ["pencil", "book", "workbook"]
+    # ```
     def fetch_all(name)
       raw_params.fetch(name) { [] of String }
     end
 
     # Returns first value for specified param name.
+    #
+    # ```
+    # params.fetch("email")                # => "john@example.org"
+    # params.fetch("non_existent_param")   # KeyError
+    # ```
     def fetch(name)
       raw_params.fetch(name).first
     end
 
     # Returns first value for specified param name. Fallbacks to provided
     # default value when there is no such param.
+    #
+    # ```
+    # params.fetch("email", "none@example.org")                # => "john@example.org"
+    # params.fetch("non_existent_param", "default value")      # => "default value"
+    # ```
     def fetch(name, default)
       raw_params.fetch(name, [default]).first
     end
 
     # Returns first value for specified param name. Fallbacks to return value
     # of provided block.
+    #
+    # ```
+    # params.fetch("email") { raise InvalidUser("email is missing") }    # InvalidUser "email is missing"
+    # params.fetch("non_existent_param") { "default computed value" }    # => "default computed value"
+    # ```
     def fetch(name, &block : -> String)
       raw_params.fetch(name) { [block.call] }.first
     end
 
     # Appends new value for specified param name. Creates param when there was
     # no such param.
+    #
+    # ```
+    # params.add("item", "keychain")
+    # params.fetch_all("item")        # => ["pencil", "book", "workbook", "keychain"]
+    # ```
     def add(name, value)
       raw_params[name] ||= [] of String
       raw_params[name] = [] of String if raw_params[name] == [""]
@@ -140,11 +174,27 @@ module HTTP
     end
 
     # Sets all values for specified param name at once.
+    #
+    # ```
+    # params.set_add("item", ["keychain", "keynote"])
+    # params.fetch_all("item")        # => ["keychain", "keynote"]
+    # ```
     def set_all(name, values)
       raw_params[name] = values
     end
 
     # Allows to iterate over all name-value pairs.
+    #
+    # ```
+    # params.each do |name, value|
+    #   puts "#{name} => #{value}"
+    # end
+    #
+    # # Outputs:
+    # # email => john@example.org
+    # # item => keychain
+    # # item => keynote
+    # ```
     def each
       raw_params.each do |name, values|
         values.each do |value|
@@ -155,6 +205,16 @@ module HTTP
 
     # Deletes first value for provided param name. If there are no values left,
     # deletes param itself. Returns deleted value.
+    #
+    # ```
+    # params.delete("item")     # => "keychain"
+    # params.fetch_all("item")  # => ["keynote"]
+    #
+    # params.delete("item")     # => "keynote"
+    # params["item"]            # KeyError
+    #
+    # params.delete("non_existent_param")  # KeyError
+    # ```
     def delete(name)
       value = raw_params[name].shift
       raw_params.delete(name) if raw_params[name].size == 0
@@ -163,11 +223,20 @@ module HTTP
 
     # Deletes all values for provided param name. Returns array of deleted
     # values.
+    #
+    # ```
+    # params.delete_all("comments")
+    # params.has_key?("comments")     # => false
+    # ```
     def delete_all(name)
       raw_params.delete(name)
     end
 
     # Serializes to string representation as http url encoded form
+    #
+    # ```
+    # params.to_s     # => "item=keychain&item=keynote&email=john@example.org"
+    # ```
     def to_s(io)
       io << HTTP::Params.build do |builder|
         each do |name, value|

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -248,7 +248,7 @@ module HTTP
     end
 
     # :nodoc:
-    struct Builder
+    class Builder
       @io :: IO
 
       def initialize(@io = StringIO.new)

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -146,7 +146,8 @@ module HTTP
     # params.fetch("non_existent_param", "default value")      # => "default value"
     # ```
     def fetch(name, default)
-      raw_params.fetch(name, [default]).first
+      return default unless has_key?(name)
+      fetch(name)
     end
 
     # Returns first value for specified param name. Fallbacks to return value
@@ -156,8 +157,9 @@ module HTTP
     # params.fetch("email") { raise InvalidUser("email is missing") }    # InvalidUser "email is missing"
     # params.fetch("non_existent_param") { "default computed value" }    # => "default computed value"
     # ```
-    def fetch(name, &block : -> String)
-      raw_params.fetch(name) { [block.call] }.first
+    def fetch(name)
+      return yield unless has_key?(name)
+      fetch(name)
     end
 
     # Appends new value for specified param name. Creates param when there was


### PR DESCRIPTION
This PR adds a convenient wrapper over raw http params `Hash(String, Array(String))`.

It allows developer to treat http params like a `Hash(String, String)` in most of the cases. And only if one needs to access `multiple-values-per-parameter` functionality, this wrapper has special methods for that.

In one of my next PRs I want to return instance of this class from `HTTP::Request#query_params` and `#post_params` (or `body_params` - still not sure about last name).

/cc @asterite @waj @jhass 