### PR TITLE
Make spawn usage consistent with a single way of calling.  

### DIFF
--- a/samples/channel_primes.cr
+++ b/samples/channel_primes.cr
@@ -17,13 +17,17 @@ def filter(in_chan, out_chan, prime)
   end
 end
 
-ch = Channel(Int32).new
-spawn generate(ch)
+def spawn_filter(in_chan, out_chan, prime)
+  spawn { filter(in_chan, out_chan, prime) }
+end
+
+ch = out_chan = Channel(Int32).new
+spawn { generate(out_chan) }
 
 100.times do
   prime = ch.receive
   puts prime
   ch1 = Channel(Int32).new
-  spawn filter(ch, ch1, prime)
+  spawn_filter(ch, ch1, prime)
   ch = ch1
 end

--- a/samples/tcp_server.cr
+++ b/samples/tcp_server.cr
@@ -20,4 +20,7 @@ end
 
 server = TCPServer.new "127.0.0.1", 9000
 puts "listen on 127.0.0.1:9000"
-loop { spawn process(server.accept) }
+loop do
+  client = server.accept
+  spawn { process(client) }
+end

--- a/src/concurrent/concurrent.cr
+++ b/src/concurrent/concurrent.cr
@@ -27,29 +27,6 @@ macro spawn
   Scheduler.enqueue %fiber
 end
 
-# TODO: this doesn't work if a Call has a block or named arguments... yet
-macro spawn(exp)
-  {% if exp.is_a?(Call) %}
-    ->(
-      {% for arg, i in exp.args %}
-        __arg{{i}} : typeof({{arg}}),
-      {% end %}
-      ) {
-      spawn do
-        {{exp.name}}(
-          {% for arg, i in exp.args %}
-            __arg{{i}},
-          {% end %}
-        )
-      end
-    }.call({{*exp.args}})
-  {% else %}
-    spawn do
-      {{exp}}
-    end
-  {% end %}
-end
-
 macro parallel(*jobs)
   %channel = Channel(Bool).new
 

--- a/src/http/server/server.cr
+++ b/src/http/server/server.cr
@@ -38,7 +38,8 @@ class HTTP::Server
   def listen
     server = TCPServer.new(@port)
     until @wants_close
-      spawn handle_client(server.accept)
+      client = server.accept
+      spawn { handle_client(client) }
     end
   end
 
@@ -46,7 +47,10 @@ class HTTP::Server
     server = TCPServer.new(@port)
     workers.times do
       fork do
-        loop { spawn handle_client(server.accept) }
+        loop do
+          client = server.accept
+          spawn { handle_client(client) }
+        end
       end
     end
 


### PR DESCRIPTION
Remove redundant macro.