### PR TITLE
add reject method for ArrayLiterals in macros

### DIFF
--- a/docs/macros.cr
+++ b/docs/macros.cr
@@ -479,6 +479,10 @@ module Macros
     def select(&block) : ArrayLiteral
     end
 
+    # Similar to `Enumerable#reject`
+    def reject(&block) : ArrayLiteral
+    end
+
     # Similar to `Array#shuffle`
     def shuffle : ArrayLiteral
     end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -421,6 +421,10 @@ describe "macro methods" do
       assert_macro "", %({{[1, 2, 3].select { |e| e == 1 }}}), [] of ASTNode, "[1]"
     end
 
+    it "executes reject" do
+      assert_macro "", %({{[1, 2, 3].reject { |e| e == 1 }}}), [] of ASTNode, "[2, 3]"
+    end
+
     it "executes find (finds)" do
       assert_macro "", %({{[1, 2, 3].find { |e| e == 2 }}}), [] of ASTNode, "2"
     end


### PR DESCRIPTION
good for

``` crystal
abstract class Foo
  macro def self.subclasses : Array(Foo.class)
    {{@type.all_subclasses.reject(&.abstract?)}}
  end
end

abstract class Bar < Foo
end

class Baz < Foo
end

class Foobar < Bar
end

Foo.subclasses # => [Baz, Foobar]
```