### PR TITLE
[HTTP::Params] Add #to_h returning internal hash

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -56,6 +56,16 @@ module HTTP
       end
     end
 
+    describe "#to_h" do
+      it "returns internal Hash(String, Array(String)) representation" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux").to_h
+
+        params["foo"].should eq(["bar", "baz"])
+        params["baz"].should eq(["qux"])
+        expect_raises(KeyError) { params["non_existent_param"] }
+      end
+    end
+
     describe "#[](name)" do
       it "returns first value for provided param name" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -247,6 +247,17 @@ module HTTP
       end
     end
 
+    # Returns internal representation of +HTTP::Params+ as
+    # +Hash(String, Array(String))+
+    #
+    # ```
+    # param_hash = HTTP::Params.parse(query).to_h
+    # # => {"foo" => ["bar", "baz"], "baz" => ["qux"]}
+    # ```
+    def to_h
+      raw_params
+    end
+
     # :nodoc:
     class Builder
       @io :: IO


### PR DESCRIPTION
Followup for #1569 related to this and following comments: https://github.com/manastech/crystal/pull/1569#issuecomment-144097167