### PR TITLE
Fixes #1659: Do not try to read response body if request was HEAD

### DIFF
--- a/spec/std/http/client_spec.cr
+++ b/spec/std/http/client_spec.cr
@@ -41,6 +41,20 @@ module HTTP
     typeof(Client.get(URI.parse("http://www.example.com")))
     typeof(Client.get("http://www.example.com"))
 
+    it "doesn't read the body if request was HEAD" do
+      resp_get = TestServer.open("localhost", 8080, 0) do
+        client = Client.new("localhost", 8080)
+        break client.get("/")
+      end
+
+      TestServer.open("localhost", 8080, 0) do
+        client = Client.new("localhost", 8080)
+        resp_head = client.head("/")
+        resp_head.headers.should eq(resp_get.headers)
+        resp_head.body.should eq("")
+      end
+    end
+
     it "raises if URI is missing scheme" do
       expect_raises(ArgumentError) do
         HTTP::Client.get "www.example.com"

--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -83,6 +83,16 @@ module HTTP
       end
     end
 
+    it "parses response ignoring body" do
+      response = Response.from_io(StringIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhelloworld"), true)
+      response.version.should eq("HTTP/1.1")
+      response.status_code.should eq(200)
+      response.status_message.should eq("OK")
+      response.headers["content-type"].should eq("text/plain")
+      response.headers["content-length"].should eq("5")
+      response.body.should eq("")
+    end
+
     it "doesn't sets content length for 1xx, 204 or 304" do
       [100, 101, 204, 304].each do |status|
         response = Response.new(status)

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -285,7 +285,7 @@ class HTTP::Client
     request.headers["User-agent"] ||= "Crystal"
     request.to_io(socket)
     socket.flush
-    HTTP::Response.from_io(socket).tap do |response|
+    HTTP::Response.from_io(socket, request.ignore_body?).tap do |response|
       close unless response.keep_alive?
     end
   end
@@ -303,7 +303,7 @@ class HTTP::Client
     request.headers["User-agent"] ||= "Crystal"
     request.to_io(socket)
     socket.flush
-    HTTP::Response.from_io(socket) do |response|
+    HTTP::Response.from_io(socket, request.ignore_body?) do |response|
       value = yield response
       response.body_io.try &.close
       close unless response.keep_alive?

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -29,6 +29,10 @@ class HTTP::Request
     HTTP.keep_alive?(self)
   end
 
+  def ignore_body?
+    @method == "HEAD"
+  end
+
   def to_io(io)
     io << @method << " " << resource << " " << @version << "\r\n"
     cookies = @cookies


### PR DESCRIPTION
As @waj [suggested](https://github.com/manastech/crystal/issues/1659#issuecomment-144524922), `HTTP::Client` tries to read the response body even when the request was for HEAD. This causes a hang as the server will not send anything. Connection may be closed only on time-out when keepalive is enabled.

Running a simple benchmark on this (from issue #1659):
```crystal
require "benchmark"
require "http"

Benchmark.ips do |x|
  x.report("GET request") { HTTP::Client.get("http://google.com/") }
  x.report("HEAD request") { HTTP::Client.head("http://google.com/") }
end
```

Before:
```
 GET request    5.4  (±25.14%)        fastest
HEAD request      0G (± 0.00%) 324.66× slower
```

After:
```
 GET request   5.21  (±29.21%)  1.02× slower
HEAD request   5.29  (±29.50%)       fastest
```