### PR TITLE
Remove heredoc indent based on the indentation of its last line

### DIFF
--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -185,11 +185,11 @@ describe "Lexer string" do
 
     tester.string_should_start_correctly
     tester.next_string_token_should_be("Hello, mom! I am HERE.")
-    tester.token_should_be_at(line: 1)
+    tester.token_should_be_at(line: 2)
     tester.next_string_token_should_be("\nHER dress is beautiful.")
-    tester.token_should_be_at(line: 1)
+    tester.token_should_be_at(line: 3)
     tester.next_string_token_should_be("\nHE is OK.")
-    tester.token_should_be_at(line: 1)
+    tester.token_should_be_at(line: 4)
     tester.string_should_end_correctly(false)
     tester.next_token_should_be(:NEWLINE)
     tester.token_should_be_at(line: 5, column: 5)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1038,6 +1038,17 @@ describe "Parser" do
   it_parses %("hello "\\\n"world"), StringLiteral.new("hello world")
   it_parses %("hello \#{1}" \\\n "\#{2} world"), StringInterpolation.new(["hello ".string, 1.int32, 2.int32, " world".string] of ASTNode)
   it_parses "<<-HERE\nHello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY\nHERE", "Hello, mom! I am HERE.\nHER dress is beautiful.\nHE is OK.\n  HERESY".string
+  it_parses "<<-HERE\n   One\n  Zero\n  HERE", " One\nZero".string
+  it_parses "<<-HERE\n   One\n\n  Zero\n  HERE", " One\n\nZero".string
+  it_parses "<<-HERE\n   One\n \n  Zero\n  HERE", " One\n\nZero".string
+  it_parses "<<-HERE\n   \#{1}One\n  \#{2}Zero\n  HERE", StringInterpolation.new([" ".string, 1.int32, "One\n".string, 2.int32, "Zero".string] of ASTNode)
+  it_parses "<<-HERE\n  foo\#{1}bar\n   baz\n  HERE", StringInterpolation.new(["foo".string, 1.int32, "bar\n".string, " baz".string] of ASTNode)
+  assert_syntax_error "<<-HERE\n   One\nwrong\n  Zero\n  HERE", "heredoc line must have an indent greater or equal than 2", 3, 1
+  assert_syntax_error "<<-HERE\n   One\n wrong\n  Zero\n  HERE", "heredoc line must have an indent greater or equal than 2", 3, 1
+  assert_syntax_error "<<-HERE\n   One\n \#{1}\n  Zero\n  HERE", "heredoc line must have an indent greater or equal than 2", 3, 1
+  assert_syntax_error "<<-HERE\n   One\n  \#{1}\n wrong\n  HERE", "heredoc line must have an indent greater or equal than 2", 4, 1
+  assert_syntax_error "<<-HERE\n   One\n  \#{1}\n wrong\#{1}\n  HERE", "heredoc line must have an indent greater or equal than 2", 4, 1
+  assert_syntax_error "<<-HERE\n One\n  \#{1}\n  HERE", "heredoc line must have an indent greater or equal than 2", 2, 1
   assert_syntax_error %("foo" "bar")
 
   it_parses "enum Foo; A\nB, C\nD = 1; end", EnumDef.new("Foo".path, [Arg.new("A"), Arg.new("B"), Arg.new("C"), Arg.new("D", 1.int32)] of ASTNode)

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -23,15 +23,27 @@ module Crystal
       property whitespace
     end
 
-    record DelimiterState, kind, nest, :end, open_count
+    record DelimiterState, kind, nest, :end, open_count, heredoc_indent
 
     struct DelimiterState
       def self.default
-        DelimiterState.new(:string, '\0', '\0', 0)
+        DelimiterState.new(:string, '\0', '\0', 0, 0)
+      end
+
+      def self.new(kind, nest, the_end)
+        new kind, nest, the_end, 0, 0
+      end
+
+      def self.new(kind, nest, the_end, open_count)
+        new kind, nest, the_end, open_count, 0
       end
 
       def with_open_count_delta(delta)
-        DelimiterState.new(@kind, @nest, @end, @open_count + delta)
+        DelimiterState.new(@kind, @nest, @end, @open_count + delta, @heredoc_indent)
+      end
+
+      def with_heredoc_indent(indent)
+        DelimiterState.new(@kind, @nest, @end, @open_count, indent)
       end
     end
 


### PR DESCRIPTION
As discusses in #2025, this changes the current semantic of heredoc to remove N leading spaces from all its lines, where N is the indentation of the last line. For example:

```crystal
# "Hello"
<<-FOO
Hello
FOO

# "  Hello"
<<-FOO
  Hello
FOO

# "  Hello"
<<-FOO
    Hello
  FOO

# Error!
<<-FOO
 Hello
  FOO
```

This is better than the rule of using the least indented line, because, as can be seen, it allows leading spaces in some lines.