### PR TITLE
Lexer: handle unterminated char literal

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -221,6 +221,8 @@ describe "Lexer" do
   it_lexes_char "'\\10'", 8.chr
   it_lexes_char "'\\110'", 72.chr
   it_lexes_char "'\\8'", '8'
+  assert_syntax_error "'", "unterminated char literal"
+  assert_syntax_error "'\\", "unterminated char literal"
   it_lexes_operators [:"=", :"<", :"<=", :">", :">=", :"+", :"-", :"*", :"(", :")",
     :"==", :"!=", :"=~", :"!", :",", :".", :"..", :"...", :"&&", :"||",
     :"|", :"{", :"}", :"?", :":", :"+=", :"-=", :"*=", :"/=", :"%=", :"&=",

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -527,9 +527,13 @@ module Crystal
           when '0', '1', '2', '3', '4', '5', '6', '7'
             char_value = consume_octal_escape(char2)
             @token.value = char_value.chr
+          when '\0'
+            raise "unterminated char literal", line, column
           else
             @token.value = char2
           end
+        when '\0'
+          raise "unterminated char literal", line, column
         else
           @token.value = char1
         end


### PR DESCRIPTION
Repro:
```
$ crystal eval "'"
$ crystal eval "'\\"
