### PR TITLE
Improvement `Range#sum` performance

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -1,4 +1,30 @@
 require "spec"
+require "big_int"
+
+struct RangeSpecIntWrapper
+  include Comparable(self)
+
+  getter value
+
+  def initialize(@value)
+  end
+
+  def succ
+    RangeSpecIntWrapper.new(@value + 1)
+  end
+
+  def <=>(other)
+    value <=> other.value
+  end
+
+  def self.zero
+    RangeSpecIntWrapper.new(0)
+  end
+
+  def +(other : RangeSpecIntWrapper)
+    RangeSpecIntWrapper.new(value + other.value)
+  end
+end
 
 describe "Range" do
   it "initialized with new method" do
@@ -50,6 +76,26 @@ describe "Range" do
 
   it "is not empty with ... and begin.succ == end" do
     (1...2).to_a.should eq([1])
+  end
+
+  describe "sum" do
+    it "called with no block is specialized for performance" do
+      (1..3).sum.should eq 6
+      (1...3).sum.should eq 3
+      (BigInt.new("1")..BigInt.new("1 000 000 000")).sum.should eq BigInt.new("500 000 000 500 000 000")
+      (1..3).sum(4).should eq 10
+      (3..1).sum(4).should eq 4
+      (1..11).step(2).sum.should eq 36
+      (1...11).step(2).sum.should eq 25
+      (BigInt.new("1")..BigInt.new("1 000 000 000")).step(2).sum.should eq BigInt.new("250 000 000 000 000 000")
+    end
+
+    it "is equivalent to Enumerable#sum" do
+      (1..3).sum{ |x| x * 2 }.should eq 12
+      (1..3).step(2).sum{ |x| x * 2 }.should eq 8
+      (RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(3)).sum.should eq RangeSpecIntWrapper.new(6)
+      (RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(3)).step(2).sum.should eq RangeSpecIntWrapper.new(4)
+    end
   end
 
   describe "each" do

--- a/src/range.cr
+++ b/src/range.cr
@@ -242,6 +242,25 @@ struct Range(B, E)
     to_s(io)
   end
 
+  # If self is a `Int` range, it provides O(1) implementation,
+  # otherwise it is same as `Enumerable#sum`.
+  def sum(initial)
+    b = self.begin
+    e = self.end
+
+    if b.is_a?(Int) && e.is_a?(Int)
+      e -= 1 if @exclusive
+      n = e - b + 1
+      if n >= 0
+        initial + n * (b + e) / 2
+      else
+        initial
+      end
+    else
+      super
+    end
+  end
+
   # :nodoc:
   class ItemIterator(B, E)
     include Iterator(B)
@@ -303,6 +322,27 @@ struct Range(B, E)
       @current = @range.begin
       @reached_end = false
       self
+    end
+
+    def sum(initial)
+      super if @reached_end
+
+      b = @current
+      e = @range.end
+      d = @step
+
+      if b.is_a?(Int) && e.is_a?(Int) && d.is_a?(Int)
+        e -= 1 if @range.excludes_end?
+        n = (e - b) / d + 1
+        if n >= 0
+          e = b + (n - 1) * d
+          initial + n * (b + e) / 2
+        else
+          initial
+        end
+      else
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
We can calculate the sum of `Range(Int)` by O(1) algorithm.
(This is the so-called finite arithmetic series.)

This implementation is a little dirty. However, this hack is indeed
only available on Int range, and this feature is hoped by many people
(See below URLs).

Warning: It has a tiny breaking change. If you want to calculate the sum
of a range that contains too small size Int to sum it up such like
`1..10_000_000.sum`, then its sum cause an integer overflow, and
probably its result is difference between the change.
But I think this change is no problem because such code is already buggy.

Reference URLs:

  - ActiveSupport's Range#sum:
    http://www.rubydoc.info/docs/rails/3.1.1/Range#sum-instance_method

  - Scale's Range#sum:
    http://www.scala-lang.org/news/2.10.4
    Above link says "Range#sum is now O(1)"