### PR TITLE
Fix as-in-block-return example

### DIFF
--- a/_gitbook/syntax_and_semantics/as.md
+++ b/_gitbook/syntax_and_semantics/as.md
@@ -116,5 +116,5 @@ This error isn't very frequent, and is usually gone if a `Person` is instantiate
 Person.new "John"
 
 a = [] of Person
-x = a.map { |f| f.name as String } # OK
+x = a.map { |f| f.name } # OK
 ```


### PR DESCRIPTION
The point of the last code block on that page is to show that `as` is not required once `Person#name` type can be inferred, so it should skip the type casting.