### PR TITLE
Fix heredoc

### DIFF
--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -153,9 +153,9 @@ describe "Lexer string" do
 
     tester.string_should_start_correctly
     tester.next_string_token_should_be("Hello, mom! I am HERE.")
-    tester.next_string_token_should_be("HER dress is beautiful.")
-    tester.next_string_token_should_be("HE is OK.")
-    tester.next_string_token_should_be("  HERESY")
+    tester.next_string_token_should_be("\nHER dress is beautiful.")
+    tester.next_string_token_should_be("\nHE is OK.")
+    tester.next_string_token_should_be("\n  HERESY")
     tester.string_should_end_correctly
   end
 
@@ -186,9 +186,9 @@ describe "Lexer string" do
     tester.string_should_start_correctly
     tester.next_string_token_should_be("Hello, mom! I am HERE.")
     tester.token_should_be_at(line: 1)
-    tester.next_string_token_should_be("HER dress is beautiful.")
+    tester.next_string_token_should_be("\nHER dress is beautiful.")
     tester.token_should_be_at(line: 1)
-    tester.next_string_token_should_be("HE is OK.")
+    tester.next_string_token_should_be("\nHE is OK.")
     tester.token_should_be_at(line: 1)
     tester.string_should_end_correctly(false)
     tester.next_token_should_be(:NEWLINE)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1031,6 +1031,7 @@ describe "Parser" do
   it_parses %("hello " \\\n "world"), StringLiteral.new("hello world")
   it_parses %("hello "\\\n"world"), StringLiteral.new("hello world")
   it_parses %("hello \#{1}" \\\n "\#{2} world"), StringInterpolation.new(["hello ".string, 1.int32, 2.int32, " world".string] of ASTNode)
+  it_parses "<<-HERE\nHello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY\nHERE", "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY".string
   assert_syntax_error %("foo" "bar")
 
   it_parses "enum Foo; A\nB, C\nD = 1; end", EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1703,6 +1703,7 @@ module Crystal
               @reader.pos = old_pos
               @column_number = old_column
               next_string_token delimiter_state
+              @token.value = '\n' + @token.value.to_s
             end
           else
             @reader.pos = old_pos
@@ -1715,7 +1716,6 @@ module Crystal
           @token.value = "\n"
         end
       else
-        count = 0
         while current_char != string_end &&
               current_char != string_nest &&
               current_char != '\0' &&


### PR DESCRIPTION
### Code

```crystal
s = <<-HERE
Hello, mom! I am HERE.
HER dress is beautiful.
HE is OK.
  HERESY
aaaaaa
HERE
puts s
```

### Output

```
Hello, mom! I am HERE.HER dress is beautiful.HE is OK.  HERESY
aaaaaa
```

Newlines were discarded wrongly when line started with the same character as heredoc identifier.  Tests were also wrong.
I fixed it by adding missing newline to token value.  And I also added a test for heredoc on parse phase.