### PR TITLE
Fix OpenSSL::DigestBase#update(IO)

### DIFF
--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -29,4 +29,16 @@ describe OpenSSL::Digest do
     OpenSSL::Digest.new("SHA1").block_size.should eq 64
     OpenSSL::Digest.new("SHA256").block_size.should eq 64
   end
+
+  it "correctly reads from IO" do
+    r, w = IO.pipe
+    digest = OpenSSL::Digest.new("SHA256")
+
+    w << "foo"
+    w.close
+    digest << r
+    r.close
+
+    digest.hexdigest.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+  end
 end

--- a/src/openssl/digest/digest_base.cr
+++ b/src/openssl/digest/digest_base.cr
@@ -11,7 +11,7 @@ module OpenSSL
     def update(io : IO)
       buffer :: UInt8[2048]
       while (read_bytes = io.read(buffer.to_slice)) > 0
-        self << buffer.to_slice
+        self << buffer.to_slice[0, read_bytes]
       end
       self
     end


### PR DESCRIPTION
It didn't correctly truncate the buffer, appending garbage to the digest