### PR TITLE
Add nested-search functionality in documentation

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -36,6 +36,15 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   };
 
+  var childMatch = function(type, regexp){
+    var types = type.querySelectorAll("ul li");
+    for (var j = 0; j < types.length; j ++) {
+      var t = types[j];
+      if(regexp.exec(t.getAttribute('data-name'))){ return true; };
+    };
+    return false;
+  };
+
   var searchTimeout;
   searchInput.addEventListener('keyup', function() {
     clearTimeout(searchTimeout);
@@ -46,17 +55,24 @@ document.addEventListener('DOMContentLoaded', function() {
         return word.length > 0;
       });
       var regexp = new RegExp(words.join('|'));
-      console.debug(words);
 
       for(var i = 0; i < types.length; i++) {
         var type = types[i];
-        if(words.length == 0 || regexp.exec(type.getAttribute('data-name'))) {
+        if(words.length == 0 || regexp.exec(type.getAttribute('data-name')) || childMatch(type, regexp)) {
           type.className = type.className.replace(/ +hide/g, '');
+          var is_parent     =   new RegExp("parent").exec(type.className);
+          var is_not_opened = !(new RegExp("open").exec(type.className));
+          if(childMatch(type,regexp) && is_parent && is_not_opened){
+            type.className += " open";
+          };
         } else {
           if(type.className.indexOf('hide') == -1) {
             type.className += ' hide';
-          }
-        }
+          };
+        };
+        if(words.length == 0){
+          type.className = type.className.replace(/ +open/g, '');
+        };
       }
     }, 200);
   });


### PR DESCRIPTION
The search functionality in the documentation generated with `crystal doc` can only search for the top layer in the list. For example, in [official API doc](http://crystal-lang.org/api/), searching for `typenode` will display no result because the item `Macros` is hidden. It might not be convenient for beginners because they have to know `TypeNode` is in the `Macros` module before they search.

In order to solve this problem, this pull request enhances the search that it allows performing nested-seach and displaying all results and their parents. For example:

![readme_-_github_com_adlerhsieh_crystal](https://cloud.githubusercontent.com/assets/6851886/10602180/5af57f06-7749-11e5-8193-37e7fd6b01e1.png)

I believe this will make documentation more friendly :)