### PR TITLE
Improve and fix heredoc identifier

### DIFF
--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -260,6 +260,14 @@ describe "Lexer string" do
     end
   end
 
+  it "raises on unexpected EOF while lexing heredoc" do
+    lexer = Lexer.new("<<-aaa")
+
+    expect_raises Crystal::SyntaxException, /unexpected EOF on heredoc identifier/ do
+      lexer.next_token
+    end
+  end
+
   it "lexes string with unicode codepoint" do
     lexer = Lexer.new "\"\\uFEDA\""
     tester = LexerObjects::Strings.new(lexer)

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -223,7 +223,7 @@ describe "Lexer string" do
   it "raises on invalid heredoc identifier (<<-HERE A)" do
     lexer = Lexer.new("<<-HERE A\ntest\nHERE\n")
 
-    expect_raises Crystal::SyntaxException, /invalid heredoc identifier/ do
+    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
       lexer.next_token
     end
   end
@@ -231,7 +231,31 @@ describe "Lexer string" do
   it "raises on invalid heredoc identifier (<<-HERE\\n)" do
     lexer = Lexer.new("<<-HERE\\ntest\nHERE\n")
 
-    expect_raises Crystal::SyntaxException, /invalid heredoc identifier/ do
+    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+      lexer.next_token
+    end
+  end
+
+  it "raises when identifier doesn't start with a leter" do
+    lexer = Lexer.new("<<-123\\ntest\n123\n")
+
+    expect_raises Crystal::SyntaxException, /heredoc identifier starts with invalid character/ do
+      lexer.next_token
+    end
+  end
+
+  it "raises when identifier contains a character not for identifier" do
+    lexer = Lexer.new("<<-aaa.bbb?\\ntest\naaa.bbb?\n")
+
+    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
+      lexer.next_token
+    end
+  end
+
+  it "raises when identifier contains spaces" do
+    lexer = Lexer.new("<<-aaa  bbb\\ntest\naaabbb\n")
+
+    expect_raises Crystal::SyntaxException, /invalid character '.+' for heredoc identifier/ do
       lexer.next_token
     end
   end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -136,29 +136,24 @@ module Crystal
           when '-'
             here = MemoryIO.new(20)
 
+            unless ident_start?(next_char)
+              raise "heredoc identifier starts with invalid character"
+            end
+
+            here << current_char
             while true
-              case char = next_char
-              when '\n'
+              char = next_char
+              case
+              when char == '\n'
                 @line_number += 1
                 @column_number = 0
                 break
-              when '\\'
-                if peek_next_char == 'n'
-                  next_char
-                  raise "invalid heredoc identifier"
-                end
-              when ' '
-                case peek_next_char
-                when ' '
-                  next_char
-                when '\n'
-                  next_char
-                  break
-                else
-                  raise "invalid heredoc identifier"
-                end
-              else
+              when ident_part?(char)
                 here << char
+              when char == '\0'
+                raise "unexpected EOF on heredoc identifier"
+              else
+                raise "invalid character #{char.inspect} for heredoc identifier"
               end
             end
 


### PR DESCRIPTION
Current (0.10.1) crystal compiler accepts *almost all* characters for heredoc identifer.  As the result, we can write odd codes as following.

```crystal
puts <<-234
aaa
bbb
ccc
234

puts <<-aaa.bbb?
aaa
bbb
ccc
aaa.bbb?

# 2 spaces in ident are ignored
puts <<-aaa  bbb
aaa
bbb
ccc
aaabbb
```

All `puts` output `"aaa\nbbb\nccc"` but they are very confusing and I think there is no case they make us happy.

So I limited characters for heredoc identifiers to leters and numbers.  And identifiers must start with letter.  (I wonder it is better to limit them to upper case only)

While adding this improvement,  I fixed a bug.

```crystal
s = <<-HERE
```

When above code doesn't end with `\n`,  compiler crashes because unexpected EOF is not expected while lexing heredoc identifier.