### PR TITLE
[ci skip] Refresh error name in doc

### DIFF
--- a/_gitbook/syntax_and_semantics/exception_handling.md
+++ b/_gitbook/syntax_and_semantics/exception_handling.md
@@ -234,7 +234,7 @@ The standard library usually provides a couple of methods to accomplish somethin
 
 ```crystal
 array = [1, 2, 3]
-array[4]  # raises because of IndexOutOfBounds
+array[4]  # raises because of IndexError
 array[4]? # returns nil because of index out of bounds
 ```
 


### PR DESCRIPTION
Seems it was `IndexOutOfBounds` earlier.