### PR TITLE
Added undent() macro to remove extra indent from multi-line string

### DIFF
--- a/spec/std/macros_spec.cr
+++ b/spec/std/macros_spec.cr
@@ -1,0 +1,186 @@
+require "spec"
+
+describe "undent" do
+  it "removes extra indent from multi-line string" do
+    s = undent <<-USAGE
+      Usage:
+        blah [options...] {file}
+      Options:
+        -h --help     Show this screen.
+        --version     Show version.
+        --foo={value} Description of foo.
+    USAGE
+
+    s.should eq <<-EXPECTED
+Usage:
+  blah [options...] {file}
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    EXPECTED
+
+    s = undent <<-HERE
+      This line is indented deeper
+    This line has shallow indent
+        This line deepest indent
+    HERE
+
+    s.should eq <<-EXPECTED
+  This line is indented deeper
+This line has shallow indent
+    This line deepest indent
+    EXPECTED
+  end
+
+  it "ignores empty lines and white space only lines" do
+    s = undent <<-EMPTY_LINES
+
+      Usage:
+        blah [options...] {file}
+          
+      Options:
+            
+        -h --help     Show this screen.
+
+        --version     Show version.
+
+        --foo={value} Description of foo.
+
+    EMPTY_LINES
+
+    s.should eq <<-EXPECTED
+
+Usage:
+  blah [options...] {file}
+    
+Options:
+      
+  -h --help     Show this screen.
+
+  --version     Show version.
+
+  --foo={value} Description of foo.
+
+    EXPECTED
+  end
+
+  it "removes extra indent from multi-line string interpolation" do
+    section1 = "Usage"
+    name = "blah"
+    section2 = "Options"
+
+    s = undent <<-USAGE
+      #{section1}:
+        #{name} [options...] {file}
+      #{section2}:
+        -h --help     Show this screen.
+        --version     Show version.
+        --foo={value} Description of foo.
+    USAGE
+
+    s.should eq <<-EXPECTED
+Usage:
+  blah [options...] {file}
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    EXPECTED
+
+    s = undent <<-HERE
+      Line #{1} is indented deeper
+    Line #{2} has shallow indent
+        Line #{3} deepest indent
+    HERE
+
+    s.should eq <<-EXPECTED
+  Line 1 is indented deeper
+Line 2 has shallow indent
+    Line 3 deepest indent
+    EXPECTED
+  end
+
+  it "ignores empty lines and white space only lines in string interpolation" do
+    section1 = "Usage"
+    name = "blah"
+    section2 = "Options"
+
+    s = undent <<-EMPTY_LINES
+
+      #{section1}:
+        #{name} [options...] {file}
+          
+      #{section2}:
+            
+        -h --help     Show this screen.
+
+        --version     Show version.
+
+        --foo={value} Description of foo.
+
+    EMPTY_LINES
+
+    s.should eq <<-EXPECTED
+
+Usage:
+  blah [options...] {file}
+    
+Options:
+      
+  -h --help     Show this screen.
+
+  --version     Show version.
+
+  --foo={value} Description of foo.
+
+    EXPECTED
+  end
+
+  it "does nothing on string which has no extra indent" do
+    s = undent <<-USAGE
+Usage:
+  blah [options...] {file}
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    USAGE
+
+    s.should eq <<-EXPECTED
+Usage:
+  blah [options...] {file}
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    EXPECTED
+
+    section1 = "Usage"
+    name = "blah"
+    section2 = "Options"
+
+    s = undent <<-USAGE
+#{section1}:
+  #{name} [options...] {file}
+#{section2}:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    USAGE
+
+    s.should eq <<-EXPECTED
+Usage:
+  blah [options...] {file}
+Options:
+  -h --help     Show this screen.
+  --version     Show version.
+  --foo={value} Description of foo.
+    EXPECTED
+  end
+
+  # TODO:
+  # Some tests should be added
+  #   - Expand with only empty lines
+  #   - Expand with neither StringLiteral nor StringInterpolation
+end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -63,6 +63,26 @@ macro assert_responds_to(var, method)
   end
 end
 
+# Remove extra indentation from multi-line string literals and string interpolations.
+#
+# ```
+# def usage
+#   undent <<-USAGE
+#     Usage: #       blah [options...] {file}
+#
+#     Options:
+#       -h --help     Show this screen.
+#       --version     Show version.
+#       --foo={value} Description of foo.
+#   USAGE
+# end
+#
+# puts usage
+# ```
+#
+# `undent` removes heading 5 white spaces of each lines.  With this macro, you can add indent
+# to your here document in order to keep your code clean.
+# This macro is heavily inspired by Homebrew's `String#undent` method.
 macro undent(str)
   {% if str.is_a? StringLiteral %}
     {% unless str.lines.all?{|l| l =~ /^ *$/ } %}


### PR DESCRIPTION
### Problem

When we used heredoc or multi-line string literals,  indentation was broken as below

```crystal
def usage
  <<-USAGE
Usage:  blah [options...] {file}

Options:
  -h --help     Show this screen.
  --version     Show version.
  --foo={value} Description of foo.
  USAGE
end

puts usage
```

in order not to include extra indentation in the string literal.

```
Usage: blah [options...] {file}

Options:
  -h --help     Show this screen.
  --version     Show version.
  --foo={value} Description of foo.
```

### Solution

To solve this problem, [Homebrew](https://github.com/Homebrew/homebrew) defines [`String#undent`](https://github.com/Homebrew/homebrew/blob/aeeee756752053b8ed5ce22da9d9ed6b4f15a825/Library/Homebrew/extend/string.rb#L2) method which removes the extra indentation.

I thought it was cool so implemented `undent()` macro in Crystal.  This PR improves above code as below.

```crystal
def usage
  undent <<-USAGE
    Usage:  blah [options...] {file}

    Options:
      -h --help     Show this screen.
      --version     Show version.
      --foo={value} Description of foo.
  USAGE
end

puts usage
```

I implemented this as macro because the size of extra indentation can be determined at compile time.  I'm C++ programmer hence I like avoiding runtime overhead.  I implemented this macro for `StringLiteral` and `StringInterpolation`.

I didn't use method-style macro because Crystal doesn't allow method call just after `<<-USAGE` (I think it is good design).  We must call it as below if it is method-style macro.

```crystal
def usage
  <<-USAGE
    Usage:  blah [options...] {file}

    Options:
      -h --help     Show this screen.
      --version     Show version.
      --foo={value} Description of foo.
  USAGE
    .undent
end
```

Just after `USAGE` is not also allowed and newline is necessary.

I also added test cases and simple documentation for `undent()`.
But tests are not complete because I don't know how to test the error case of macro expansion (How can we catch `{% raise %}`?).

And about naming.  I can't decide that `undent` is a suitable name for this because I'm not a native English speaker.  If there is more suitable name,  please let me know and I'll change the name.
