### PR TITLE
Websocket refactoring

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -5,6 +5,14 @@ require "openssl"
 require "uri"
 
 class HTTP::WebSocket
+  @[Flags]
+  enum Flags : UInt8
+    FINAL = 0x80
+    RSV1 = 0x40
+    RSV2 = 0x20
+    RSV3 = 0x10
+  end
+
   enum Opcode : UInt8
     CONTINUATION   = 0x0
     TEXT           = 0x1
@@ -27,39 +35,15 @@ class HTTP::WebSocket
     @remaining = 0
   end
 
-  def send(data)
-    write_header(data.size)
-    @io.print data
-    @io.flush
-  end
-
-  def send_masked(data)
-    write_header(data.size, true)
-
-    mask_array = StaticArray(UInt8, 4).new { rand(256).to_u8 }
-    @io.write mask_array.to_slice
-
-    data.size.times do |index|
-      mask = mask_array[index % 4]
-      @io.write_byte (mask ^ data.byte_at(index).to_u8).to_u8
+  {% for data_type, opcode in { "String" => "Opcode::TEXT", "Slice(UInt8)" => "Opcode::BINARY" } %}
+    def send(data : {{data_type.id}}, masked = false)
+      slice = {{data_type == "Slice(UInt8)" ? "data".id : "data.to_slice".id}}
+      write_header(slice.size, {{opcode.id}}, masked)
+      write_payload(slice, masked)
+      @io.flush
     end
-    @io.flush
-  end
+  {% end %}
 
-  private def write_header(size, masked = false)
-    @io.write_byte(0x81_u8)
-
-    mask = masked ? MASK_BIT : 0
-    if size <= 125
-      @io.write_byte(size.to_u8 | mask)
-    elsif size <= UInt16::MAX
-      @io.write_byte(126_u8 | mask)
-      1.downto(0) { |i| @io.write_byte((size >> i * 8).to_u8) }
-    else
-      @io.write_byte(127_u8 | mask)
-      3.downto(0) { |i| @io.write_byte((size >> i * 8).to_u8) }
-    end
-  end
 
   def receive(buffer : Slice(UInt8))
     if @remaining == 0
@@ -68,18 +52,37 @@ class HTTP::WebSocket
       opcode = @opcode
     end
 
-    read = @io.read buffer[0, Math.min(@remaining, buffer.size)]
+    read = read_payload(buffer)
     @remaining -= read
-
-    # Unmask payload, if needed
-    if masked?
-      read.times do |i|
-        buffer[i] ^= @mask[@mask_offset % 4]
-        @mask_offset += 1
-      end
-    end
-
     PacketInfo.new(opcode, read.to_i, final? && @remaining == 0)
+  end
+
+  private def write_header(size, opcode, masked = false, flags = Flags::FINAL)
+    @io.write_byte(flags.value | opcode.value)
+
+    mask = masked ? MASK_BIT : 0_u8
+    if size <= 125
+      @io.write_byte(size.to_u8 | mask)
+    elsif size <= UInt16::MAX
+      @io.write_byte(126_u8 | mask)
+      @io.write_bytes(size.to_u16, IO::ByteFormat::NetworkEndian)
+    else
+      @io.write_byte(127_u8 | mask)
+      @io.write_bytes(size.to_u64, IO::ByteFormat::NetworkEndian)
+    end
+  end
+
+  private def write_payload(data, masked = false)
+    return @io.write(data) unless masked
+
+    key = Random::DEFAULT.next_int
+    mask_array = (pointerof(key) as Pointer(UInt8[4])).value
+    @io.write mask_array.to_slice
+
+    data.each_with_index do |byte, index|
+      mask = mask_array[index % 4]
+      @io.write_byte(byte ^ mask_array[index % 4])
+    end
   end
 
   private def read_header
@@ -125,6 +128,20 @@ class HTTP::WebSocket
       4.times { size <<= 8; size += @io.read_byte.not_nil! }
     end
     size
+  end
+
+  private def read_payload(buffer)
+    count = Math.min(@remaining, buffer.size)
+    if masked?
+      count.times do |i|
+        buffer[i] = @io.read_byte.not_nil! ^ @mask[@mask_offset % 4]
+        @mask_offset += 1
+      end
+    else
+      @io.read_fully(buffer[0, count])
+    end
+
+    count
   end
 
   private def control?


### PR DESCRIPTION
**Update**: this PR enables writing binary WebSocket frames with an overload for send. It also merges `send` and `send_masked` in favor of a `mask` param which is `false` by default. In addition it adds a send overload which allows it to specify the Opcode and Flags to be used. We will need this in the WebSocket handler to answer to Ping and Close frames. Last but not least this adds `text_stream` and `binary_stream` methods which allow streaming data of unknown length over WebSocket.

> I'll open this now although it's a WIP to get some feedback. Expect travis to fail. This PR is dependent on many of my other PR, so to get a working copy you'd need to check out my development branch https://github.com/jreinert/crystal/tree/development