### PR TITLE
Fix: File.basename("/") gets negative count (ArgumentError)

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -122,6 +122,7 @@ describe "File" do
     File.basename("/foo/").should eq("foo")
     File.basename("foo").should eq("foo")
     File.basename("").should eq("")
+    File.basename("/").should eq("/")
   end
 
   it "gets basename removing suffix" do

--- a/src/file.cr
+++ b/src/file.cr
@@ -233,6 +233,7 @@ class File < IO::FileDescriptor
 
   def self.basename(filename)
     return "" if filename.bytesize == 0
+    return SEPARATOR_STRING if filename == SEPARATOR_STRING
 
     last = filename.size - 1
     last -= 1 if filename[last] == SEPARATOR


### PR DESCRIPTION
File.basename("/") should return empty string instead of raise ArgumentError.

in Ruby,it returns "/",but I think empty string should make sense since "/" is actually not a file name.