### PR TITLE
Add --no-color option to `crystal spec` subcommand

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -83,3 +83,19 @@ describe "Spec matchers" do
     end
   end
 end
+
+describe "Spec" do
+  describe "use_colors?" do
+    it "returns if output is colored or not" do
+      saved = Spec.use_colors?
+      begin
+        Spec.use_colors = false
+        Spec.use_colors?.should be_false
+        Spec.use_colors = true
+        Spec.use_colors?.should be_true
+      ensure
+        Spec.use_colors = saved
+      end
+    end
+  end
+end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -237,12 +237,13 @@ USAGE
   end
 
   private def run_specs
-    target_filename_and_line_number = options.first?
-    if target_filename_and_line_number
+    target_index = options.index{|o| !o.starts_with? '-'}
+    if target_index
+      target_filename_and_line_number = options[target_index]
       splitted = target_filename_and_line_number.split ':', 2
       target_filename = splitted[0]
       if File.file?(target_filename)
-        options.shift
+        options.delete_at target_index
         cwd = Dir.working_directory
         if target_filename.starts_with?(cwd)
           target_filename = "#{target_filename[cwd.size .. -1]}"

--- a/src/spec/spec.cr
+++ b/src/spec/spec.cr
@@ -82,9 +82,22 @@ module Spec
     pending: '*',
   }
 
+  @@use_colors = true
+
   # :nodoc:
   def self.color(str, status)
-    str.colorize(COLORS[status])
+    if use_colors?
+      str.colorize(COLORS[status])
+    else
+      str
+    end
+  end
+
+  def self.use_colors?
+    @@use_colors
+  end
+
+  def self.use_colors=(@@use_colors)
   end
 
   # :nodoc:
@@ -197,6 +210,9 @@ OptionParser.parse! do |opts|
   end
   opts.on("-v", "--verbose", "verbose output") do
     Spec.formatter = Spec::VerboseFormatter.new
+  end
+  opts.on("--no-color", "Disable colored output") do
+    Spec.use_colors = false
   end
 end
 


### PR DESCRIPTION
I added `--no-color` option to `spec` subcommand.  This is already discussed at #1587.