### PR TITLE
Fix broken link 

### DIFF
--- a/_gitbook/syntax_and_semantics/c_bindings/alias.md
+++ b/_gitbook/syntax_and_semantics/c_bindings/alias.md
@@ -34,4 +34,4 @@ lib C
 end
 ```
 
-Refer to the [type grammar](type_grammar.html) for the notation used in alias types.
+Refer to the [type grammar](../type_grammar.html) for the notation used in alias types.


### PR DESCRIPTION
The broken link is at the bottom of [this page](http://crystal-lang.org/docs/syntax_and_semantics/c_bindings/alias.html).