### PR TITLE
Allow `protected` methods to be called between types in the same namespace

### DIFF
--- a/spec/compiler/type_inference/visibility_modifiers_spec.cr
+++ b/spec/compiler/type_inference/visibility_modifiers_spec.cr
@@ -234,4 +234,87 @@ describe "Visibility modifiers" do
       Foo.new.foo
       )) { int32 }
   end
+
+  it "allows invoking protected method from container to contained" do
+    assert_type(%(
+      class Foo
+        def foo
+          Bar.new.bar
+        end
+
+        class Bar
+          protected def bar
+            1
+          end
+        end
+      end
+
+      Foo.new.foo
+      )) { int32 }
+  end
+
+  it "allows invoking protected method from contained to container" do
+    assert_type(%(
+      class Foo
+        protected def foo
+          1
+        end
+
+        class Bar
+          def bar
+            Foo.new.foo
+          end
+        end
+      end
+
+      Foo::Bar.new.bar
+      )) { int32 }
+  end
+
+  it "allows invoking protected method between types in the same namespace" do
+    assert_type(%(
+      module NS1
+        class NS2
+          class Foo
+            def foo
+              Bar.new.bar
+            end
+          end
+
+          class Bar
+            protected def bar
+              1
+            end
+          end
+        end
+      end
+
+      NS1::NS2::Foo.new.foo
+      )) { int32 }
+  end
+
+  it "allows invoking protected method between types in the same namespace when inheriting" do
+    assert_type(%(
+      module NS1
+        class NS2
+          class Foo
+            def foo
+              Bar.new.bar
+            end
+          end
+
+          class Bar
+            protected def bar
+              1
+            end
+          end
+        end
+      end
+
+      class MyFoo < NS1::NS2::Foo
+      end
+
+      MyFoo.new.foo
+      )) { int32 }
+  end
 end


### PR DESCRIPTION
Check the specs in this PR to understand the behaviour.

The motivation behind this is that it frequently happens that you have a set of types under a single namespace and you need to invoke some methods between them, but you don't want them to be public. I believe in Ruby you either make them public but undocumented, or you use `send`. Neither solution is elegant.

Some concrete examples in the standard library:
1. [Channel](https://github.com/manastech/crystal/blob/90e8ecd173d8febccf6b1c0ab35b8b140d3b429a/src/concurrent/channel.cr) defines [some operations](https://github.com/manastech/crystal/blob/90e8ecd173d8febccf6b1c0ab35b8b140d3b429a/src/concurrent/channel.cr#L112) which have a reference to a channel and need to invoke [some methods](https://github.com/manastech/crystal/blob/90e8ecd173d8febccf6b1c0ab35b8b140d3b429a/src/concurrent/channel.cr#L125). The only way to make that work is to make those methods public but undocumented (ugly), but it makes sense for the internal class to be able to see protected methods of the namespace it's in, and viceversa.
2. [Hash](https://github.com/manastech/crystal/blob/90e8ecd173d8febccf6b1c0ab35b8b140d3b429a/src/hash.cr) has [entries](https://github.com/manastech/crystal/blob/90e8ecd173d8febccf6b1c0ab35b8b140d3b429a/src/hash.cr#L777), and it makes sense for Hash to be able to invoke protected methods on Entry, because it knows Entry.
3. The runtime will have a Scheduler, Fiber and Event types that need some coordination and co-operation. We'll probably put all of those under a `Crystal::Runtime` namespace, and this will allow these types to cooperate by using protected methods.

Another motivation is that when you define a shard, you generally define new types under a single namespace, and it makes sense for these types to know each other and sometimes invoke some methods between them, even though those aren't public.

Basically, `protected` will now mean "protected by a namespace". Classes outside the namespace won't be able to invoke these methods.

An alternative solution would be to introduce a new keyword, but I think just `protected` is enough, instead of having one for "inside the same type hierarchy" and "inside the same namespace".

We'd like some feedback on this, but we think it's a sound change.