### PR TITLE
Add HTTP::Request#body_params

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -257,5 +257,42 @@ module HTTP
         request.query_params.to_s.should eq(new_query)
       end
     end
+
+    describe "#body_params" do
+      it "returns parsed HTTP::Params" do
+        request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+        params = request.body_params
+
+        params["foo"].should eq("bar")
+        params.fetch_all("foo").should eq(["bar", "baz"])
+        params["baz"].should eq("qux")
+      end
+
+      it "fails to parse body with non x-www-form-urlencoded content type" do
+        expect_raises(Exception, "Content-Type should be application/x-www-form-urlencoded to use #body_params") do
+          request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+          request.body_params
+        end
+      end
+
+      it "affects body when modified" do
+        request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+        params = request.body_params
+
+        params["foo"] = "not-bar"
+        request.body.should eq("foo=not-bar&foo=baz&baz=qux")
+      end
+
+      it "updates serialized form when modified" do
+        request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+        params = request.body_params
+
+        params["foo"] = "not-bar"
+
+        io = MemoryIO.new
+        request.to_io(io)
+        io.to_s.should eq("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 27\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=not-bar&foo=baz&baz=qux")
+      end
+    end
   end
 end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -258,6 +258,18 @@ module HTTP
       end
     end
 
+    describe "#has_body_params?" do
+      it "is true when Content-Type is correct" do
+        request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+        request.has_body_params?.should be_true
+      end
+
+      it "is false when Content-Type is incorrect" do
+        request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/json\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!
+        request.has_body_params?.should be_false
+      end
+    end
+
     describe "#body_params" do
       it "returns parsed HTTP::Params" do
         request = Request.from_io(MemoryIO.new("POST /api/v3/some/resource HTTP/1.1\r\nContent-Length: 23\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nfoo=bar&foo=baz&baz=qux")).not_nil!

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -35,6 +35,12 @@ class HTTP::Request
     @body_params ||= parse_body_params
   end
 
+  # Returns true if Content-Type is application/x-www-form-urlencoded.
+  # Otherwise returns false.
+  def has_body_params?
+    headers["Content-Type"]? == BODY_PARAMS_CONTENT_TYPE
+  end
+
   def resource
     update_uri
     @uri.try(&.full_path) || @resource
@@ -102,7 +108,7 @@ class HTTP::Request
   end
 
   private def parse_body_params
-    unless headers["Content-Type"]? == BODY_PARAMS_CONTENT_TYPE
+    unless has_body_params?
       raise "Content-Type should be #{BODY_PARAMS_CONTENT_TYPE} to use #body_params"
     end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -3,9 +3,10 @@ require "uri"
 require "http/params"
 
 class HTTP::Request
+  BODY_PARAMS_CONTENT_TYPE = "application/x-www-form-urlencoded"
+
   getter method
   getter headers
-  getter body
   getter version
 
   def initialize(@method : String, @resource, @headers = Headers.new : Headers, @body = nil, @version = "HTTP/1.1")
@@ -28,6 +29,12 @@ class HTTP::Request
     @query_params ||= parse_query_params
   end
 
+  # Returns a convenience wrapper around querying and setting body url-encoded
+  # params, see `HTTP::Params`.
+  def body_params
+    @body_params ||= parse_body_params
+  end
+
   def resource
     update_uri
     @uri.try(&.full_path) || @resource
@@ -45,7 +52,7 @@ class HTTP::Request
     io << @method << " " << resource << " " << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
-    HTTP.serialize_headers_and_body(io, headers, @body, @version)
+    HTTP.serialize_headers_and_body(io, headers, body, @version)
   end
 
   def self.from_io(io)
@@ -80,12 +87,26 @@ class HTTP::Request
     value
   end
 
+  # Request's body.
+  def body
+    update_body
+    @body
+  end
+
   private def uri
     (@uri ||= URI.parse(@resource)).not_nil!
   end
 
   private def parse_query_params
     HTTP::Params.parse(uri.query || "")
+  end
+
+  private def parse_body_params
+    unless headers["Content-Type"]? == BODY_PARAMS_CONTENT_TYPE
+      raise "Content-Type should be #{BODY_PARAMS_CONTENT_TYPE} to use #body_params"
+    end
+
+    HTTP::Params.parse(body || "")
   end
 
   private def update_query_params
@@ -96,5 +117,10 @@ class HTTP::Request
   private def update_uri
     return unless @query_params
     uri.query = query_params.to_s
+  end
+
+  private def update_body
+    return unless @body_params
+    @body = body_params.to_s
   end
 end


### PR DESCRIPTION
closes #1392 

This is a final piece to make it easier to have basic workflows while writing HTTP server handlers.

This PR adds `#body_params` method for request object, which lazily parses body and returns corresponding `HTTP::Params` object.

This enables one to simply accept URL-encoded HTML forms as a body of POST (or PUT, etc.) requests and work with it through a simple interface that `HTTP::Params` currently provides.

This implementation requires `Content-Type` header to be correct (`== "application/x-www-form-urlencoded"`), otherwise it raises descriptive error, when `#body_params` is called. So typical usage will be:

```crystal
def call(request)
  return bad_request unless request.has_body_params?
  # .. use request.body_params ..
end
```

I am currently on the fence about this solution. Maybe someone can come up with something more elegant.

About mutation: it is totally fine to mutate `request.body_params` and it will be reflected on its `#body` and when serialized to `io`.

/cc @waj @asterite @jhass 