### PR TITLE
time/span: add / and * methods

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -189,6 +189,24 @@ describe Time::Span do
     # TODO check overflow
   end
 
+  it "test multiply" do
+    t1 = Time::Span.new 5, 4, 3, 2, 1
+    t2 = t1 * 61
+
+    t2.should eq(Time::Span.new 315, 7, 5, 2, 61)
+
+    # TODO check overflow
+  end
+
+  it "test divide" do
+    t1 = Time::Span.new 3, 3, 3, 3, 3
+    t2 = t1 / 2
+
+    t2.should eq(Time::Span.new(1, 13, 31, 31, 501) + Time::Span.new(5000))
+
+    # TODO check overflow
+  end
+
   it "test to_s" do
     t1 = Time::Span.new 1, 2, 3, 4, 5
     t2 = -t1

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -214,6 +214,16 @@ struct Time::Span
     self
   end
 
+  def *(number : Number)
+    # TODO check overflow
+    Span.new(ticks * number)
+  end
+
+  def /(number : Number)
+    # TODO check overflow
+    Span.new(ticks / number)
+  end
+
   def <=>(other : self)
     ticks <=> other.ticks
   end


### PR DESCRIPTION
Allows you to multiplay and divide a `Time::Span` by a number.