### PR TITLE
Remove tap in Mac Homebrew installation

### DIFF
--- a/_gitbook/installation/on_mac_osx_using_homebrew.md
+++ b/_gitbook/installation/on_mac_osx_using_homebrew.md
@@ -1,9 +1,8 @@
 # On Mac OSX using Homebrew
 
-To easily install Crystall on Mac you can use our [Homebrew](http://brew.sh/) [tap](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md)
+To easily install Crystall on Mac you can use [Homebrew](http://brew.sh/).
 
 ```
-brew tap manastech/crystal
 brew update
 brew install crystal-lang
 ```


### PR DESCRIPTION
`Crystal` is now in official Homebrew repository. `tap` is not required.