### PR TITLE
Make `JSON.parse` return `JSON::Any`, and make it easy to traverse a dynamic JSON structure. Fixes #1832

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -1,0 +1,92 @@
+require "spec"
+require "json"
+
+describe JSON::Any do
+  describe "casts" do
+    it "gets nil" do
+      JSON.parse("null").as_nil.should be_nil
+    end
+
+    it "gets bool" do
+      JSON.parse("true").as_bool.should be_true
+      JSON.parse("false").as_bool.should be_false
+    end
+
+    it "gets int" do
+      JSON.parse("123").as_i.should eq(123)
+      JSON.parse("123456789123456").as_i64.should eq(123456789123456)
+    end
+
+    it "gets float" do
+      JSON.parse("123.45").as_f.should eq(123.45)
+      JSON.parse("123.45").as_f32.should eq(123.45_f32)
+    end
+
+    it "gets string" do
+      JSON.parse(%("hello")).as_s.should eq("hello")
+    end
+
+    it "gets array" do
+      JSON.parse(%([1, 2, 3])).as_a.should eq([1, 2, 3])
+    end
+
+    it "gets hash" do
+      JSON.parse(%({"foo": "bar"})).as_h.should eq({"foo": "bar"})
+    end
+  end
+
+  describe "#size" do
+    it "of array" do
+      JSON.parse("[1, 2, 3]").size.should eq(3)
+    end
+
+    it "of hash" do
+      JSON.parse(%({"foo": "bar"})).size.should eq(1)
+    end
+  end
+
+  describe "#[]" do
+    it "of array" do
+      JSON.parse("[1, 2, 3]")[1].raw.should eq(2)
+    end
+
+    it "of hash" do
+      JSON.parse(%({"foo": "bar"}))["foo"].raw.should eq("bar")
+    end
+  end
+
+  describe "#[]?" do
+    it "of array" do
+      JSON.parse("[1, 2, 3]")[1]?.not_nil!.raw.should eq(2)
+      JSON.parse("[1, 2, 3]")[3]?.should be_nil
+    end
+
+    it "of hash" do
+      JSON.parse(%({"foo": "bar"}))["foo"]?.not_nil!.raw.should eq("bar")
+      JSON.parse(%({"foo": "bar"}))["fox"]?.should be_nil
+    end
+  end
+
+  describe "each" do
+    it "of array" do
+      elems = [] of Int32
+      JSON.parse("[1, 2, 3]").each do |any|
+        elems << any.as_i
+      end
+      elems.should eq([1, 2, 3])
+    end
+
+    it "of hash" do
+      elems = [] of String
+      JSON.parse(%({"foo": "bar"})).each do |key, value|
+        elems << key.to_s << value.to_s
+      end
+      elems.should eq(%w(foo bar))
+    end
+  end
+
+  it "traverses big structure" do
+    obj = JSON.parse(%({"foo": [1, {"bar": [2, 3]}]}))
+    obj["foo"][1]["bar"][1].as_i.should eq(3)
+  end
+end

--- a/spec/std/json/lexer_spec.cr
+++ b/spec/std/json/lexer_spec.cr
@@ -63,7 +63,7 @@ private def it_lexes_float(string, float_value, file = __FILE__, line = __LINE__
   end
 end
 
-describe "JSON::Lexer" do
+describe JSON::Lexer do
   it_lexes "", :EOF
   it_lexes "{", :"{"
   it_lexes "}", :"}"

--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -176,7 +176,7 @@ describe "JSON mapping" do
   it "parses json with any" do
     json = JSONWithAny.from_json(%({"name": "Hi", "any": [{"x": 1}, 2, "hey", true, false, 1.5, null]}))
     json.name.should eq("Hi")
-    json.any.should eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
+    json.any.raw.should eq([{"x": 1}, 2, "hey", true, false, 1.5, nil])
     json.to_json.should eq(%({"name":"Hi","any":[{"x":1},2,"hey",true,false,1.5,null]}))
   end
 

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -3,7 +3,7 @@ require "json"
 
 private def it_parses(string, expected_value, file = __FILE__, line = __LINE__)
   it "parses #{string}", file, line do
-    JSON.parse(string).should eq(expected_value)
+    JSON.parse(string).raw.should eq(expected_value)
   end
 end
 
@@ -15,7 +15,7 @@ private def it_raises_on_parse(string, file = __FILE__, line = __LINE__)
   end
 end
 
-describe "JSON::Parser" do
+describe JSON::Parser do
   it_parses "1", 1
   it_parses "2.5", 2.5
   it_parses %("hello"), "hello"

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -95,7 +95,7 @@ end
 private def assert_pull_parse(string)
   it "parses #{string}" do
     parser = JSON::PullParser.new string
-    parser.assert JSON.parse(string)
+    parser.assert JSON.parse(string).raw
     parser.kind.should eq(:EOF)
   end
 end
@@ -111,7 +111,7 @@ private def assert_pull_parse_error(string)
   end
 end
 
-describe "JSON::PullParser" do
+describe JSON::PullParser do
   assert_pull_parse "null"
   assert_pull_parse "false"
   assert_pull_parse "true"

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -1,34 +1,205 @@
-# You can use `JSON::Any` inside a `JSON#mapping` to make a property be parsed
-# to a `JSON::Type`. This is useful if you have properties with dynamic content
-# that must later be inspected at runtime.
-module JSON::Any
-  # Reads a `JSON::Type` value from the given pull parser.
+# `JSON::Any` is a convenient wrapper around all possible JSON types (`JSON::Type`)
+# and can be used for traversing dynamic or unknown JSON structures.
+#
+# ```
+# obj = JSON.parse(%({"access": [{"name": "mapping", "speed": "fast"}, {"name": "any", "speed": "slow"}]}))
+# obj["access"][1]["name"].as_s  # => "any"
+# obj["access"][1]["speed"].as_s # => "slow"
+# ```
+#
+# Note that methods used to traverse a JSON structure, `#[]`, `#[]?` and `#each`,
+# always return a `JSON::Any` to allow further traversal. To convert them to `String`,
+# `Int32`, etc., use the "as_" methods, such as `#as_s`, `#as_i`, which perform
+# a type check against the raw underlying value. This means that invoking `#as_s`
+# when the underlying value is not a String will raise: the value won't automatically
+# be converted (parsed) to a String.
+struct JSON::Any
+  # Reads a `JSON::Any` value from the given pull parser.
   def self.new(pull : JSON::PullParser)
     case pull.kind
     when :null
-      pull.read_null
+      new pull.read_null
     when :bool
-      pull.read_bool
+      new pull.read_bool
     when :int
-      pull.read_int
+      new pull.read_int
     when :float
-      pull.read_float
+      new pull.read_float
     when :string
-      pull.read_string
+      new pull.read_string
     when :begin_array
       ary = [] of JSON::Type
       pull.read_array do
-        ary << new pull
+        ary << new(pull).raw
       end
-      ary
+      new ary
     when :begin_object
       hash = {} of String => JSON::Type
       pull.read_object do |key|
-        hash[key] = new pull
+        hash[key] = new(pull).raw
       end
-      hash
+      new hash
     else
       raise "Unknown pull kind: #{pull.kind}"
     end
+  end
+
+  # Returns the raw underlying value, a `JSON::Type`.
+  getter raw
+
+  # Creates a `JSON::Any` that wraps the given `JSON::Type`.
+  def initialize(@raw : JSON::Type)
+  end
+
+  # Assumes the underlying value is an `Array` or `Hash` and returns
+  # its size.
+  # Raises if the underlying value is not an `Array` or `Hash`.
+  def size : Int
+    case object = @raw
+    when Array
+      object.size
+    when Hash
+      object.size
+    else
+      raise "expected Array or Hash for #size, not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an Array and returns the element
+  # at the given index.
+  # Raises if the underlying value is not an Array.
+  def [](index : Int) : JSON::Any
+    case object = @raw
+    when Array
+      Any.new object[index]
+    else
+      raise "expected Array for #[](index : Int), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an Array and returns the element
+  # at the given index, or nil if out of bounds.
+  # Raises if the underlying value is not an Array.
+  def []?(index : Int) : JSON::Any?
+    case object = @raw
+    when Array
+      value = object[index]?
+      value ? Any.new(value) : nil
+    else
+      raise "expected Array for #[]?(index : Int), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is a Hash and returns the element
+  # with the given key.
+  # Raises if the underlying value is not a Hash.
+  def [](key : String) : JSON::Any
+    case object = @raw
+    when Hash
+      Any.new object[key]
+    else
+      raise "expected Hash for #[](key : String), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is a Hash and returns the element
+  # with the given key, or nil if the key is not present.
+  # Raises if the underlying value is not a Hash.
+  def []?(key : String) : JSON::Any?
+    case object = @raw
+    when Hash
+      value = object[key]?
+      value ? Any.new(value) : nil
+    else
+      raise "expected Hash for #[]?(key : String), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an `Array` or `Hash` and yields each
+  # of the elements or key/values, always as `JSON::Any`.
+  # Raises if the underlying value is not an `Array` or `Hash`.
+  def each
+    case object = @raw
+    when Array
+      object.each do |elem|
+        yield Any.new(elem), Any.new(nil)
+      end
+    when Hash
+      object.each do |key, value|
+        yield Any.new(key), Any.new(value)
+      end
+    else
+      raise "expected Array or Hash for #each, not #{object.class}"
+    end
+  end
+
+  # Checks that the underlying value is `Nil`, and returns `nil`. Raises otherwise.
+  def as_nil : Nil
+    @raw as Nil
+  end
+
+  # Checks that the underlying value is `Bool`, and returns its value. Raises otherwise.
+  def as_bool : Bool
+    @raw as Bool
+  end
+
+  # Checks that the underlying value is `Int`, and returns its value as an `Int32`. Raises otherwise.
+  def as_i : Int32
+    (@raw as Int).to_i
+  end
+
+  # Checks that the underlying value is `Int`, and returns its value as an `Int64`. Raises otherwise.
+  def as_i64 : Int64
+    (@raw as Int).to_i64
+  end
+
+  # Checks that the underlying value is `Float`, and returns its value as an `Float64`. Raises otherwise.
+  def as_f : Float64
+    (@raw as Float).to_f
+  end
+
+  # Checks that the underlying value is `Float`, and returns its value as an `Float32`. Raises otherwise.
+  def as_f32 : Float32
+    (@raw as Float).to_f32
+  end
+
+  # Checks that the underlying value is `String`, and returns its value. Raises otherwise.
+  def as_s : String
+    @raw as String
+  end
+
+  # Checks that the underlying value is `Array`, and returns its value. Raises otherwise.
+  def as_a : Array(Type)
+    @raw as Array
+  end
+
+  # Checks that the underlying value is `Hash`, and returns its value. Raises otherwise.
+  def as_h : Hash(String, Type)
+    @raw as Hash
+  end
+
+  # :nodoc:
+  def inspect(io)
+    @raw.inspect(io)
+  end
+
+  # :nodoc:
+  def to_s(io)
+    @raw.to_s(io)
+  end
+
+  # :nodoc:
+  def ==(other : JSON::Any)
+    raw == other.raw
+  end
+
+  # :nodoc:
+  def hash
+    raw.hash
+  end
+
+  # :nodoc:
+  def to_json(io)
+    raw.to_json(io)
   end
 end

--- a/src/json/json.cr
+++ b/src/json/json.cr
@@ -8,20 +8,25 @@
 #
 # ### Parsing with `JSON#parse`
 #
-# `JSON#parse` will return a `Type`, which is a union of all possible JSON types,
-# making it mandatory to use casts or type checks to deal with parsed values:
+# `JSON#parse` will return an `Any`, which is a convenient wrapper around all possible JSON types,
+# making it easy to traverse a complex JSON structure but requires some casts from time time,
+# mostly via some method invocations.
 #
 # ```
 # require "json"
 #
-# value = JSON.parse("[1, 2, 3]") # :: JSON::Type
-# # value[0] # compile-error, compiler can't know that value is indeed an Array
-# array = value as Array
-# array[0]               # :: JSON::Type
-# (array[0] as Int) + 10 # => 11
+# value = JSON.parse("[1, 2, 3]") # :: JSON::Any
+#
+# value[0]              # => 1
+# typeof(value[0])      # => JSON::Any
+# value[0].as_i         # => 1
+# typeof(value[0].as_i) # => Int32
+#
+# value[0] + 1       # Error, because value[0] is JSON::Any
+# value[0].as_i + 10 # => 11
 # ```
 #
-# The above becomes tedious quickly, but can be useful for handling dynamic JSON content.
+# The above is useful for dealing with a dynamic JSON structure but is slower than using `JSON#mapping`.
 #
 # ### Generating with `JSON::Builder`
 #
@@ -48,8 +53,8 @@ module JSON
   alias Type = Nil | Bool | Int64 | Float64 | String | Array(Type) | Hash(String, Type)
 
   # Parses a JSON document.
-  def self.parse(input : String | IO) : Type
-    Parser.new(input).parse
+  def self.parse(input : String | IO) : Any
+    Any.new Parser.new(input).parse
   end
 end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -35,7 +35,7 @@ module JSON
   # that accepts a `JSON::PullParser` and returns an object from it.
   #
   # The value can also be another hash literal with the following options:
-  # * type: (required) the single type described above
+  # * type: (required) the single type described above (you can use `JSON::Any` too)
   # * key: the property name in the JSON document (as opposed to the property name in the Crystal code)
   # * nilable: if true, the property can be `Nil`
   # * emit_null: if true, emits a `null` value for nilable properties (by default nulls are not emitted)


### PR DESCRIPTION
This is the implementation for #1832

I decided to name the "cast" methods `as_i`, `as_s`, etc., to avoid confusion: if you do `to_s` on a value that isn't necessarily a String, will the value be converted to a String? Or if you do `to_i` and the underlying value is a String that can be parsed as an int, will it work? Because `as_...` is not related to `to_...` methods, which usually perform conversion/parsing, the distinction is a bit more clear.