### PR TITLE
require http server to be initialized with host

### DIFF
--- a/samples/http_server.cr
+++ b/samples/http_server.cr
@@ -1,6 +1,6 @@
 require "http/server"
 
-server = HTTP::Server.new 8080, do |request|
+server = HTTP::Server.new "0.0.0.0", 8080, do |request|
   HTTP::Response.ok "text/plain", "Hello world!"
 end
 

--- a/spec/std/http/client_spec.cr
+++ b/spec/std/http/client_spec.cr
@@ -2,6 +2,25 @@ require "spec"
 require "http/client"
 require "http/server"
 
+class TestServer < TCPServer
+  def self.open(host, port, read_time = 0)
+    server = new(host, port)
+    begin
+      spawn do
+        io = server.accept
+        sleep read_time
+        response = HTTP::Response.ok("text/plain", "OK")
+        response.to_io(io)
+        io.flush
+      end
+
+      yield
+    ensure
+      server.close
+    end
+  end
+end
+
 module HTTP
   describe Client do
     {% for method in %w(get post put head delete patch) %}
@@ -22,14 +41,6 @@ module HTTP
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get("http://www.example.com"))
 
-    server = HTTP::Server.new(8081) do |req|
-      sleep 0.5
-      HTTP::Response.ok("text/plain", "OK")
-    end
-    spawn do
-      server.listen
-    end
-
     it "raises if URI is missing scheme" do
       expect_raises(ArgumentError) do
         HTTP::Client.get "www.example.com"
@@ -37,22 +48,27 @@ module HTTP
     end
 
     it "tests read_timeout" do
-      client = Client.new("localhost", 8081)
-      client.read_timeout = 1
-      client.get("/")
-
-      expect_raises(IO::Timeout, "read timed out") do
-        client.read_timeout = 0.0001
+      TestServer.open("localhost", 8080, 0) do
+        client = Client.new("localhost", 8080)
+        client.read_timeout = 1.second
         client.get("/")
+      end
+
+      TestServer.open("localhost", 8080, 0.5) do
+        client = Client.new("localhost", 8080)
+        expect_raises(IO::Timeout, "read timed out") do
+          client.read_timeout = 0.001
+          client.get("/?sleep=1")
+        end
       end
     end
 
     it "tests connect_timeout" do
-      client = Client.new("localhost", 8081)
-      client.connect_timeout = 1.second
-      client.get("/")
+      TestServer.open("localhost", 8080, 0) do
+        client = Client.new("localhost", 8080)
+        client.connect_timeout = 0.5
+        client.get("/")
+      end
     end
-
-    server.close
   end
 end

--- a/spec/std/http/server_spec.cr
+++ b/spec/std/http/server_spec.cr
@@ -2,6 +2,25 @@ require "http/server"
 
 module HTTP
   typeof(begin
+    # Initialize with custom host
+    server = Server.new("0.0.0.0", 8080) { |req| HTTP::Response.ok("text/plain", "OK") }
+    server.listen
+    server.listen_fork(workers: 2)
+    server.close
+
+    Server.new("0.0.0.0", 8080, [
+        ErrorHandler.new,
+        LogHandler.new,
+        DeflateHandler.new,
+        StaticFileHandler.new("."),
+      ]
+      ).listen
+
+    server = Server.new("0.0.0.0", 8080, [StaticFileHandler.new(".")]) { |req| HTTP::Response.ok("text/plain", "OK") }
+    server.listen
+    server.close
+
+    # Initialize with default host
     server = Server.new(8080) { |req| HTTP::Response.ok("text/plain", "OK") }
     server.listen
     server.listen_fork(workers: 2)
@@ -14,5 +33,9 @@ module HTTP
         StaticFileHandler.new("."),
       ]
       ).listen
+
+    server = Server.new(8080, [StaticFileHandler.new(".")]) { |req| HTTP::Response.ok("text/plain", "OK") }
+    server.listen
+    server.close
   end)
 end


### PR DESCRIPTION
This change requires a host to be set when creating an HTTP::Server. This allows it to be set and forces users to think about if they want to open a port to the world or just localhost.

I know this breaks the website's example, but I believe it's for a good cause :-)
