### PR TITLE
Add Int#popcount from LLVM intrinsic

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -366,4 +366,26 @@ describe "Int" do
     iter.rewind
     iter.next.should eq(1)
   end
+
+  describe "#popcount" do
+    assert { 5_i8.popcount.should eq(2) }
+    assert { 127_i8.popcount.should eq(7) }
+    assert { -1_i8.popcount.should eq(8) }
+    assert { -128_i8.popcount.should eq(1) }
+
+    assert { 0_u8.popcount.should eq(0) }
+    assert { 255_u8.popcount.should eq(8) }
+
+    assert { 5_i16.popcount.should eq(2) }
+    assert { -6_i16.popcount.should eq(14) }
+    assert { 65535_u16.popcount.should eq(16) }
+
+    assert { 0_i32.popcount.should eq(0) }
+    assert { 2147483647_i32.popcount.should eq(31) }
+    assert { 4294967295_u32.popcount.should eq(32) }
+
+    assert { 5_i64.popcount.should eq(2) }
+    assert { 9223372036854775807_i64.popcount.should eq(63) }
+    assert { 18446744073709551615_u64.popcount.should eq(64) }
+  end
 end

--- a/src/int.cr
+++ b/src/int.cr
@@ -363,6 +363,14 @@ struct Int
     format.decode(self, io)
   end
 
+  # Counts `1`-bits in the binary representation of this integer.
+  #
+  # ```
+  # 5.popcount    #=> 2
+  # -15.popcount  #=> 5
+  # ```
+  abstract def popcount
+
   # :nodoc:
   class TimesIterator(T)
     include Iterator(T)
@@ -442,6 +450,10 @@ struct Int8
   def -
     0_i8 - self
   end
+
+  def popcount
+    Intrinsics.popcount8(self)
+  end
 end
 
 struct Int16
@@ -450,6 +462,10 @@ struct Int16
 
   def -
     0_i16 - self
+  end
+
+  def popcount
+    Intrinsics.popcount16(self)
   end
 end
 
@@ -460,6 +476,10 @@ struct Int32
   def -
     0 - self
   end
+
+  def popcount
+    Intrinsics.popcount32(self)
+  end
 end
 
 struct Int64
@@ -468,6 +488,10 @@ struct Int64
 
   def -
     0_i64 - self
+  end
+
+  def popcount
+    Intrinsics.popcount64(self)
   end
 end
 
@@ -478,6 +502,10 @@ struct UInt8
   def abs
     self
   end
+
+  def popcount
+    Intrinsics.popcount8(self)
+  end
 end
 
 struct UInt16
@@ -486,6 +514,10 @@ struct UInt16
 
   def abs
     self
+  end
+
+  def popcount
+    Intrinsics.popcount16(self)
   end
 end
 
@@ -496,6 +528,10 @@ struct UInt32
   def abs
     self
   end
+
+  def popcount
+    Intrinsics.popcount32(self)
+  end
 end
 
 struct UInt64
@@ -504,5 +540,9 @@ struct UInt64
 
   def abs
     self
+  end
+
+  def popcount
+    Intrinsics.popcount64(self)
   end
 end

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -5,6 +5,11 @@ lib Intrinsics
   fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, align : UInt32, is_volatile : Bool)
   fun read_cycle_counter = "llvm.readcyclecounter" : UInt64
   fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
+
+  fun popcount8 = "llvm.ctpop.i8"(src : Int8) : Int8
+  fun popcount16 = "llvm.ctpop.i16"(src : Int16) : Int16
+  fun popcount32 = "llvm.ctpop.i32"(src : Int32) : Int32
+  fun popcount64 = "llvm.ctpop.i64"(src : Int64) : Int64
 end
 
 macro debugger


### PR DESCRIPTION
This is useful for treating integers as bit arrays. For my part, I was trying to implement a hash array mapped trie and went looking for this function (#1927).

I've used the name `popcount` since it was the first thing I learned. But there are few different names for this operation out there:

- __popcount__: Haskell, GCC, LLVM (`ctpop`)
- __bitcount__: MySQL, Java, C++
- __logcount__: CommonLisp 😕

I'm happy to switch the name if one of these others would fit in better!

More info: 

- Wikipedia ["Hamming weight#Language Support"](https://en.wikipedia.org/wiki/Hamming_weight#Language_support)
- A (rejected) [PR to add this behavior to Ruby](https://bugs.ruby-lang.org/issues/8748)

## Questions 

- [x] Is the name ok?
- [x] Is that `int_intrinsic_popcount` macro appropriate? Should I hardcode the methods instead?
- [x] Is that test coverage ok?
