### PR TITLE
Fix to catch all exceptions in at_exit handlers.

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -90,10 +90,12 @@ module AtExitHandlers
     return if @@running
     @@running = true
 
-    begin
-      @@handlers.try &.reverse_each &.call status
-    rescue handler_ex
-      puts "Error running at_exit handler: #{handler_ex}"
+    @@handlers.try &.reverse_each do |handler|
+      begin
+        handler.call status
+      rescue handler_ex
+        STDERR.puts "Error running at_exit handler: #{handler_ex}"
+      end
     end
   end
 end


### PR DESCRIPTION
`at_exit` handler is used for two purpose, I think: the first is to hook main script, the another is to release global resources.
Current implementation does not catch all exceptions but the first exception only and stop to execute handlers. It is wrong behavior in the second usecase, because to release should execute even if raised an exception.