### PR TITLE
Add type restrictions to methods' arguments in SecureRandom library

### DIFF
--- a/src/secure_random.cr
+++ b/src/secure_random.cr
@@ -2,19 +2,19 @@ require "base64"
 require "openssl/lib_crypto"
 
 module SecureRandom
-  def self.base64(n = 16)
+  def self.base64(n = 16 : Int)
     Base64.strict_encode(random_bytes(n))
   end
 
-  def self.urlsafe_base64(n = 16, padding = false)
+  def self.urlsafe_base64(n = 16 : Int, padding = false)
     Base64.urlsafe_encode(random_bytes(n), padding)
   end
 
-  def self.hex(n = 16)
+  def self.hex(n = 16 : Int)
     random_bytes(n).hexstring
   end
 
-  def self.random_bytes(n = 16)
+  def self.random_bytes(n = 16 : Int)
     if n < 0
       raise ArgumentError.new "negative size: #{n}"
     end


### PR DESCRIPTION
The purpose is to keep error messages neat. Since type error is pretty straightforward in this library, it will be more user-friendly if we keep it only one error message.

For example, if we mistakenly use methods like `SecureRandom.hex("abc")`, the error message is:

```
Error in /Users/user/secure_random.cr:5: instantiating 'SecureRandom:Module#hex(String)'

SecureRandom.hex("abc")
                  ^~~

in ./src/secure_random.cr:14: instantiating 'random_bytes(String)'

    random_bytes(n).hexstring
    ^~~~~~~~~~~~

in ./src/secure_random.cr:18: no overload matches 'String#<' with types Int32
Overloads are:
 - String#<(other : T)

    if n < 0
         ^
```

It traces in the source code until a comparison between `String` and `Int32`. However, as default we don't want users to bring in arguments other than `Int32`. So here I suggest output only the message we need to pay attention to:

```
Error in /Users/user/secure_random.cr:5: instantiating 'SecureRandom:Module#hex(String)'

SecureRandom.hex("abc")
                  ^~~
```

It can be achieved by adding type restrictions. The message will look like this:

```
Error in /Users/user/secure_random.cr:5 : no overload matches 'SecureRandom::hex' with types String
Overloads are:
 - SecureRandom::hex(n = 16 : Int32)

SecureRandom.hex("abc")
                  ^~~
```

It would be more straightforward.