### PR TITLE
Fix to unescape user and password in URI#parse

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -54,6 +54,13 @@ describe "URI" do
       u.password = "s3cr3t"
       u.to_s.should eq("http://alice:s3cr3t@www.example.com")
     end
+    assert do
+      u = URI.new("http", "www.example.com")
+      u.user = ":D"
+      u.to_s.should eq("http://%3AD@www.example.com")
+      u.password = "@_@"
+      u.to_s.should eq("http://%3AD:%40_%40@www.example.com")
+    end
     assert { URI.new("http", "www.example.com", user: "@al:ce", password: "s/cr3t").to_s.should eq("http://%40al%3Ace:s%2Fcr3t@www.example.com") }
     assert { URI.new("http", "www.example.com", fragment: "top").to_s.should eq("http://www.example.com#top") }
     assert { URI.new("http", "www.example.com", 1234).to_s.should eq("http://www.example.com:1234") }

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -25,6 +25,7 @@ describe "URI" do
   assert_uri("https://www.example.com", scheme: "https", host: "www.example.com")
   assert_uri("https://alice:pa55w0rd@www.example.com", scheme: "https", host: "www.example.com", user: "alice", password: "pa55w0rd")
   assert_uri("https://alice@www.example.com", scheme: "https", host: "www.example.com", user: "alice", password: nil)
+  assert_uri("https://%3AD:%40_%40@www.example.com", scheme: "https", host: "www.example.com", user: ":D", password: "@_@")
   assert_uri("https://www.example.com/#top", scheme: "https", host: "www.example.com", path: "/", fragment: "top")
   assert_uri("http://www.foo-bar.example.com", scheme: "http", host: "www.foo-bar.example.com")
   assert_uri("/foo", path: "/foo")

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -206,8 +206,10 @@ class URI
 
     if userinfo
       split = userinfo.split(":")
-      user = split[0]
-      password = split[1]?
+      user = URI.unescape split[0]
+      if password = split[1]?
+        password = URI.unescape split[1]
+      end
     else
       user = password = nil
     end


### PR DESCRIPTION
https://play.crystal-lang.org/#/r/p04

```crystal
require "uri"

uri1 = URI.parse "http://example.com/"
uri1.user = ":D"
p uri1.user #=> ":D"

uri2 = URI.parse uri1.to_s
p uri2.user #=> "%3AD"
p uri1.user == uri2.user #=> false
# ??? I expected ":D" and true. I'm confused.
```