### PR TITLE
Suggest using the release flag when building

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -66,6 +66,10 @@ module Crystal
 
       @link_flags = "#{@link_flags} -rdynamic"
 
+      unless @release
+        puts "Use the --release flag to build an optimized binary"
+      end
+
       node, original_node = parse program, sources
       node = infer_type program, node
       codegen program, node, sources, output_filename unless @no_codegen


### PR DESCRIPTION
Sometimes people don't know or forget about the `--release` flag.

This PR adds a message suggesting to use `--release` every time someone runs `crystal build`, so people become aware of it.

I don't know if there is a way to test `puts` method, but if there is please let me know and I will write a spec.