### PR TITLE
Relocate Char::Reader comments for documentation

### DIFF
--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -1,16 +1,16 @@
-# A Char::Reader allows iterating a String by Chars.
-#
-# As soon as you instantiate a Char::Reader it will decode the first
-# char in the String, which can be accesed by invoking `current_char`.
-# At this point `pos`, the current position in the string, will equal zero.
-# Successive calls to `next_char` return the next chars in the string,
-# advancing `pos`.
-#
-# Note that the null character '\0' will be returned in `current_char` when
-# the end is reached (as well as when the string is empty). Thus, `has_next?`
-# will return `false` only when `pos` is equal to the string's bytesize, in which
-# case `current_char` will always be '\0'.
 struct Char
+  # A Char::Reader allows iterating a String by Chars.
+  #
+  # As soon as you instantiate a Char::Reader it will decode the first
+  # char in the String, which can be accesed by invoking `current_char`.
+  # At this point `pos`, the current position in the string, will equal zero.
+  # Successive calls to `next_char` return the next chars in the string,
+  # advancing `pos`.
+  #
+  # Note that the null character '\0' will be returned in `current_char` when
+  # the end is reached (as well as when the string is empty). Thus, `has_next?`
+  # will return `false` only when `pos` is equal to the string's bytesize, in which
+  # case `current_char` will always be '\0'.
   struct Reader
     include Enumerable(Char)
 


### PR DESCRIPTION
Char::Reader struct comments were placed at top level (Char) instead
of the proper, inner structure, Reader.

Because of this, generated documentation missed to collect them and
include in the output.

This change, while doesn't introduce any new documentation, ensures
at least this comment is not lost.

Thank you.

:heart: :heart: :heart: 