### PR TITLE
ECR: support comments (<%# %>) and escapes (<%% %>)

### DIFF
--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -65,6 +65,81 @@ describe "ECR::Lexer" do
     token.type.should eq(:EOF)
   end
 
+  it "lexes with <%# %>" do
+    lexer = ECR::Lexer.new("hello <%# foo %> bar")
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(:CONTROL)
+    token.value.should eq("# foo ")
+    token.line_number.should eq(1)
+    token.column_number.should eq(9)
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(17)
+
+    token = lexer.next_token
+    token.type.should eq(:EOF)
+  end
+
+  it "lexes with <%% %>" do
+    lexer = ECR::Lexer.new("hello <%% foo %> bar")
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq("<% foo %>")
+    token.line_number.should eq(1)
+    token.column_number.should eq(10)
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(17)
+
+    token = lexer.next_token
+    token.type.should eq(:EOF)
+  end
+
+  it "lexes with <%%= %>" do
+    lexer = ECR::Lexer.new("hello <%%= foo %> bar")
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq("<%= foo %>")
+    token.line_number.should eq(1)
+    token.column_number.should eq(10)
+
+    token = lexer.next_token
+    token.type.should eq(:STRING)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(18)
+
+    token = lexer.next_token
+    token.type.should eq(:EOF)
+  end
+
   it "lexes with <% %> and correct location info" do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -11,7 +11,7 @@ end
 
 describe "ECR" do
   it "builds a crystal program from a source" do
-    program = ECR.process_string "hello <%= 1 %> wor\nld <% while true %> 2 <% end %>", "foo.cr"
+    program = ECR.process_string "hello <%= 1 %> wor\nld <% while true %> 2 <% end %>\n<%# skip %> <%% \"string\" %>", "foo.cr"
 
     pieces = [
       %(__str__ << "hello "),
@@ -20,6 +20,10 @@ describe "ECR" do
       %(#<loc:"foo.cr",2,6> while true ),
       %(__str__ << " 2 "),
       %(#<loc:"foo.cr",2,25> end ),
+      %(__str__ << "\\n"),
+      %(#<loc:\"foo.cr\",3,3> # skip ),
+      %(__str__ << " "),
+      %(__str__ << "<% \\"string\\" %>"),
     ]
     program.should eq(pieces.join("\n") + "\n")
   end

--- a/src/ecr/ecr.cr
+++ b/src/ecr/ecr.cr
@@ -83,6 +83,7 @@ module ECR
           str << "\n"
         when :CONTROL
           append_loc(str, filename, token)
+          str << " " unless token.value.starts_with?(' ')
           str << token.value
           str << "\n"
         when :EOF


### PR DESCRIPTION
~~WIP: it's still missing the transform specs (comments are dropped, escaped are transformed to strings, minus a %).~~

I don't make a difference between `<%%` and `<%%=` since we'd treat them exactly the same (output them as is minus a %).

closes #1999 