### PR TITLE
Logger: write messages atomically and drop coroutine

### DIFF
--- a/src/logger.cr
+++ b/src/logger.cr
@@ -53,7 +53,7 @@ class Logger(T)
     UNKNOWN
   end
 
-  alias Formatter = String, Time, String, String, IO ->
+  alias Formatter = String, Time, String, String, String::Builder -> String::Builder
 
   # :nodoc:
   DEFAULT_FORMATTER = Formatter.new do |severity, datetime, progname, message, io|
@@ -61,19 +61,14 @@ class Logger(T)
     io << severity.rjust(5) << " -- " << progname << ": " << message
   end
 
-  # :nodoc:
-  record Message, severity, datetime, progname, message
-
   def initialize(@io : T)
     @level = Severity::INFO
     @formatter = DEFAULT_FORMATTER
     @progname = ""
-    @channel = Channel(Message).new(100)
-    spawn write_messages
   end
 
   def close
-    @channel.close
+    @io.close
   end
 
   {% for name in Severity.constants %}
@@ -92,27 +87,18 @@ class Logger(T)
     end
   {% end %}
 
+  def log(severity, progname = nil)
+    log(severity, yield, progname)
+  end
+
   def log(severity, message, progname = nil)
     return if severity < level
-    enqueue(severity, Time.now, progname || @progname, message)
-  end
 
-  def log(severity, progname = nil)
-    return if severity < level
-    enqueue(severity, Time.now, progname || @progname, yield)
-  end
-
-  private def enqueue(severity, datetime, progname, message)
-    @channel.send Message.new(severity, datetime, progname, message)
-  end
-
-  private def write_messages
-    while msg = @channel.receive?
-      label = msg.severity == Severity::UNKNOWN ? "ANY" : msg.severity.to_s
-      formatter.call(label, msg.datetime, msg.progname.to_s, msg.message.to_s, @io)
-      @io.puts
-      @io.flush
+    @io << String.build do |str|
+      label = severity == Severity::UNKNOWN ? "ANY" : severity.to_s
+      formatter.call(label, Time.now, progname || @progname, message.to_s, str) << "\n"
     end
-    @io.close
+
+    @io.flush
   end
 end


### PR DESCRIPTION
Here is a proposed change for Logger to return back to not using a separate coroutine, which results in lost messages in common cases (fixes #1781) while still trying to prevent mixed garbage but buffering the message to format before eventually writing it with a single write (#1748). The buffer also results in a 60% performance boost over many writes.

I couldn't test that it doesn't generate mixed garbage, because I couldn't reproduce the problem. @kostya @asterite could provide me with a failing example?