### PR TITLE
command: forward sigint to temp spec

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -437,7 +437,13 @@ USAGE
 
   private def execute(output_filename, run_args)
     begin
-      status = Process.run(output_filename, args: run_args, input: true, output: true, error: true)
+      Process.run(output_filename, args: run_args, input: true, output: true, error: true) do |process|
+        Signal::INT.trap do
+          process.kill
+          exit
+        end
+      end
+      status = $?
     ensure
       File.delete output_filename
     end


### PR DESCRIPTION
While working on the URIParser, a few times I had infinite loops, and noticed that the temp spec program was still running after ctrl-c. 

This forwards the sigint to the temp program.

```
/tmp ➤ cat sp.cr
require "spec"

loop do
end

/tmp ➤ crystal spec sp.cr
^C

/tmp ➤ pgrep -lf crystal
zsh: correct 'crystal' to '.crystal' [nyae]? n
69891 /tmp/.crystal/crystal-run-spec.tmp

/tmp ➤ pkill -lf crystal
zsh: correct 'crystal' to '.crystal' [nyae]? n
kill -15 69891

/tmp ➤ ~/code/crystal/bin/crystal spec sp.cr
Using compiled compiler at .build/crystal
^C%

/tmp ➤ pgrep -lf crystal
zsh: correct 'crystal' to '.crystal' [nyae]? n

/tmp ➤
```