### PR TITLE
[ci skip] small grammar fix in json/mapping.cr

### DIFF
--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -32,7 +32,7 @@
 #
 # `json_mapping` must receive a hash literal whose keys will define Crystal properties.
 #
-# The value of each key can be a single type (not an union type). Primitive types (numbers, string, boolean and nil)
+# The value of each key can be a single type (not a union type). Primitive types (numbers, string, boolean and nil)
 # are supported, as well as custom objects which use `json_mapping` or define a `new` method
 # that accepts a `JSON::PullParser` and returns an object from it.
 #


### PR DESCRIPTION
Was changed to "an union", but "a union" is standard.

See e.g. http://english.stackexchange.com/questions/266309/why-is-union-an-exception-to-the-a-an-rule