### PR TITLE
Time#epoch return local timestamps instead of UTC

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -232,9 +232,15 @@ describe Time do
   end
 
   it "gets unix epoch seconds" do
-    t1 = Time.new 2014, 10, 30, 21, 18, 13
+    t1 = Time.new 2014, 10, 30, 21, 18, 13, 0, Time::Kind::Utc
     t1.epoch.should eq(1414703893)
     t1.epoch_f.should be_close(1414703893, 1e-01)
+  end
+
+  it "gets unix epoch seconds at GMT" do
+    t1 = Time.now
+    t1.epoch.should eq(t1.to_utc.epoch)
+    t1.epoch_f.should be_close(t1.to_utc.epoch_f, 1e-01)
   end
 
   it "to_s" do

--- a/src/time/time.cr
+++ b/src/time/time.cr
@@ -345,15 +345,15 @@ struct Time
 
   # Returns the number of seconds since the Epoch
   def epoch
-    (ticks - UnixEpoch) / Span::TicksPerSecond
+    (to_utc.ticks - UnixEpoch) / Span::TicksPerSecond
   end
 
   def epoch_ms
-    (ticks - UnixEpoch) / Span::TicksPerMillisecond
+    (to_utc.ticks - UnixEpoch) / Span::TicksPerMillisecond
   end
 
   def epoch_f
-    (ticks - UnixEpoch) / Span::TicksPerSecond.to_f
+    (to_utc.ticks - UnixEpoch) / Span::TicksPerSecond.to_f
   end
 
   def to_utc


### PR DESCRIPTION
Everything's in the title. This allows some basic transformations like `Time.epoch(now.epoch)` to be correct.