### PR TITLE
Added a block argument to at_exit

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -82,16 +82,16 @@ module AtExitHandlers
   @@handlers = nil
 
   def self.add(handler)
-    handlers = @@handlers ||= [] of ->
+    handlers = @@handlers ||= [] of Int32 ->
     handlers << handler
   end
 
-  def self.run
+  def self.run(status)
     return if @@running
     @@running = true
 
     begin
-      @@handlers.try &.reverse_each &.call
+      @@handlers.try &.reverse_each &.call status
     rescue handler_ex
       puts "Error running at_exit handler: #{handler_ex}"
     end
@@ -116,7 +116,7 @@ end
 # ```text
 # goodbye cruel world
 # ```
-def at_exit(&handler)
+def at_exit(&handler : Int32 ->)
   AtExitHandlers.add(handler)
 end
 
@@ -125,7 +125,7 @@ end
 #
 # Registered `at_exit` procs are executed.
 def exit(status = 0)
-  AtExitHandlers.run
+  AtExitHandlers.run status
   STDOUT.flush
   STDERR.flush
   Process.exit(status)

--- a/src/main.cr
+++ b/src/main.cr
@@ -5,15 +5,20 @@ end
 
 macro redefine_main(name = main)
   fun main = {{name}}(argc : Int32, argv : UInt8**) : Int32
-    GC.init
-    {{yield LibCrystalMain.__crystal_main(argc, argv)}}
-    0
-  rescue ex
-    ex.inspect_with_backtrace STDERR
-    1
-  ensure
-    AtExitHandlers.run
+    %ex = nil
+    %status = begin
+      GC.init
+      {{yield LibCrystalMain.__crystal_main(argc, argv)}}
+      0
+    rescue ex
+      %ex = ex
+      1
+    end
+
+    AtExitHandlers.run %status
+    %ex.inspect_with_backtrace STDERR if %ex
     STDOUT.flush
+    %status
   end
 end
 


### PR DESCRIPTION
This feature becomes able to check an error in a `at_exit` block. It is useful to run your code when main script finished. See [kemal.cr](https://github.com/sdogruyol/kemal/blob/master/src/kemal.cr) for example. It uses `at_exit` to starts a HTTP server after main script. It is good. However, it starts the server even if main script failed. I think this behavior is wrong. If this PR is merged, I will fix like following code.

```crystal
at_exit do |status|
  if status == 0
    # starting server process here
    # ...
  end
end
```