### PR TITLE
Fix example in Instance variables type inference

### DIFF
--- a/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
+++ b/_gitbook/syntax_and_semantics/instance_variables_type_inference.md
@@ -80,7 +80,7 @@ john = Person.new "John"
 one = Person.new 1
 
 # Error: undefined method 'size' for Int32
-john.name.size
+one.name.size
 
 # Error: no overload matches 'String#+' with types Int32
 john.name + 3


### PR DESCRIPTION
Hello,

Just found a small error in the documentation of [Instance variables type inference](http://crystal-lang.org/docs/syntax_and_semantics/instance_variables_type_inference.html):

```Crystal
john = Person.new "John"
one = Person.new 1

# Error: undefined method 'size' for Int32
john.name.size

# Error: no overload matches 'String#+' with types Int32
john.name + 3
```

The first example should be `one.name.size`

m2c