### PR TITLE
Please respect user's CRYSTAL_PATH (second challenge)

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -116,7 +116,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=$CRYSTAL_ROOT/src:libs
+export CRYSTAL_PATH="$CRYSTAL_ROOT/src:$CRYSTAL_PATH:libs"
 
 if [ -x "$CRYSTAL_DIR/crystal" ]
 then


### PR DESCRIPTION
It's a second challenge about #1911.

Let see [this gist](https://gist.github.com/MakeNowJust/69a8afe66817136d6b6c). This bash script is `crystal` wrapper to find root directory of the crystal project then add the libraries using this project to `CRYSTAL_PATH`. I often dive into `src` directory in development. In such a case, this wrapper is really useful.

I think `CRYSTAL_PATH` has more ability. Don't you think so?