### PR TITLE
minor improvements to `IO::ByteFormat` and `Slice`

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -113,6 +113,18 @@ describe "Slice" do
     iter.next.should eq(1)
   end
 
+  it "does reverse iterator" do
+    slice = Slice(Int32).new(3) { |i| i + 1 }
+    iter = slice.each_reverse
+    iter.next.should eq(3)
+    iter.next.should eq(2)
+    iter.next.should eq(1)
+    iter.next.should be_a(Iterator::Stop)
+
+    iter.rewind
+    iter.next.should eq(3)
+  end
+
   it "does to_a" do
     slice = Slice.new(3) { |i| i }
     ary = slice.to_a

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -48,7 +48,7 @@ module IO::ByteFormat
           buffer :: UInt8[{{2 ** (i / 2)}}]
           io.read_fully(buffer.to_slice)
           buffer.reverse! unless SystemEndian == self
-          (buffer.to_slice.to_unsafe as Pointer({{type.id}})).value
+          (buffer.to_unsafe as Pointer({{type.id}})).value
         end
       {% end %}
     end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -174,14 +174,30 @@ struct Slice(T)
     @size == 0
   end
 
-  def each
+  # Pass each element of slice to block.
+  def each(&block)
     size.times do |i|
       yield @pointer[i]
     end
+
+    self
   end
 
   def each
     ItemIterator(T).new(self)
+  end
+
+  # Same as `#each`, but works in reverse.
+  def each_reverse(&block)
+    (size-1).downto(0) do |i|
+      yield @pointer[i]
+    end
+
+    self
+  end
+
+  def each_reverse
+    ReverseIterator(T).new(self)
   end
 
   def pointer(size)
@@ -282,13 +298,30 @@ struct Slice(T)
     end
 
     def next
-      value = @slice.at(@index) { stop }
+      return stop if @index >= @slice.size
       @index += 1
-      value
+      @slice.at(@index - 1)
     end
 
     def rewind
       @index = 0
+      self
+    end
+  end
+
+  class ReverseIterator(T)
+    include Iterator(T)
+
+    def initialize(@slice : ::Slice(T), @index = slice.size)
+    end
+
+    def next
+      return stop if @index <= 0
+      @slice.at(@index -= 1)
+    end
+
+    def rewind
+      @index = @slice.size
       self
     end
   end


### PR DESCRIPTION
 - Adds `Slice#each_reverse`
 - Modifies `Slice#each(&block)` to return `self` (like Ruby)
 - Adds `Slice(T)::ItemIterator(T)#prev`
 - Modifies `Slice(T)::ItemIterator(T)#next` (`@index` would needlessly
   increment once past the highest possible index). Also made it easier to
   read.
 - Modified `IO::ByteFormat.encode` to remove unnecessary `reverse!` method call
 - Modified `IO::ByteFormat.decode` to remove unnecessary `to_slice` method call

Also added some doc/comments and changed method defs to (more obviously) reflect to
the reader that they accept a block.