### PR TITLE
deal with malformed HTTP response headers

### DIFF
--- a/spec/std/http/response_spec.cr
+++ b/spec/std/http/response_spec.cr
@@ -59,6 +59,14 @@ module HTTP
       response.body?.should be_nil
     end
 
+    it "parses response without status message" do
+      response = Response.from_io(MemoryIO.new("HTTP/1.1 200\r\n\r\n"))
+      response.status_code.should eq(200)
+      response.status_message.should eq("")
+      response.headers.size.should eq(0)
+      response.body.should eq("")
+    end
+
     it "parses response with duplicated headers" do
       response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nWarning: 111 Revalidation failed\r\nWarning: 110 Response is stale\r\n\r\nhelloworld"))
       response.headers.get("Warning").should eq(["111 Revalidation failed", "110 Response is stale"])

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -91,7 +91,17 @@ class HTTP::Response
   def self.from_io(io, ignore_body = false, &block)
     line = io.gets
     if line
-      http_version, status_code, status_message = line.split(3)
+      spaces = line.scan(" ")
+
+      # deal with malformed responses
+      if spaces.size == 1
+        http_version, status_code = line.split(2)
+        status_code = status_code.chomp.to_i
+        status_message = self.default_status_message_for(status_code)
+      else
+        http_version, status_code, status_message = line.split(3)
+      end
+
       status_code = status_code.to_i
       status_message = status_message.chomp
       body_type = HTTP::BodyType::OnDemand

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -94,7 +94,7 @@ class HTTP::Response
       pieces = line.split(3)
       http_version = pieces[0]
       status_code = pieces[1].to_i
-      status_message = pieces[2]? ? pieces[2].chop : ""
+      status_message = pieces[2] ? pieces[2].chop : ""
 
       body_type = HTTP::BodyType::OnDemand
       body_type = HTTP::BodyType::Mandatory if mandatory_body?(status_code)

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -94,7 +94,7 @@ class HTTP::Response
       pieces = line.split(3)
       http_version = pieces[0]
       status_code = pieces[1].to_i
-      status_message = pieces[2] ? pieces[2].chop : ""
+      status_message = pieces[2]? ? pieces[2].chomp : ""
 
       body_type = HTTP::BodyType::OnDemand
       body_type = HTTP::BodyType::Mandatory if mandatory_body?(status_code)

--- a/src/http/response.cr
+++ b/src/http/response.cr
@@ -91,12 +91,10 @@ class HTTP::Response
   def self.from_io(io, ignore_body = false, &block)
     line = io.gets
     if line
-      http_version, status_code, status_message = "", 0, ""
-      line.match(/(HTTP\/\d+\.\d+)\s+(\d{3})\s*([\w\s]+)?/) do |md|
-        http_version   = md[1]
-        status_code    = md[2].to_i
-        status_message = md[3]? ? md[3].chop : self.default_status_message_for(status_code)
-      end
+      pieces = line.split(3)
+      http_version = pieces[0]
+      status_code = pieces[1].to_i
+      status_message = pieces[2]? ? pieces[2].chop : ""
 
       body_type = HTTP::BodyType::OnDemand
       body_type = HTTP::BodyType::Mandatory if mandatory_body?(status_code)


### PR DESCRIPTION
Hi, I'm using crystal to implement a client API and I face an error when server responds with a malformed  HTTP message.

Servers should respond something like:
```
HTTP/1.1 200 OK\r\n
```
but in my case, sometimes responds:
```
HTTP/1.1 200\r\n
```
This leads to an error in `HTTP::Response#from_io` multiple assigment. This MR makes the method more resilient.