### PR TITLE
Arrays can unshift multiple values

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -717,26 +717,16 @@ describe "Array" do
   end
 
   describe "push" do
-    it "adds one element to the end of the array" do
+    it "pushes one element" do
       a = [1, 2]
-      a.push(3)
+      a.push(3).should be(a)
       a.should eq [1, 2, 3]
     end
 
-    it "returns the array when adding one element" do
+    it "pushes multiple elements" do
       a = [1, 2]
-      a.push(3).should eq [1, 2, 3]
-    end
-
-    it "adds mutliple elements to the end of the array" do
-      a = [1, 2]
-      a.push(3, 4)
+      a.push(3, 4).should be(a)
       a.should eq [1, 2, 3, 4]
-    end
-
-    it "returns the array when adding multiple elements" do
-      a = [1, 2]
-      a.push(3, 4).should eq [1, 2, 3, 4]
     end
 
     it "has the << alias" do
@@ -1060,11 +1050,18 @@ describe "Array" do
     end
   end
 
-  it "does unshift" do
-    a = [2, 3]
-    expected = [1, 2, 3]
-    a.unshift(1).should eq(expected)
-    a.should eq(expected)
+  describe "unshift" do
+    it "unshifts one element" do
+      a = [1, 2]
+      a.unshift(3).should be(a)
+      a.should eq [3, 1, 2]
+    end
+
+    it "unshifts multiple elements" do
+      a = [1, 2]
+      a.unshift(3, 4).should be(a)
+      a.should eq [3, 4, 1, 2]
+    end
   end
 
   it "does update" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -172,6 +172,28 @@ describe "Tuple" do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end
 
+  it "does reverse_each" do
+    str = ""
+    {"a", "b", "c"}.reverse_each do |i|
+      str += i
+    end
+    str.should eq("cba")
+  end
+
+  describe "reverse_each iterator" do
+    it "does next" do
+      a = {1, 2, 3}
+      iter = a.reverse_each
+      iter.next.should eq(3)
+      iter.next.should eq(2)
+      iter.next.should eq(1)
+      iter.next.should be_a(Iterator::Stop)
+
+      iter.rewind
+      iter.next.should eq(3)
+    end
+  end
+
   it "gets first element" do
     tuple = {1, 2.5}
     tuple.first.should eq(1)

--- a/src/array.cr
+++ b/src/array.cr
@@ -1471,9 +1471,12 @@ class Array(T)
   # Append multiple values. The same as `push`, but takes an arbitrary number
   # of values to push into the array. Returns `self`.
   def push(*values : T)
-    values.each do |value|
-      self << value
+    new_size = @size + values.size
+    resize_to_capacity(Math.pw2ceil(new_size)) if @size > @capacity
+    values.each_with_index do |value, i|
+      @buffer[@size + i] = value
     end
+    @size = new_size
     self
   end
 
@@ -1806,6 +1809,21 @@ class Array(T)
 
   def unshift(obj : T)
     insert 0, obj
+  end
+
+  # Prepend multiple values. The same as `unshift`, but takes an arbitrary number
+  # of values to add to the array. Returns `self`.
+  def unshift(*values : T)
+    new_size = @size + values.size
+    resize_to_capacity(Math.pw2ceil(new_size)) if @size > @capacity
+    move_value = values.size
+    @buffer.move_to(@buffer + move_value, @size)
+
+    values.each_with_index do |value, i|
+      @buffer[i] = value
+    end
+    @size = new_size
+    self
   end
 
   def update(index : Int)

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -347,6 +347,38 @@ struct Tuple
     {% end %}
   end
 
+  # Yields each of the elements in this tuple in reverse order.
+  #
+  # ```
+  # tuple = {1, "hello", 'x'}
+  # tuple.reverse_each do |value|
+  #   puts value
+  # end
+  # ```
+  #
+  # Output:
+  #
+  # ```text
+  # 'x'
+  # "hello"
+  # 1
+  # ```
+  def reverse_each
+    {% for i in 1..@type.size %}
+      yield self[{{@type.size - i}}]
+    {% end %}
+    self
+  end
+
+  # Returns an `Iterator` for the elements in this tuple.
+  #
+  # ```
+  # {1, 'a'}.reverse_each.cycle.take(3).to_a # => [1, 'a', 1]
+  # ```
+  def reverse_each
+    ReverseIterator(typeof((i = 0; self[i]))).new(self)
+  end
+
   # Returns the first element of this tuple. Doesn't compile
   # if the tuple is empty.
   #
@@ -420,6 +452,27 @@ struct Tuple
 
     def rewind
       @index = 0
+      self
+    end
+  end
+
+  # :nodoc:
+  class ReverseIterator(T)
+    include Iterator(T)
+
+    def initialize(@tuple, @index = tuple.size - 1)
+    end
+
+    def next
+      return stop if @index < 0
+
+      value = @tuple.at(@index) { stop }
+      @index -= 1
+      value
+    end
+
+    def rewind
+      @index = @tuple.size - 1
       self
     end
   end


### PR DESCRIPTION
Documentation notes:
Prepend multiple values. The same as `unshift`, but takes an arbitrary number of values to add to the array. Returns `self`.
