### PR TITLE
refactor(String#split) use the string implementation, even for Chars

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1660,40 +1660,6 @@ class String
     ary
   end
 
-  def split(separator : Char, limit = nil)
-    if separator == ' '
-      return split(limit)
-    end
-
-    if limit && limit <= 1
-      return [self]
-    end
-
-    ary = Array(String).new
-
-    byte_offset = 0
-    single_byte_optimizable = single_byte_optimizable?
-
-    reader = Char::Reader.new(self)
-    reader.each_with_index do |char, i|
-      if char == separator
-        piece_bytesize = reader.pos - byte_offset
-        piece_size = single_byte_optimizable ? piece_bytesize : 0
-        ary.push String.new(cstr + byte_offset, piece_bytesize, piece_size)
-        byte_offset = reader.pos + reader.current_char_width
-        break if limit && ary.size + 1 == limit
-      end
-    end
-
-    if byte_offset != bytesize
-      piece_bytesize = bytesize - byte_offset
-      piece_size = single_byte_optimizable ? piece_bytesize : 0
-      ary.push String.new(cstr + byte_offset, piece_bytesize, piece_size)
-    end
-
-    ary
-  end
-
   def split(separator : String, limit = nil)
     ary = Array(String).new
     byte_offset = 0
@@ -1742,6 +1708,10 @@ class String
       ary.push String.new(cstr + byte_offset, piece_bytesize, piece_size)
     end
     ary
+  end
+
+  def split(separator : Char, limit = nil)
+    split(separator.to_s, limit)
   end
 
   def split(separator : Regex, limit = nil)


### PR DESCRIPTION
As I was reading about these methods, I experimented a bit with this one.  I was surprised to find that treating a `Char` like a one-character `String` brought a performance gain.

Of course, I don't really understand Crystal internals yet so I can't say anything about _why_ ... but, do you want this PR? Or is there something else going on?

Here's the benchmark:

```
equire "benchmark"

class String
  def split_as_string(char : Char, limit)
    split(char.to_s, limit)
  end
end

short_string = "Mississippi"
long_string = "b169af8aff8b146c6a93328f9966fc1558a2e6dd11ca4375ca8dd66265a34364af6cc6805a6cf59b9e07d86c3fa25214f691c76ae5ba7910ff7c1b842cf3521cb5d68f40ee81a21feed0dfefc65b7837cf4fdf682db0608a09584a96cb30ed3c602adc6bee9c775c9dd051bdad64d41d55ad480daee48ff44471778ab868379f077ea12e3cb29aa0cd7446e5a0b31bed3ecf3ef431de0386db7086a0597c714e4f258691a587c7b969116b450d61c8152f8e84df0bb677cff7ac33e45837e5453db4658d1f22641321ea9bdca1873cf3fbad49026b9923bc270e228a413517db1cba135e7f64757a0e73a1384916ecaf83ab4600357f22ce174253e7be17fa12a4632941879fbe0de6744cb4ad6c6d673419a0f6f95b88598c7395648ec5e4161fe6bc0e1b1c8479ed5f8cb6cf8ca0739595cccac06f8756a86e6e6dce1190bbff4a1b14790a8b7e7f966182b539918d06475b36da278d3c5ddbdce60a5dc70efe693b04c76e976288f5831323ca195b05b06b0ff193d9de338001f81014b50669f5ad1d683123648b2117d56285eadbb5709482b5684e73abf73de1f78e228fab86b5a05c4193fac8a56dcbeb9d06639b1f3c3f10ae6ba119ac3740c23390963608be286a71d65e2706120df5b95991d0c32b40062c888bfabe87e9d604c4cdf3e6a748ade6ec26606ea7bd403d9164c45196f992a5a64fa1923ab53ac991b4da0e8364655ce5345a981ece495d91e3b0083d8967b8a6f597275def352aa1bd7836ea47c72e3e2c7faf140a827af8b26b0e6218d0bc642e5e7930b83cc535f431141db89841a5fc55ffb1f0a0b2ac9a4a96a6887cc1679626332e05937a787c450769cc59ec04c5794d00acd6deb72527775f7abd653f7c4143a38504055b24d7602fad3eda3422e44ed5b0cca1d8312f6b1603427583a48bec068355dddc0ee784bdda7b825d15afba068c31a6bb16ff72d81c0b7526646080ae2b8b917002a5ee04abf99f0412d09f9b0007ec8c76d8b4469cc3a8ea6b92957921a9e9ba464088290f04706681c80242411dc3f160e51e1b83f3f4f7d098a66dfb33a67b0018c26129d503336217fcfd422f2f36eaf345f22b39328642b6d645959f08355902707cb651fbac1d9b8aace14e37347f510794a6aa0940c9c0f4c02123e4782cc08e05506d1ac5bfcdce134956fd6f3bd3fd1cff11b34958a9cf08a21f02c6a773f1b3df2236fea4a355998e67d4c79b6635a43bdcf0c3a29f0ab6d36db9ef9133b5821779c1c05a33a6bf9e285f7b0df3e27ea1a38b0886f4deab576e0bba1c370be9e6de3d922ee6690bb2221ae79f33dcda184e58d797dc2cf85a9768b630188f6d4cf6e04076db978aa81bbb8822f3dcdb597e2cf0dbc19b8a594cd62e938de61846c056f84b8b2cb0da484172d15392e6635d5f140fb7529bc5ad48d8fb37a6560ef5a744ea037baf970979e956a2a014fdd8e34e355b2b46a4061e17d3f07ec6241f06fb121c4678c0d68c535ac0092214e5bcf9b561025cfbe83e8d0b424dce25b8691213946baedc1f49f45372733776143859bda806dd19d7658c5be3d8a9f3845a6300fe0488ad6296f2dc8f582df0f0fca8cafeae24acac4d1c1f960a9552ff43e10e77eb74f95daf381fdf7efe79f2c6fb9aa06d530ffda9e2ac17330574bb8d46b74d7aca017477b909a4f6d671504f02e8b8affbd68d1fdbb31d23add5101d5a0f7e884129c17f82d6848124e466f84ac56c6f31ab73b2c04e4d4bb53e8f23a2f0aa74c896496577f55860f8a5df67a8233d90b1b42d8553e77af79c5e9807e3fd800f56f1d16563b12d0727bb3e6c4c3826e88206650b0b3e6e1d786e49dfc7fb1f1386a446c5cb58c40ac2031302c1890d8296c71a96d3ad24936ace4984a5f66e810e3f01825db3b848be61a9882dca07acd3b9965f26d0b4fdbb0626736de0ee50396aad8f60c03dbfbaac956f1a5d29e6655b90853caaab44461e5b7676e1bea3398f088ebe1ae8468e412ac825e84186138ada8fa2971eb65fd77a987bbef513a8db38a186cfd9fc9c12352456a347344ae4791fbcfb07642a6fc000c9f3db872ae6c1bb41e089b3945bb5e71211c0e6b66b149c6267489d3922cde00e2eabcef3f88195a7d341d8dd696df8c415bed1cc920da79acf04f49d510ad33e41e757976d1767fa5a96ebd3e62c89b49510871642f09f105cd5a744a3e5378a38fc381a5976d39a0b9c09503c686584dfb60b3dce9e9cacdeb169af8aff8b146c6a93328f9966fc1558a2e6dd11ca4375ca8dd66265a34364af6cc6805a6cf59b9e07d86c3fa25214f691c76ae5ba7910ff7c1b842cf3521cb5d68f40ee81a21feed0dfefc65b7837cf4fdf682db0608a09584a96cb30ed3c602adc6bee9c775c9dd051bdad64d41d55ad480daee48ff44471778ab868379f077ea12e3cb29aa0cd7446e5a0b31bed3ecf3ef431de0386db7086a0597c714e4f258691a587c7b969116b450d61c8152f8e84df0bb677cff7ac33e45837e5453db4658d1f22641321ea9bdca1873cf3fbad49026b9923bc270e228a413517db1cba135e7f64757a0e73a1384916ecaf83ab4600357f22ce174253e7be17fa12a4632941879fbe0de6744cb4ad6c6d673419a0f6f95b88598c7395648ec5e4161fe6bc0e1b1c8479ed5f8cb6cf8ca0739595cccac06f8756a86e6e6dce1190bbff4a1b14790a8b7e7f966182b539918d06475b36da278d3c5ddbdce60a5dc70efe693b04c76e976288f5831323ca195b05b06b0ff193d9de338001f81014b50669f5ad1d683123648b2117d56285eadbb5709482b5684e73abf73de1f78e228fab86b5a05c4193fac8a56dcbeb9d06639b1f3c3f10ae6ba119ac3740c23390963608be286a71d65e2706120df5b95991d0c32b40062c888bfabe87e9d604c4cdf3e6a748ade6ec26606ea7bd403d9164c45196f992a5a64fa1923ab53ac991b4da0e8364655ce5345a981ece495d91e3b0083d8967b8a6f597275def352aa1bd7836ea47c72e3e2c7faf140a827af8b26b0e6218d0bc642e5e7930b83cc535f431141db89841a5fc55ffb1f0a0b2ac9a4a96a6887cc1679626332e05937a787c450769cc59ec04c5794d00acd6deb72527775f7abd653f7c4143a38504055b24d7602fad3eda3422e44ed5b0cca1d8312f6b1603427583a48bec068355dddc0ee784bdda7b825d15afba068c31a6bb16ff72d81c0b7526646080ae2b8b917002a5ee04abf99f0412d09f9b0007ec8c76d8b4469cc3a8ea6b92957921a9e9ba464088290f04706681c80242411dc3f160e51e1b83f3f4f7d098a66dfb33a67b0018c26129d503336217fcfd422f2f36eaf345f22b39328642b6d645959f08355902707cb651fbac1d9b8aace14e37347f510794a6aa0940c9c0f4c02123e4782cc08e05506d1ac5bfcdce134956fd6f3bd3fd1cff11b34958a9cf08a21f02c6a773f1b3df2236fea4a355998e67d4c79b6635a43bdcf0c3a29f0ab6d36db9ef9133b5821779c1c05a33a6bf9e285f7b0df3e27ea1a38b0886f4deab576e0bba1c370be9e6de3d922ee6690bb2221ae79f33dcda184e58d797dc2cf85a9768b630188f6d4cf6e04076db978aa81bbb8822f3dcdb597e2cf0dbc19b8a594cd62e938de61846c056f84b8b2cb0da484172d15392e6635d5f140fb7529bc5ad48d8fb37a6560ef5a744ea037baf970979e956a2a014fdd8e34e355b2b46a4061e17d3f07ec6241f06fb121c4678c0d68c535ac0092214e5bcf9b561025cfbe83e8d0b424dce25b8691213946baedc1f49f45372733776143859bda806dd19d7658c5be3d8a9f3845a6300fe0488ad6296f2dc8f582df0f0fca8cafeae24acac4d1c1f960a9552ff43e10e77eb74f95daf381fdf7efe79f2c6fb9aa06d530ffda9e2ac17330574bb8d46b74d7aca017477b909a4f6d671504f02e8b8affbd68d1fdbb31d23add5101d5a0f7e884129c17f82d6848124e466f84ac56c6f31ab73b2c04e4d4bb53e8f23a2f0aa74c896496577f55860f8a5df67a8233d90b1b42d8553e77af79c5e9807e3fd800f56f1d16563b12d0727bb3e6c4c3826e88206650b0b3e6e1d786e49dfc7fb1f1386a446c5cb58c40ac2031302c1890d8296c71a96d3ad24936ace4984a5f66e810e3f01825db3b848be61a9882dca07acd3b9965f26d0b4fdbb0626736de0ee50396aad8f60c03dbfbaac956f1a5d29e6655b90853caaab44461e5b7676e1bea3398f088ebe1ae8468e412ac825e84186138ada8fa2971eb65fd77a987bbef513a8db38a186cfd9fc9c12352456a347344ae4791fbcfb07642a6fc000c9f3db872ae6c1bb41e089b3945bb5e71211c0e6b66b149c6267489d3922cde00e2eabcef3f88195a7d341d8dd696df8c415bed1cc920da79acf04f49d510ad33e41e757976d1767fa5a96ebd3e62c89b49510871642f09f105cd5a744a3e5378a38fc381a5976d39a0b9c09503c686584dfb60b3dce9e9cacde"

puts "running..."
puts "========="

Benchmark.ips do |x|
  x.report("long string a -      Char") { long_string.split('a', 10) }
  x.report("long string a -    String") { long_string.split("a", 10) }
  x.report("long string a - Ch -> Str") { long_string.split_as_string('a', 10) }
end
puts "---------"
Benchmark.ips do |x|
  x.report("long string g -      Char") { long_string.split('g', 10) }
  x.report("long string g -    String") { long_string.split("g", 10) }
  x.report("long string g - Ch -> Str") { long_string.split_as_string('g', 10) }
end
puts "---------"
Benchmark.ips do |x|
  x.report("short string s -      Char") { short_string.split('s', 10) }
  x.report("short string s -    String") { short_string.split("s", 10) }
  x.report("short string s - Ch -> Str") { short_string.split_as_string('s', 10) }
end
puts "---------"
Benchmark.ips do |x|
  x.report("short string i -      Char") { short_string.split('i', 10) }
  x.report("short string i -    String") { short_string.split("i", 10) }
  x.report("short string i - Ch -> Str") { short_string.split_as_string('i', 10) }
end
```

And the result, from two runs:

```
~/projects/crystal $ crystal run str_split.cr
running...
=========
long string a -      Char 111.32k (±11.44%)  1.03× slower
long string a -    String 111.72k (±11.89%)  1.03× slower
long string a - Ch -> Str 114.71k (± 5.91%)       fastest
---------
long string g -      Char   7.84k (± 5.83%)  1.84× slower
long string g -    String  13.93k (± 9.83%)  1.04× slower
long string g - Ch -> Str  14.46k (± 6.18%)       fastest
---------
short string s -      Char 947.08k (±13.31%)  1.33× slower
short string s -    String   1.26M (± 8.65%)       fastest
short string s - Ch -> Str   1.12M (± 7.44%)  1.12× slower
---------
short string i -      Char   1.15M (±10.26%)  1.26× slower
short string i -    String   1.44M (± 5.69%)       fastest
short string i - Ch -> Str   1.17M (± 9.72%)  1.23× slower
~/projects/crystal $ crystal run str_split.cr
running...
=========
long string a -      Char 112.11k (±13.38%)  1.05× slower
long string a -    String 117.54k (±10.65%)       fastest
long string a - Ch -> Str  77.58k (±19.36%)  1.52× slower
---------
long string g -      Char   7.43k (± 9.46%)  2.01× slower
long string g -    String  14.93k (± 1.23%)       fastest
long string g - Ch -> Str   14.9k (± 0.73%)  1.00× slower
---------
short string s -      Char   1.09M (± 4.50%)  1.23× slower
short string s -    String   1.34M (± 2.17%)       fastest
short string s - Ch -> Str   1.17M (± 2.81%)  1.14× slower
---------
short string i -      Char    1.2M (± 4.49%)  1.17× slower
short string i -    String   1.41M (± 9.07%)       fastest
short string i - Ch -> Str   1.26M (± 5.34%)  1.12× slower
```