### PR TITLE
Reseed PRNG after fork

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -143,7 +143,8 @@ class Process
   @@after_fork_child_callbacks = [
     -> { Scheduler.after_fork; nil },
     -> { Event::SignalHandler.after_fork; nil },
-    -> { Event::SignalChildHandler.instance.after_fork; nil }
+    -> { Event::SignalChildHandler.instance.after_fork; nil },
+    -> { Random::DEFAULT.new_seed; nil },
   ]
 end
 

--- a/src/random/isaac.cr
+++ b/src/random/isaac.cr
@@ -16,6 +16,11 @@ class Random::ISAAC
     init_by_array(seeds)
   end
 
+  def new_seed(seeds = StaticArray(UInt32, 8).new { Random.new_seed })
+    @aa = @bb = @cc = 0_u32
+    init_by_array(seeds)
+  end
+
   def next_u32
     if (@counter -= 1) == -1
       isaac

--- a/src/random/mt19937.cr
+++ b/src/random/mt19937.cr
@@ -59,6 +59,11 @@ class Random::MT19937
     init_by_array(seeds)
   end
 
+  def new_seed(seeds = StaticArray(UInt32, 4).new { Random.new_seed })
+    @mti = N + 1
+    init_by_array(seeds)
+  end
+
   def self.new(seed : Int)
     seeds = UInt32[1]
     seeds[0] = seed.to_u32


### PR DESCRIPTION
The default PRNG must be reseed after each fork, otherwise the both the parent and the child processes will generate the same random sequence. This is very apparent when forking many child processes at the same time, where all children follow the same sequence.