### PR TITLE
Fix typo in sponsors.haml

### DIFF
--- a/sponsors.haml
+++ b/sponsors.haml
@@ -65,7 +65,7 @@ layout: default
 
   %p
     These are the companies and individuals contributing a monthly amount to help sustain Crystal's development. See the
-    %a{href: "https://salt.bountysource.com/teams/crystal-lang", target: "_blank"} Bountysource campaing
+    %a{href: "https://salt.bountysource.com/teams/crystal-lang", target: "_blank"} Bountysource campaign
     for more details.
 
   %img{src: "/images/sponsors/ironin.png"}


### PR DESCRIPTION
Changed `campaing` to `campaign`.