### PR TITLE
Implement bash auto complete

### DIFF
--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -4,12 +4,7 @@
 # Get list of crystal files or directories, that match $pattern
 _crystal_compgen_files(){
     local pattern=$1
-    compgen -f -o plusdirs  -X '!*.cr' -- $pattern
-}
-
-# compopt is not available in ancient bash versions
-_crystal_compopt_filenames(){
-    type compopt &>/dev/null && compopt -o filenames
+    compgen -f -o plusdirs -X '!*.cr' -- $pattern
 }
 
 _crystal()
@@ -19,14 +14,13 @@ _crystal()
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="init build deps docs eval run spec tool help version"
+    commands="init build deps docs eval run spec tool help version --help --version"
 
     case "${cmd}" in
         init)
             if [[ "${prev}" == "init" ]] ; then
                 COMPREPLY=( $(compgen -W "app lib" -- ${cur}) )
             else
-                _crystal_compopt_filenames
                 COMPREPLY=( $(compgen -f ${cur}) )
             fi
             ;;
@@ -35,7 +29,6 @@ _crystal()
                 local opts="--cross-compile --debug --emit --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --help"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
-                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
             ;;
@@ -48,7 +41,6 @@ _crystal()
                     local subcommands="check install list update"
                     COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
                 else
-                    _crystal_compopt_filenames
                     COMPREPLY=($(_crystal_compgen_files $cur))
                 fi
             fi
@@ -58,7 +50,6 @@ _crystal()
                 local opts="--debug --define --emit --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
-                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
             ;;
@@ -71,14 +62,12 @@ _crystal()
                     local subcommands="browser context format hierarchy implementations types"
                     COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
                 else
-                    _crystal_compopt_filenames
                     COMPREPLY=($(_crystal_compgen_files $cur))
                 fi
             fi
             ;;
         docs|eval|spec|version|help)
             # These commands do not accept any options nor subcommands
-            _crystal_compopt_filenames
             COMPREPLY=( $(compgen -f ${cur}) )
             ;;
         *)
@@ -86,11 +75,10 @@ _crystal()
             if [[ "${prev}" == "${program}" && $(compgen -W "${commands}" -- ${cur})  ]] ; then
                 COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
             else
-                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
     esac
     return 0
 }
 
-complete -F _crystal crystal
+complete -F _crystal -o filenames crystal

--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -1,0 +1,91 @@
+# Bash completion for "crystal" command.
+# Written by Sergey Potapov <blake131313@gmail.com>.
+
+# Get list of crystal files or directories, that match $pattern
+_crystal_compgen_files(){
+    local pattern=$1
+    compgen -f -o plusdirs  -X '!*.cr' -- $pattern
+}
+
+_crystal()
+{
+    local program=${COMP_WORDS[0]}
+    local cmd=${COMP_WORDS[1]}
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    commands="init build deps docs eval run spec tool help version"
+
+    case "${cmd}" in
+        init)
+            if [[ "${prev}" == "init" ]] ; then
+                COMPREPLY=( $(compgen -W "app lib" -- ${cur}) )
+            else
+                compopt -o filenames
+                COMPREPLY=( $(compgen -f ${cur}) )
+            fi
+            ;;
+        build)
+            if [[ ${cur} == -* ]] ; then
+                local opts="--cross-compile --debug --emit --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --help"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            else
+                compopt -o filenames
+                COMPREPLY=($(_crystal_compgen_files $cur))
+            fi
+            ;;
+        deps)
+            if [[ ${cur} == -* ]] ; then
+                local opts="--no-color --version --production"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            else
+                if [[ "${prev}" == "deps" ]] ; then
+                    local subcommands="check install list update"
+                    COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
+                else
+                    compopt -o filenames
+                    COMPREPLY=($(_crystal_compgen_files $cur))
+                fi
+            fi
+            ;;
+        run)
+            if [[ ${cur} == -* ]] ; then
+                local opts="--debug --define --emit --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            else
+                compopt -o filenames
+                COMPREPLY=($(_crystal_compgen_files $cur))
+            fi
+            ;;
+        tool)
+            if [[ ${cur} == -* ]] ; then
+                local opts="--no-color --prelude --define --format --cursor"
+                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+            else
+                if [[ "${prev}" == "tool" ]] ; then
+                    local subcommands="browser context format hierarchy implementations types"
+                    COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
+                else
+                    compopt -o filenames
+                    COMPREPLY=($(_crystal_compgen_files $cur))
+                fi
+            fi
+            ;;
+        docs|eval|spec|version|help)
+            # These commands do not accept any options nor subcommands
+            compopt -o filenames
+            COMPREPLY=( $(compgen -f ${cur}) )
+            ;;
+        *)
+            # When any of sumbcommands matches directly
+            if [[ "${prev}" == "${program}" && $(compgen -W "${commands}" -- ${cur})  ]] ; then
+                COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+            else
+                compopt -o filenames
+                COMPREPLY=($(_crystal_compgen_files $cur))
+            fi
+    esac
+    return 0
+}
+
+complete -F _crystal crystal

--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -7,6 +7,11 @@ _crystal_compgen_files(){
     compgen -f -o plusdirs  -X '!*.cr' -- $pattern
 }
 
+# compopt is not available in ancient bash versions
+_crystal_compopt_filenames(){
+    type compopt &>/dev/null && compopt -o filenames
+}
+
 _crystal()
 {
     local program=${COMP_WORDS[0]}
@@ -21,7 +26,7 @@ _crystal()
             if [[ "${prev}" == "init" ]] ; then
                 COMPREPLY=( $(compgen -W "app lib" -- ${cur}) )
             else
-                compopt -o filenames
+                _crystal_compopt_filenames
                 COMPREPLY=( $(compgen -f ${cur}) )
             fi
             ;;
@@ -30,7 +35,7 @@ _crystal()
                 local opts="--cross-compile --debug --emit --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --help"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
-                compopt -o filenames
+                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
             ;;
@@ -43,7 +48,7 @@ _crystal()
                     local subcommands="check install list update"
                     COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
                 else
-                    compopt -o filenames
+                    _crystal_compopt_filenames
                     COMPREPLY=($(_crystal_compgen_files $cur))
                 fi
             fi
@@ -53,7 +58,7 @@ _crystal()
                 local opts="--debug --define --emit --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose"
                 COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             else
-                compopt -o filenames
+                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
             ;;
@@ -66,14 +71,14 @@ _crystal()
                     local subcommands="browser context format hierarchy implementations types"
                     COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
                 else
-                    compopt -o filenames
+                    _crystal_compopt_filenames
                     COMPREPLY=($(_crystal_compgen_files $cur))
                 fi
             fi
             ;;
         docs|eval|spec|version|help)
             # These commands do not accept any options nor subcommands
-            compopt -o filenames
+            _crystal_compopt_filenames
             COMPREPLY=( $(compgen -f ${cur}) )
             ;;
         *)
@@ -81,7 +86,7 @@ _crystal()
             if [[ "${prev}" == "${program}" && $(compgen -W "${commands}" -- ${cur})  ]] ; then
                 COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
             else
-                compopt -o filenames
+                _crystal_compopt_filenames
                 COMPREPLY=($(_crystal_compgen_files $cur))
             fi
     esac


### PR DESCRIPTION
#### Changes
* Create `etc/completion.bash` that contains auto complete for Bash

#### How to try/test it?
* Run `bash` shell, likely it's already installed in your system
* Load auto complete:
```sh
source ./etc/completion.bash
```
* Start typing commands, e.g: 
```
$ crystal <TAB>
build    deps     docs     eval     help     init     run      spec     tool     version 

$ crystal build <TAB>
bin/     docs/    etc/     .git/    samples/ spec/    src/

$ crystal build --<TAB>
--cross-compile  --emit           --link-flags     --mcpu           --no-color       --release        --target         --verbose        
--debug          --help           --ll             --no-codegen     --prelude        --single-module  --threads
```

#### Notes
* In debian-like Linux system the file should be copied to `/etc/bash_completion.d/crystal` during crystal installation. Any ideas how to do this?
* If you wonder how bash autocomplete works, there is good 2 pages tutorial: https://www.debian-administration.org/article/316/An_introduction_to_bash_completion_part_1

Thanks, guys!