### PR TITLE
Reject request path containing '\0' character

### DIFF
--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -49,4 +49,12 @@ describe HTTP::StaticFileHandler do
       response.body.should eq(File.read("#{__DIR__}/static/test.txt"))
     end
   end
+
+  it "should return 400" do
+    handler = HTTP::StaticFileHandler.new "#{__DIR__}/static"
+    %w(%00 test.txt%00).each do |path|
+      response = handler.call HTTP::Request.new("GET", "/#{path}")
+      response.status_code.should eq(400)
+    end
+  end
 end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -9,6 +9,11 @@ class HTTP::StaticFileHandler < HTTP::Handler
   def call(request)
     request_path = URI.unescape(request.path.not_nil!)
     expanded_path = File.expand_path(request_path, "/")
+
+    # File path cannot contains '\0' (NUL) because all filesystem I know
+    # don't accept '\0' character as file name.
+    return HTTP::Response.new(400) if expanded_path.includes? '\0'
+
     file_path = File.join(@publicdir, expanded_path)
     if Dir.exists?(file_path)
       HTTP::Response.new(200, directory_listing(request_path, file_path), HTTP::Headers{"Content-Type": "text/html"})


### PR DESCRIPTION
Because all file system I know don't accept `'\0'` character as file name,
and Apache and Nginx and lighttpd and any server reject such a path.

Besides, see following code:

```crystal
require "http/server"

class CustomFileHandler < HTTP::StaticFileHandler
  def call(req)
    # serve PNG
    if req.path.not_nil!.ends_with? ".png"
      super
    else
      call_next req
    end
  end
end
```
customizing `HTTP::StaticFileHandler`, it has file traversal vulnerability if
path check suffix only. For example, when requested `GET /password.txt%00.png`,
custom handler serves `password.txt` content because `File.read` calls C API and
C string terminates with `'\0'` and `"/password.txt%00.png"` is unescaped to
`"/password.txt\0.png"`.