### PR TITLE
Fix: Process still used Dir.chdir

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -80,6 +80,14 @@ describe Process do
     $?.exit_code.should eq(0)
   end
 
+  it "sets working directory" do
+    parent = File.dirname(Dir.working_directory)
+    value = Process.run("pwd", shell: true, chdir: parent, output: nil) do |proc|
+      proc.output.gets_to_end
+    end
+    value.should eq "#{parent}\n"
+  end
+
   it "disallows passing arguments to nowhere" do
     expect_raises ArgumentError, /args.+@/ do
       Process.run("foo bar", {"baz"}, shell: true)

--- a/src/process/run.cr
+++ b/src/process/run.cr
@@ -127,7 +127,7 @@ class Process
           end
         end
 
-        Dir.chdir(chdir) if chdir
+        Dir.cd(chdir) if chdir
 
         LibC.execvp(command, argv)
       rescue ex


### PR DESCRIPTION
Process.new and Process.run take a `chdir` argument but didn't have a spec to assert it.