### PR TITLE
Add `crystal help` and `crystal version` subcommand

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -20,8 +20,8 @@ Command:
     run (default)            compile and run program
     spec                     compile and run specs (in spec directory)
     tool                     run a tool
-    --help, -h               show this help
-    --version, -v            show version
+    help, --help, -h         show this help
+    version, --version, -v   show version
 USAGE
 
   COMMANDS_USAGE = <<-USAGE
@@ -78,10 +78,10 @@ USAGE
       when "tool".starts_with?(command)
         options.shift
         tool
-      when "--help" == command, "-h" == command
+      when "help".starts_with?(command), "--help" == command, "-h" == command
         puts USAGE
         exit
-      when "--version" == command, "-v" == command
+      when "version".starts_with?(command), "--version" == command, "-v" == command
         puts "Crystal #{Crystal.version_string}"
         exit
       else


### PR DESCRIPTION
First challenge, `git`:

```console
$ git help
usage: git [--version] [--help] [-C <path>] [-c name=value]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p|--paginate|--no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           <command> [<args>]

The most commonly used git commands are:
   add        Add file contents to the index
   bisect     Find by binary search the change that introduced a bug
   branch     List, create, or delete branches
...
```

Second, `npm`:

```console
$ npm help
Usage: npm <command>

where <command> is one of:
    access, add-user, adduser, apihelp, author, bin, bugs, c,
    cache, completion, config, ddp, dedupe, deprecate, dist-tag,
    dist-tags, docs, edit, explore, faq, find, find-dupes, get,
    help, help-search, home, i, info, init, install, issues, la,
    link, list, ll, ln, login, logout, ls, outdated, owner,
    pack, ping, prefix, prune, publish, r, rb, rebuild, remove,
    repo, restart, rm, root, run-script, s, se, search, set,
    show, shrinkwrap, star, stars, start, stop, t, tag, team,
    test, tst, un, uninstall, unlink, unpublish, unstar, up,
    update, upgrade, v, verison, version, view, whoami

npm <cmd> -h     quick help on <cmd>
...
```

Third, `bundle`:

```console
$ bundle help
(show man help for bundle command)
```

Good!

Last, `crystal`:

```console
$ crystal help
Error: unknown command: help
```

Oh, no! So, I added `crystal help` and `crystal version`.