### PR TITLE
Base 62 support

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -93,6 +93,15 @@ describe "Int" do
     assert { 0.to_s(16).should eq("0") }
     assert { 1.to_s(2).should eq("1") }
     assert { 1.to_s(16).should eq("1") }
+    assert { 0.to_s(62).should eq("0") }
+    assert { 1.to_s(62).should eq("1") }
+    assert { 10.to_s(62).should eq("a") }
+    assert { 35.to_s(62).should eq("z") }
+    assert { 36.to_s(62).should eq("A") }
+    assert { 61.to_s(62).should eq("Z") }
+    assert { 62.to_s(62).should eq("10") }
+    assert { 97.to_s(62).should eq("1z") }
+    assert { 3843.to_s(62).should eq("ZZ") }
 
     it "raises on base 1" do
       expect_raises { 123.to_s(1) }
@@ -100,6 +109,10 @@ describe "Int" do
 
     it "raises on base 37" do
       expect_raises { 123.to_s(37) }
+    end
+
+    it "raises on base 62 with upcase" do
+      expect_raises { 123.to_s(62, upcase: true) }
     end
 
     assert { to_s_with_io(12, 2).should eq("1100") }
@@ -117,6 +130,15 @@ describe "Int" do
     assert { to_s_with_io(0, 16).should eq("0") }
     assert { to_s_with_io(1, 2).should eq("1") }
     assert { to_s_with_io(1, 16).should eq("1") }
+    assert { to_s_with_io(0, 62).should eq("0") }
+    assert { to_s_with_io(1, 62).should eq("1") }
+    assert { to_s_with_io(10, 62).should eq("a") }
+    assert { to_s_with_io(35, 62).should eq("z") }
+    assert { to_s_with_io(36, 62).should eq("A") }
+    assert { to_s_with_io(61, 62).should eq("Z") }
+    assert { to_s_with_io(62, 62).should eq("10") }
+    assert { to_s_with_io(97, 62).should eq("1z") }
+    assert { to_s_with_io(3843, 62).should eq("ZZ") }
 
     it "raises on base 1 with io" do
       expect_raises { to_s_with_io(123, 1) }
@@ -124,6 +146,10 @@ describe "Int" do
 
     it "raises on base 37 with io" do
       expect_raises { to_s_with_io(123, 37) }
+    end
+
+    it "raises on base 62 with upcase with io" do
+      expect_raises { to_s_with_io(12, 62, upcase: true) }
     end
   end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -203,6 +203,17 @@ describe "String" do
     assert { expect_raises(ArgumentError) { "000b123".to_i(prefix: true) } }
     assert { expect_raises(ArgumentError) { "000x123".to_i(prefix: true) } }
     assert { expect_raises(ArgumentError) { "123hello".to_i } }
+    assert { "z".to_i(36).should eq(35) }
+    assert { "Z".to_i(36).should eq(35) }
+    assert { "0".to_i(62).should eq(0) }
+    assert { "1".to_i(62).should eq(1) }
+    assert { "a".to_i(62).should eq(10) }
+    assert { "z".to_i(62).should eq(35) }
+    assert { "A".to_i(62).should eq(36) }
+    assert { "Z".to_i(62).should eq(61) }
+    assert { "10".to_i(62).should eq(62) }
+    assert { "1z".to_i(62).should eq(97) }
+    assert { "ZZ".to_i(62).should eq(3843) }
 
     describe "to_i8" do
       assert { "127".to_i8.should eq(127) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -279,6 +279,8 @@ struct Int
   DIGITS_DOWNCASE = "0123456789abcdefghijklmnopqrstuvwxyz"
   # :nodoc:
   DIGITS_UPCASE = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  # :nodoc:
+  DIGITS_BASE62 = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
   def to_s
     to_s(10)
@@ -289,7 +291,8 @@ struct Int
   end
 
   def to_s(base : Int, upcase = false : Bool)
-    raise "Invalid base #{base}" unless 2 <= base <= 36
+    raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
+    raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
     case self
     when 0
@@ -304,7 +307,8 @@ struct Int
   end
 
   def to_s(base : Int, io : IO, upcase = false : Bool)
-    raise "Invalid base #{base}" unless 2 <= base <= 36
+    raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
+    raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
     case self
     when 0
@@ -328,7 +332,7 @@ struct Int
 
     neg = num < 0
 
-    digits = (upcase ? DIGITS_UPCASE : DIGITS_DOWNCASE).to_unsafe
+    digits = (base == 62 ? DIGITS_BASE62 : (upcase ? DIGITS_UPCASE : DIGITS_DOWNCASE)).to_unsafe
 
     while num != 0
       ptr -= 1

--- a/src/string.cr
+++ b/src/string.cr
@@ -428,6 +428,15 @@ class String
   end
 
   # :nodoc:
+  CHAR_TO_DIGIT62 = begin
+    table = CHAR_TO_DIGIT.clone
+    26_i8.times do |i|
+      table.to_unsafe[65 + i] = i + 36
+    end
+    table
+  end
+
+  # :nodoc:
   record ToU64Info, value, negative, invalid
 
   # :nodoc
@@ -451,7 +460,7 @@ class String
   end
 
   private def to_u64_info(base, whitespace, underscore, prefix, strict)
-    raise ArgumentError.new "invalid base #{base}" unless 2 <= base <= 36
+    raise ArgumentError.new("invalid base #{base}") unless 2 <= base <= 36 || base == 62
 
     ptr = cstr
 
@@ -500,7 +509,7 @@ class String
     last_is_underscore = true
     invalid = false
 
-    digits = CHAR_TO_DIGIT.to_unsafe
+    digits = (base == 62 ? CHAR_TO_DIGIT62 : CHAR_TO_DIGIT).to_unsafe
     while ptr.value != 0
       if ptr.value.chr == '_' && underscore
         break if last_is_underscore


### PR DESCRIPTION
This adds base 62 support to `String#to_i` and `Int#to_s`. Base 62 uses the alphabet of `0-9a-zA-Z`

Base 62 is base 36 on steroids. It's extremely useful to turn numerical IDs into short and memorable identifiers. There are no "weird" characters and no non-ASCII characters used. Base 36 achieves a maximum value of `46655` with three characters (`zzz`), base 62 achieves a maximum value of `238327` with the same amount (`ZZZ`), that's over five times more. For four characters almost nine times more.

Real world applications that can benefit from this are URL shorteners, paste services, IDs in URL slugs and the like, everything where for example short URLs are relevant.