### PR TITLE
Array#sort_by & Array#sort_by! calls given block only once for each element

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -934,6 +934,13 @@ describe "Array" do
       a.sort_by! &.size
       a.should eq(["a", "foo", "hello"])
     end
+
+    it "calls given block exactly once for each element" do
+      calls = Hash(String, Int32).new(0)
+      a = ["foo", "a", "hello"]
+      a.sort_by! { |e| calls[e] += 1; e.size }
+      calls.should eq({"foo": 1, "a": 1, "hello": 1})
+    end
   end
 
   describe "swap" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -1430,7 +1430,11 @@ class Array(T)
   end
 
   def sort_by!(&block : T -> _)
-    sort! { |x, y| block.call(x) <=> block.call(y) }
+    sorted = map { |e| {e, block.call(e)} }.sort! { |x, y| x[1] <=> y[1] }
+    @size.times do |i|
+      @buffer[i] = sorted.buffer[i][0]
+    end
+    self
   end
 
   def swap(index0, index1)


### PR DESCRIPTION
Array#sort_by & Array#sort_by! methods in Ruby call given block only once for each element. Current version used by crystal calls given block for every comparison (which means there are multiple calls for the same elements). For me Ruby version is more natural and has better semantic. Imagine something like `urls.sort_by { |url| http_get(url).body.size }`. I don't think that anyone will expect it will fetch each url multiple times. My proposed version is also faster (about ~2x).