### PR TITLE
Docs - Troubleshooting OSX 10.11 (El Capitan)

### DIFF
--- a/_gitbook/installation/on_mac_osx_using_homebrew.md
+++ b/_gitbook/installation/on_mac_osx_using_homebrew.md
@@ -12,3 +12,12 @@ If you're planning to contribute to the project you might find useful to install
 ```
 brew install crystal-lang --with-llvm
 ```
+
+## Troubleshooting on OSX 10.11 (El Capitan)
+
+Reinstall Xcode Command Line Tools, then set the path for the active developer directory.
+
+```
+xcode-select --install
+xcode-select --switch /Library/Developer/CommandLineTools
+``


### PR DESCRIPTION
A few users had a problem with crystal upon updating to 10.11 (including myself). (`ld: library not found for -levent`)

This comment by @waj solved it: https://github.com/manastech/crystal/issues/1798#issuecomment-150046859