### PR TITLE
Change Enum.parse to camelcase from lowercase.

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -6,6 +6,10 @@ enum SpecEnum : Int8
   Three
 end
 
+enum SpecEnum2
+  FourtyTwo
+end
+
 @[Flags]
 enum SpecEnumFlags
   One
@@ -98,6 +102,8 @@ describe Enum do
 
   it "parses" do
     SpecEnum.parse("Two").should eq(SpecEnum::Two)
+    SpecEnum2.parse("FourtyTwo").should eq(SpecEnum2::FourtyTwo)
+    SpecEnum2.parse("fourty_two").should eq(SpecEnum2::FourtyTwo)
     expect_raises(Exception, "Unknown enum SpecEnum value: Four") { SpecEnum.parse("Four") }
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -359,9 +359,9 @@ struct Enum
   # Color.parse?("Yellow") #=> nil
   # ```
   macro def self.parse?(string) : self ?
-    case string.downcase
+    case string.camelcase
     {% for member in @type.constants %}
-      when {{member.stringify.downcase}}
+      when {{member.stringify.camelcase}}
         {{member}}
     {% end %}
     else


### PR DESCRIPTION
The current method is inconsistent.  The style of enum's is generally camel case or upper case with underscores.  Using `downcase` for string parsing leads to sandwiched names and incorrect expectations.