### PR TITLE
add github_name option to init config and read from global git config

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -10,9 +10,9 @@ def describe_file(name, &block : String ->)
   end
 end
 
-def run_init_project(skeleton_type, name, dir, author, email)
+def run_init_project(skeleton_type, name, dir, author, email, github_name)
   Crystal::Init::InitProject.new(
-    Crystal::Init::Config.new(skeleton_type, name, dir, author, email, true)
+    Crystal::Init::Config.new(skeleton_type, name, dir, author, email, github_name, true)
   ).run
 end
 
@@ -21,10 +21,10 @@ module Crystal
     `[ -d tmp/example ] && rm -r tmp/example`
     `[ -d tmp/example_app ] && rm -r tmp/example_app`
 
-    run_init_project("lib", "example", "tmp/example", "John Smith", "john@smith.com")
-    run_init_project("app", "example_app", "tmp/example_app", "John Smith", "john@smith.com")
-    run_init_project("lib", "example-lib", "tmp/example-lib", "John Smith", "john@smith.com")
-    run_init_project("lib", "camel_example-camel_lib", "tmp/camel_example-camel_lib", "John Smith", "john@smith.com")
+    run_init_project("lib", "example", "tmp/example", "John Smith", "john@smith.com", "jsmith")
+    run_init_project("app", "example_app", "tmp/example_app", "John Smith", "john@smith.com", "jsmith")
+    run_init_project("lib", "example-lib", "tmp/example-lib", "John Smith", "john@smith.com", "jsmith")
+    run_init_project("lib", "camel_example-camel_lib", "tmp/camel_example-camel_lib", "John Smith", "john@smith.com", "jsmith")
 
     describe_file "example-lib/src/example-lib.cr" do |file|
       file.should contain("Example::Lib")
@@ -58,14 +58,14 @@ module Crystal
       readme.should contain(%{```yaml
 dependencies:
   example:
-    github: [your-github-name]/example
+    github: jsmith/example
 ```})
 
       readme.should contain(%{TODO: Write a description here})
       readme.should_not contain(%{TODO: Write installation instructions here})
       readme.should contain(%{require "example"})
-      readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example/fork )})
-      readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
+      readme.should contain(%{1. Fork it ( https://github.com/jsmith/example/fork )})
+      readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
     end
 
     describe_file "example_app/README.md" do |readme|
@@ -74,14 +74,14 @@ dependencies:
       readme.should_not contain(%{```yaml
 dependencies:
   example:
-    github: [your-github-name]/example
+    github: jsmith/example
 ```})
 
       readme.should contain(%{TODO: Write a description here})
       readme.should contain(%{TODO: Write installation instructions here})
       readme.should_not contain(%{require "example"})
-      readme.should contain(%{1. Fork it ( https://github.com/[your-github-name]/example_app/fork )})
-      readme.should contain(%{[your-github-name](https://github.com/[your-github-name]) John Smith - creator, maintainer})
+      readme.should contain(%{1. Fork it ( https://github.com/jsmith/example_app/fork )})
+      readme.should contain(%{[jsmith](https://github.com/jsmith) John Smith - creator, maintainer})
     end
 
     describe_file "example/shard.yml" do |shard_yml|

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -35,6 +35,7 @@ DIR  - directory where project will be generated,
 
       config.author = fetch_author
       config.email = fetch_email
+      config.github_name = fetch_github_name
       InitProject.new(config).run
     end
 
@@ -46,6 +47,13 @@ DIR  - directory where project will be generated,
     def self.fetch_email
       return "[your-email-here]" unless system(WHICH_GIT_COMMAND)
       `git config --get user.email`.strip
+    end
+
+    def self.fetch_github_name
+      default = "[your-github-name]"
+      return default unless system(WHICH_GIT_COMMAND)
+      github_user = `git config --get github.user`.strip
+      github_user.empty? ? default : github_user
     end
 
     def self.fetch_skeleton_type(opts, args)
@@ -73,6 +81,7 @@ DIR  - directory where project will be generated,
       property dir
       property author
       property email
+      property github_name
       property silent
 
       def initialize(
@@ -81,6 +90,7 @@ DIR  - directory where project will be generated,
                      @dir = "none",
                      @author = "none",
                      @email = "none",
+                     @github_name = "none",
                      @silent = false
                     )
       end

--- a/src/compiler/crystal/tools/init/template/readme.md.ecr
+++ b/src/compiler/crystal/tools/init/template/readme.md.ecr
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   <%= config.name %>:
-    github: [your-github-name]/<%= config.name %>
+    github: <%= config.github_name %>/<%= config.name %>
 ```
 <% else %>
 TODO: Write installation instructions here
@@ -32,7 +32,7 @@ TODO: Write development instructions here
 
 ## Contributing
 
-1. Fork it ( https://github.com/[your-github-name]/<%= config.name %>/fork )
+1. Fork it ( https://github.com/<%= config.github_name %>/<%= config.name %>/fork )
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)
@@ -40,4 +40,4 @@ TODO: Write development instructions here
 
 ## Contributors
 
-- [your-github-name](https://github.com/[your-github-name]) <%= config.author %> - creator, maintainer
+- [<%= config.github_name %>](https://github.com/<%= config.github_name %>) <%= config.author %> - creator, maintainer


### PR DESCRIPTION
this will set the creator, maintainer line in ## Contributers in the README to `- [[your-github-name]] ...` if no github.user git option is set.

I left it like that, because technically it's clear from the previous occurences of [your-github-name], that the [] are supposed to be replaced too. It would've otherwise also added unnecessary complexity to the template. (`sub(/(?<=^\[).*(?=\]$)/, ...)`)