### PR TITLE
Ensure `crystal deps` fails with a non-zero exit code if `shards` does

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -399,7 +399,8 @@ USAGE
       error "`shards` executable is missing. Please install shards: https://github.com/ysbaddaden/shards"
     end
 
-    Process.run(path_to_shards, args: options, output: true, error: true)
+    status = Process.run(path_to_shards, args: options, output: true, error: true)
+    exit status.exit_code unless status.success?
   end
 
   private def docs


### PR DESCRIPTION
Noticed that if `shards` fails for whatever reason, it will exit with a non-zero status code. But `crystal deps` wrapping the same command will swallow it and return 0.

No tests for this PR, but I didn't see any covering the shards integration at all, so ¯\\\_(ツ)\_/¯.

WDYT?