### PR TITLE
refactor(String#includes?) use a single def for Char and String

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1597,12 +1597,14 @@ class String
     nil
   end
 
-  def includes?(c : Char)
-    !!index(c)
-  end
-
-  def includes?(str : String)
-    !!index(str)
+  # Returns true if `str` contains `search`.
+  #
+  # ```
+  # "Team".includes?('i')             #=> false
+  # "Dysfunctional".includes?("fun")  #=> true
+  # ```
+  def includes?(search : Char | String)
+    !!index(search)
   end
 
   def split(limit = nil : Int32?)


### PR DESCRIPTION
I noticed these two definitions _could_ be merged into one. Is that desirable?

The benchmark (http://pastebin.com/0q56PG1J) suggests this is the tiniest bit slower. Is that a deal-breaker? On my machine:

```
~/projects/crystal $ crystal eval
class String
  def combo_includes?(c : (Char|String))
    !!index(c)
  end
end

STR = "hello this is a string"

require "benchmark"

Benchmark.ips do |x|
  x.report("std chr") { STR.includes?('a') }
  x.report("std str") { STR.includes?("a") }
  x.report("combo chr") { STR.combo_includes?('a') }
  x.report("combo str") { STR.combo_includes?("a") }
end

  std chr      6M (± 3.82%)       fastest
  std str   1.85M (± 3.38%)  3.24× slower
combo chr   5.97M (± 2.24%)  1.00× slower
combo str   1.85M (± 2.31%)  3.25× slower
```