### PR TITLE
Added the special variable $!

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -820,6 +820,11 @@ describe "Parser" do
   it_parses "foo $?", Call.new(nil, "foo", Call.new("$?".var, "not_nil!"))
   it_parses "$? = 1", Assign.new("$?".var, 1.int32)
 
+  it_parses "$!", Global.new("$!")
+  it_parses "$!.foo", Call.new(Global.new("$!"), "foo")
+  it_parses "foo $!", Call.new(nil, "foo", Global.new("$!"))
+  it_parses "$! = 1", Assign.new(Global.new("$!"), 1.int32)
+
   it_parses "$0", Path.global("PROGRAM_NAME")
   it_parses "foo $0", Call.new(nil, "foo", Path.global("PROGRAM_NAME"))
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -583,6 +583,9 @@ module Crystal
         when '?'
           next_char
           @token.type = :"$?"
+        when '!'
+          next_char
+          @token.type = :"$!"
         when .digit?
           start = current_pos
           char = next_char

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -841,6 +841,8 @@ module Crystal
       when :GLOBAL
         @wants_regex = false
         node_and_next_token Global.new(@token.value.to_s)
+      when :"$!"
+        node_and_next_token Global.new(@token.to_s)
       when :"$~", :"$?"
         location = @token.location
         var = Var.new(@token.to_s).at(location)
@@ -3269,7 +3271,7 @@ module Crystal
         end
       when :"{"
         return nil unless allow_curly
-      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"+", :"-", :"~", :"&", :"->", :"{{", :__LINE__, :__FILE__, :__DIR__, :UNDERSCORE
+      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :"$!", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"+", :"-", :"~", :"&", :"->", :"{{", :__LINE__, :__FILE__, :__DIR__, :UNDERSCORE
         # Nothing
       when :"*"
         if current_char.whitespace?

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -94,7 +94,12 @@ fun __crystal_get_exception(unwind_ex : LibUnwind::Exception*) : UInt64
   unwind_ex.value.exception_object
 end
 
+@[ThreadLocal]
+$! = nil
+
 def raise(ex : Exception)
+  $! = ex
+
   unwind_ex = Pointer(LibUnwind::Exception).malloc
   unwind_ex.value.exception_class = LibC::SizeT.zero
   unwind_ex.value.exception_cleanup = LibC::SizeT.zero


### PR DESCRIPTION
Ruby has `$!` special variable which means the last raised exception. It is useful in two cases: we want to get an exception object in postfix `rescue` and `at_exit` block.