### PR TITLE
docs(on_arch_linux): remove update section

### DIFF
--- a/_gitbook/installation/on_arch_linux.md
+++ b/_gitbook/installation/on_arch_linux.md
@@ -7,11 +7,3 @@ Arch Linux includes the Crystal compiler in the Community repository.
 ```
 sudo pacman -S crystal
 ```
-
-## Upgrade
-
-When a new Crystal version is released you can upgrade your system using:
-
-```
-sudo pacman -Sy --needed crystal
-```


### PR DESCRIPTION
Because it is fairly unnecessary anyway as @Earnestly explains in #1633,
and it is unsupported too [1]. Arch users know how to update packages
anyway (or at least with packages in the official repositories, like
with Crystal).

Closes #1633.

[1]: https://wiki.archlinux.org/index.php/Pacman#Partial_upgrades_are_unsupported

---

Hope I edited the correct file?