### PR TITLE
Fix documentation format for the doc parser.

### DIFF
--- a/src/ecr/ecr.cr
+++ b/src/ecr/ecr.cr
@@ -53,8 +53,6 @@
 #     #=> Hi, Ben!
 #
 # Likewise, other Crystal logic can be implemented in ECR text.
-
-
 module ECR
   extend self
 

--- a/src/markdown/markdown.cr
+++ b/src/markdown/markdown.cr
@@ -5,13 +5,11 @@
 # 
 #     require "markdown"
 #     
-#     text = "## This is title \n" \ 
-#            "This is a [link](http://crystal-lang.org)"
+#     text = "## This is title \n This is a [link](http://crystal-lang.org)"
 #
 #     Markdown.to_html(text)
 #     #=><h2>This is title</h2>
 #     #=><p>This is a <a href="http://crystal-lang.org">link</a></p>
-
 class Markdown
   def self.parse(text, renderer)
     parser = Parser.new(text, renderer)

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -1,3 +1,12 @@
+lib LibC
+  struct TimeZone
+    tz_minuteswest : Int
+    tz_dsttime     : Int
+  end
+
+  fun gettimeofday(tp : TimeVal*, tzp : TimeZone*) : Int
+end
+
 # The `Time` library allows you to inspect, analyze, calculate, and format time. Here are some examples:
 # 
 # ### Basic Usage
@@ -57,16 +66,6 @@
 #     span       #=> 02:00:00
 #     span.class #=> Time::Span
 #     span.hours #=> 2
-
-lib LibC
-  struct TimeZone
-    tz_minuteswest : Int
-    tz_dsttime     : Int
-  end
-
-  fun gettimeofday(tp : TimeVal*, tzp : TimeZone*) : Int
-end
-
 struct Time
   # *Heavily* inspired by Mono's DateTime class:
   # https://github.com/mono/mono/blob/master/mcs/class/corlib/System/DateTime.cs


### PR DESCRIPTION
As stated in  #1619 , the documentation I updated in previous commits do not show up using `make doc`. Following changes are made so that they become visible.
- Remove extra gaps between doc and class definition in Markdown & ECR library.
- Attach doc right above Time struct.