### PR TITLE
String small refactors and documentation

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -442,6 +442,7 @@ describe "String" do
     assert { "  \n\t かたな \n\f\v".strip.should eq("かたな") }
     assert { "  \n\t かたな".strip.should eq("かたな") }
     assert { "かたな".strip.should eq("かたな") }
+    assert { "".strip.should eq("") }
     assert { "\n".strip.should eq("") }
     assert { "\n\t  ".strip.should eq("") }
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -859,11 +859,7 @@ class String
   # ```
   def chomp(char : Char)
     if ends_with?(char)
-      count = 0
-      char.each_byte do |byte|
-        count += 1
-      end
-      String.new(unsafe_byte_slice(0, bytesize - count))
+      String.new(unsafe_byte_slice(0, bytesize - char.bytesize))
     else
       self
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -899,19 +899,12 @@ class String
   end
 
   def strip
-    excess_right = 0
-    while to_unsafe[bytesize - 1 - excess_right].chr.whitespace?
-      excess_right += 1
-    end
-
+    excess_right = calc_excess_right
     if excess_right == bytesize
       return ""
     end
 
-    excess_left = 0
-    while to_unsafe[excess_left].chr.whitespace?
-      excess_left += 1
-    end
+    excess_left = calc_excess_left
 
     if excess_right == 0 && excess_left == 0
       self
@@ -921,10 +914,7 @@ class String
   end
 
   def rstrip
-    excess_right = 0
-    while to_unsafe[bytesize - 1 - excess_right].chr.whitespace?
-      excess_right += 1
-    end
+    excess_right = calc_excess_right
 
     if excess_right == 0
       self
@@ -934,16 +924,29 @@ class String
   end
 
   def lstrip
-    excess_left = 0
-    while to_unsafe[excess_left].chr.whitespace?
-      excess_left += 1
-    end
+    excess_left = calc_excess_left
 
     if excess_left == 0
       self
     else
       byte_slice excess_left
     end
+  end
+
+  private def calc_excess_right
+    excess_right = 0
+    while c = to_unsafe[bytesize - 1 - excess_right].chr.whitespace?
+      excess_right += 1
+    end
+    excess_right
+  end
+
+  private def calc_excess_left
+    excess_left = 0
+    while to_unsafe[excess_left].chr.whitespace?
+      excess_left += 1
+    end
+    excess_left
   end
 
   def tr(from : String, to : String)

--- a/src/string.cr
+++ b/src/string.cr
@@ -792,6 +792,12 @@ class String
     to_unsafe[index]
   end
 
+  # Returns a new string with each uppercase letter replaced with its lowercase
+  # counterpart.
+  #
+  # ```
+  # "hEllO".downcase # => "hello"
+  # ```
   def downcase
     String.build(bytesize) do |io|
       each_char do |char|
@@ -800,6 +806,12 @@ class String
     end
   end
 
+  # Returns a new string with each lowercase letter replaced with its uppercase
+  # counterpart.
+  #
+  # ```
+  # "hEllO".upcase # => "HELLO"
+  # ```
   def upcase
     String.build(bytesize) do |io|
       each_char do |char|
@@ -808,6 +820,12 @@ class String
     end
   end
 
+  # Returns a new string with the first letter converted to uppercase and every
+  # subsequent letter converted to lowercase.
+  #
+  # ```
+  # "hEllO".capitalize # => "Hello"
+  # ```
   def capitalize
     return self if bytesize == 0
 
@@ -992,6 +1010,15 @@ class String
     excess_left
   end
 
+  # Returns a new string _tr_anslating characters using *from* and *to* as a
+  # map. If *to* is shorter than *from*, the last character in *to* is used for
+  # the rest.
+  #
+  # ```
+  # "aabbcc".tr("abc", "xyz") # => "xxyyzz"
+  # "aabbcc".tr("abc", "x")   # => "xxxxxx"
+  # "aabbcc".tr("a", "xyz")   # => "xxbbcc"
+  # ```
   def tr(from : String, to : String)
     multi = nil
     table = StaticArray(Int32, 256).new(-1)

--- a/src/string.cr
+++ b/src/string.cr
@@ -822,6 +822,18 @@ class String
     end
   end
 
+  # Returns a new String with the last carriage return removed (that is it will
+  # remove \n, \r, and \r\n).
+  #
+  # ```
+  # "string\r\n".chomp # => "string"
+  # "string\n\r".chomp # => "string\n"
+  # "string\n".chomp   # => "string"
+  # "string".chomp     # => "string"
+  # "x".chomp.chmop    # => "x"
+  # ```
+  #
+  # See also: `#chop`
   def chomp
     return self if bytesize == 0
 
@@ -839,6 +851,12 @@ class String
     end
   end
 
+  # Returns a new String with *char* removed if the string ends with it.
+  #
+  # ```
+  # "hello".chomp('o') # => "hell"
+  # "hello".chomp('a') # => "hello"
+  # ```
   def chomp(char : Char)
     if ends_with?(char)
       count = 0
@@ -851,6 +869,17 @@ class String
     end
   end
 
+  # Returns a new String with *string* removed if the string ends with it.
+  # If *string* is `""`, all trailing `\r\n` or `\n` characters are removed.
+  #
+  # ```
+  # "hello".chomp("llo") # => "he"
+  # "hello".chomp("ol")  # => "hello"
+  #
+  # "hello\n\n\n\n".chomp("")   # => "hello"
+  # "hello\r\n\r\n".chomp("")   # => "hello"
+  # "hello\r\n\r\r\n".chomp("") # => "hello\r\n\r"
+  # ```
   def chomp(string : String)
     if string.empty?
       return self if empty?
@@ -898,6 +927,12 @@ class String
     self[0, size - 1]
   end
 
+  # Returns a new string with leading and trailing whitespace removed.
+  #
+  # ```
+  # "    hello    ".strip # => "hello"
+  # "\tgoodbye\r\n".strip # => "goodbye"
+  # ```
   def strip
     excess_right = calc_excess_right
     if excess_right == bytesize
@@ -913,6 +948,12 @@ class String
     end
   end
 
+  # Returns a new string with trailing whitespace removed.
+  #
+  # ```
+  # "    hello    ".strip # => "    hello"
+  # "\tgoodbye\r\n".strip # => "\tgoodbye"
+  # ```
   def rstrip
     excess_right = calc_excess_right
 
@@ -923,6 +964,12 @@ class String
     end
   end
 
+  # Returns a new string with leading whitespace removed.
+  #
+  # ```
+  # "    hello    ".strip # => "hello    "
+  # "\tgoodbye\r\n".strip # => "goodbye\r\n"
+  # ```
   def lstrip
     excess_left = calc_excess_left
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -840,8 +840,8 @@ class String
     end
   end
 
-  # Returns a new String with the last carriage return removed (that is it will
-  # remove \n, \r, and \r\n).
+  # Returns a new String with the last carriage return removed (that is, it
+  # will remove \n, \r, and \r\n).
   #
   # ```
   # "string\r\n".chomp # => "string"
@@ -883,8 +883,8 @@ class String
     end
   end
 
-  # Returns a new String with *string* removed if the string ends with it.
-  # If *string* is `""`, all trailing `\r\n` or `\n` characters are removed.
+  # Returns a new String with *str* removed if the string ends with it.
+  # If *str* is `""`, all trailing `\r\n` or `\n` characters are removed.
   #
   # ```
   # "hello".chomp("llo") # => "he"
@@ -894,8 +894,8 @@ class String
   # "hello\r\n\r\n".chomp("")   # => "hello"
   # "hello\r\n\r\r\n".chomp("") # => "hello\r\n\r"
   # ```
-  def chomp(string : String)
-    if string.empty?
+  def chomp(str : String)
+    if str.empty?
       return self if empty?
 
       pos = bytesize - 1
@@ -907,8 +907,8 @@ class String
         end
       end
       String.new(unsafe_byte_slice(0, pos + 1))
-    elsif ends_with?(string)
-      String.new(unsafe_byte_slice(0, bytesize - string.bytesize))
+    elsif ends_with?(str)
+      String.new(unsafe_byte_slice(0, bytesize - str.bytesize))
     else
       self
     end
@@ -996,7 +996,7 @@ class String
 
   private def calc_excess_right
     excess_right = 0
-    while c = to_unsafe[bytesize - 1 - excess_right].chr.whitespace?
+    while to_unsafe[bytesize - 1 - excess_right].chr.whitespace?
       excess_right += 1
     end
     excess_right


### PR DESCRIPTION
Originally I was looking in here to see if `#strip` could easily remove extra null bytes that you get when you overestimate the buffer size in `String.new(int) { |buff| }` or if that `#new` should do it. I didn't get to that yet though.

Also while going through these methods, I think the behavior you get when you pass an empty string to `#chomp` is confusing. It's very similar to `#chomp` with no arguments, but does more. That special case behavior should be removed entirely, or made to be the behavior of argless chomp. That change is not included here yet.