### PR TITLE
Remove Dir::chdir

### DIFF
--- a/spec/compiler/compiler_spec.cr
+++ b/spec/compiler/compiler_spec.cr
@@ -14,7 +14,7 @@ describe "Compiler" do
   end
 
   it "runs subcommand in preference to a filename " do
-    Dir.chdir "#{__DIR__}/data/" do
+    Dir.cd "#{__DIR__}/data/" do
       tempfile = Tempfile.new "compiler_spec_output"
       tempfile.close
 

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -131,10 +131,10 @@ describe "Dir" do
     result.any? { |path| path.ends_with? "io.cr" }.should be_true
   end
 
-  describe "chdir" do
+  describe "cd" do
     it "should work" do
       cwd = Dir.working_directory
-      Dir.chdir("..")
+      Dir.cd("..")
       Dir.working_directory.should_not eq(cwd)
       Dir.cd(cwd)
       Dir.working_directory.should eq(cwd)
@@ -142,14 +142,14 @@ describe "Dir" do
 
     it "raises" do
       expect_raises do
-        Dir.chdir("/nope")
+        Dir.cd("/nope")
       end
     end
 
     it "accepts a block" do
       cwd = Dir.working_directory
 
-      Dir.chdir("..") do
+      Dir.cd("..") do
         Dir.working_directory.should_not eq(cwd)
       end
 

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -143,7 +143,7 @@ class Dir
   end
 
   # Changes the current working directory of the process to the given string.
-  def self.chdir path
+  def self.cd path
     if LibC.chdir(path) != 0
       raise Errno.new("Error while changing directory to #{path.inspect}")
     end
@@ -152,19 +152,14 @@ class Dir
   # Changes the current working directory of the process to the given string
   # and invokes the block, restoring the original working directory
   # when the block exists.
-  def self.chdir(path)
+  def self.cd(path)
     old = working_directory
     begin
-      chdir(path)
+      cd(path)
       yield
     ensure
-      chdir(old)
+      cd(old)
     end
-  end
-
-  # Alias for `chdir`.
-  def self.cd path
-    chdir(path)
   end
 
   # Calls the block once for each entry in the named directory,


### PR DESCRIPTION
`Dir::cd` should be an alias of `Dir::chdir`.  I added missing block version of `Dir::cd`.