### PR TITLE
Support "run" macro from a directory with spaces in it

### DIFF
--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -122,7 +122,7 @@ module Crystal
       compiled_file = @cache[filename] ||= compile(filename)
 
       command = String.build do |str|
-        str << compiled_file
+        str << compiled_file.inspect
         args.each do |arg|
           str << " "
           str << arg.inspect


### PR DESCRIPTION
Actually, I think some `exec` should be used here to avoid dealing with shell syntax