### PR TITLE
Array#push always returns self

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -717,21 +717,32 @@ describe "Array" do
   end
 
   describe "push" do
-    it "adds one element to the array" do
-      a = ["a", "b"]
-      a.push("c")
-      a.should eq ["a", "b", "c"]
+    it "adds one element to the end of the array" do
+      a = [1, 2]
+      a.push(3)
+      a.should eq [1, 2, 3]
     end
 
-    it "returns the array" do
-      a = ["a", "b"]
-      a.push("c").should eq ["a", "b", "c"]
+    it "returns the array when adding one element" do
+      a = [1, 2]
+      a.push(3).should eq [1, 2, 3]
+    end
+
+    it "adds mutliple elements to the end of the array" do
+      a = [1, 2]
+      a.push(3, 4)
+      a.should eq [1, 2, 3, 4]
+    end
+
+    it "returns the array when adding multiple elements" do
+      a = [1, 2]
+      a.push(3, 4).should eq [1, 2, 3, 4]
     end
 
     it "has the << alias" do
-      a = ["a", "b"]
-      a << "c"
-      a.should eq ["a", "b", "c"]
+      a = [1, 2]
+      a << 3
+      a.should eq [1, 2, 3]
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -1469,11 +1469,12 @@ class Array(T)
   end
 
   # Append multiple values. The same as `push`, but takes an arbitrary number
-  # of values to push into the array.
+  # of values to push into the array. Returns `self`.
   def push(*values : T)
     values.each do |value|
       self << value
     end
+    self
   end
 
   def replace(other : Array)


### PR DESCRIPTION
This is a thought I had, about expecting returns from a method.  Since there's already a `.push` method that returns the original array (`self`), the multiple-value version of `push` should also return `self`.

Currently, the method returns a set of the values passed.  Is there any value to this?