### PR TITLE
Spec: Add class to eq matcher when inspect is same

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -10,7 +10,13 @@ module Spec
     end
 
     def failure_message
-      "expected: #{@value.inspect}\n     got: #{@target.inspect}"
+      expected = @value.inspect
+      got = @target.inspect
+      if expected == got
+        expected += " : #{@value.class}"
+        got += " : #{@target.class}"
+      end
+      "expected: #{expected}\n     got: #{got}"
     end
 
     def negative_failure_message


### PR DESCRIPTION
This changes the error message from 

```
Failures:

  1) PG::Decoder json
     Failure/Error: test_decode "json", "'[1,\"a\",true]'::json", [1, "a", true]

       expected: [1, "a", true]
            got: [1, "a", true]

     # ./spec/pg/decoder_spec.cr:36
```

to

```
  1) PG::Decoder json
     Failure/Error: test_decode "json", "'[1,\"a\",true]'::json", [1, "a", true]

       expected: [1, "a", true] : Array(String | Int32 | Bool)
            got: [1, "a", true] : JSON::Any

     # ./spec/pg/decoder_spec.cr:36
```