### PR TITLE
Add specs for splitting an empty string

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -539,6 +539,7 @@ describe "String" do
 
   describe "split" do
     describe "by char" do
+      assert { "".split(',').should eq([] of String) }
       assert { "foo,bar,,baz,".split(',').should eq(["foo", "bar", "", "baz"]) }
       assert { "foo,bar,,baz".split(',').should eq(["foo", "bar", "", "baz"]) }
       assert { "foo".split(',').should eq(["foo"]) }
@@ -561,6 +562,7 @@ describe "String" do
     end
 
     describe "by string" do
+      assert { "".split(":-").should eq([] of String) }
       assert { "foo:-bar:-:-baz:-".split(":-").should eq(["foo", "bar", "", "baz"]) }
       assert { "foo:-bar:-:-baz".split(":-").should eq(["foo", "bar", "", "baz"]) }
       assert { "foo".split(":-").should eq(["foo"]) }
@@ -573,6 +575,7 @@ describe "String" do
     end
 
     describe "by regex" do
+      assert { "".split(/\n\t/).should eq([] of String) }
       assert { "foo\n\tbar\n\t\n\tbaz".split(/\n\t/).should eq(["foo", "bar", "", "baz"]) }
       assert { "foo\n\tbar\n\t\n\tbaz".split(/(?:\n\t)+/).should eq(["foo", "bar", "baz"]) }
       assert { "foo,bar".split(/,/, 1).should eq(["foo,bar"]) }


### PR DESCRIPTION
I noticed today that Ruby seems to have different string splitting semantics for the edge case of splitting the empty string most other languages. Most languages seem to return a single-element array containing the empty string:

```console
maciek@mothra:~$ psql -qAt <<< "select array_length(regexp_split_to_array('', ','), 1)"
1
maciek@mothra:~$ cat Test.java
public class Test {
    public static void main(String[] args) {
	System.out.println("".split(",").length);
    }
}
maciek@mothra:~$ javac Test.java && java Test
1
maciek@mothra:~$ cat test.go
package main

import (
	"fmt"
	"strings"
)

func main() {
	fmt.Println(len(strings.Split("", ",")))
}
maciek@mothra:~$ go run test.go
1
maciek@mothra:~$ python <<< "print len(''.split(','))"
1
maciek@mothra:~$ ruby <<< "puts ''.split(',').length"
0
maciek@mothra:~$ crystal eval 'p "".split(",").size'
0
```

This is consistent with the "delimiter not found in string" behavior when splitting non-empty strings, but it neglects an important use case when splitting arrays--"parsing" X-delimited lists of things into arrays of those things. When doing this, an empty input string maps much more naturally to an empty array than to a one-element array containing an empty string. Ruby seems to recognize this and returns the former.

@will pointed out that crystal does the same thing, but when I checked the specs, I didn't see this behavior tested there. I'm not sure if crystal is following Ruby intentionally or not here, but I really like this behavior and I would love to see it codified as intentional with specs.