### PR TITLE
Make empty arrays not allocate memory until needed

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -70,15 +70,18 @@ class Array(T)
   # ary = Array(Int32).new(5)
   # ary.size #=> 0
   # ```
-  def initialize(initial_capacity = 3 : Int)
+  def initialize(initial_capacity = 0 : Int)
     if initial_capacity < 0
       raise ArgumentError.new("negative array size: #{initial_capacity}")
     end
 
-    initial_capacity = Math.max(initial_capacity, 3)
     @size = 0
     @capacity = initial_capacity.to_i
-    @buffer = Pointer(T).malloc(initial_capacity)
+    if initial_capacity == 0
+      @buffer = Pointer(T).null
+    else
+      @buffer = Pointer(T).malloc(initial_capacity)
+    end
   end
 
   # Creates a new Array of the given size filled with the
@@ -98,12 +101,11 @@ class Array(T)
     end
 
     @size = size.to_i
+    @capacity = size.to_i
 
     if size == 0
-      @capacity = 3
-      @buffer = Pointer(T).malloc(@capacity)
+      @buffer = Pointer(T).null
     else
-      @capacity = size.to_i
       @buffer = Pointer(T).malloc(size, value)
     end
   end
@@ -1525,12 +1527,16 @@ class Array(T)
   end
 
   private def check_needs_resize
-    resize_to_capacity(@capacity * 2) if @size == @capacity
+    resize_to_capacity(@capacity == 0 ? 3 : (@capacity * 2)) if @size == @capacity
   end
 
   private def resize_to_capacity(capacity)
     @capacity = capacity
-    @buffer = @buffer.realloc(@capacity)
+    if @buffer
+      @buffer = @buffer.realloc(@capacity)
+    else
+      @buffer = Pointer(T).malloc(@capacity)
+    end
   end
 
   protected def self.quicksort!(a, n, comp)


### PR DESCRIPTION
This change makes this:

```crystal
[] of Int32
```

create an array whose pointer is null. That is, no `malloc` call is done. Then, if you push elements to an array, the malloc call will be done. In this way some memory can be saved until it's really needed. The changes are pretty small because in every place, before accessing the buffer, bound checks are already performed.

Of course, doing `map` on an empty array, and creating empty arrays in general have the same benefit.

With this, [havlak](https://github.com/manastech/crystal/blob/master/samples/havlak.cr) changes from `16.04s, 357.9Mb` to `15.03s, 287.9Mb`. The compiler's time/memory doesn't changed in my tests. Other samples don't change either, but I believe that in general some memory can be saved.

We could merge this right now, but if you have any sample code that you can test this with and check if performance improves or gets worse, it would be great :-)