### PR TITLE
Code styling fix: Indent heredocs for more readable code.

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -9,32 +9,32 @@ end
 
 class Crystal::Command
   USAGE = <<-USAGE
-Usage: crystal [command] [switches] [program file] [--] [arguments]
+    Usage: crystal [command] [switches] [program file] [--] [arguments]
 
-Command:
-    init                     generate a new project
-    build                    compile program
-    deps                     install project dependencies
-    docs                     generate documentation
-    eval                     eval code from args or standard input
-    run (default)            compile and run program
-    spec                     compile and run specs (in spec directory)
-    tool                     run a tool
-    help, --help, -h         show this help
-    version, --version, -v   show version
-USAGE
+    Command:
+        init                     generate a new project
+        build                    compile program
+        deps                     install project dependencies
+        docs                     generate documentation
+        eval                     eval code from args or standard input
+        run (default)            compile and run program
+        spec                     compile and run specs (in spec directory)
+        tool                     run a tool
+        help, --help, -h         show this help
+        version, --version, -v   show version
+    USAGE
 
   COMMANDS_USAGE = <<-USAGE
-Usage: crystal tool [tool] [switches] [program file] [--] [arguments]
+    Usage: crystal tool [tool] [switches] [program file] [--] [arguments]
 
-Tool:
-    context                  show context for given location
-    format                   format project, directories and/or files
-    hierarchy                show type hierarchy
-    implementations          show implementations for given call in location
-    types                    show type of main variables
-    --help, -h               show this help
-USAGE
+    Tool:
+        context                  show context for given location
+        format                   format project, directories and/or files
+        hierarchy                show type hierarchy
+        implementations          show implementations for given call in location
+        types                    show type of main variables
+        --help, -h               show this help
+    USAGE
 
   VALID_EMIT_VALUES = %w(asm llvm-bc llvm-ir obj)
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -9,19 +9,21 @@ module Crystal
       config = Config.new
 
       OptionParser.parse(args) do |opts|
-        opts.banner = %{USAGE: crystal init TYPE NAME [DIR]
+        opts.banner = <<-USAGE
+          Usage: crystal init TYPE NAME [DIR]
 
-TYPE is one of:
-    lib                      creates library skeleton
-    app                      creates application skeleton
+          TYPE is one of:
+              lib                      creates library skeleton
+              app                      creates application skeleton
 
-NAME - name of project to be generated,
-       eg: example
-DIR  - directory where project will be generated,
-       default: NAME, eg: ./custom/path/example
-}
+          NAME - name of project to be generated,
+                 eg: example
+          DIR  - directory where project will be generated,
+                 default: NAME, eg: ./custom/path/example
 
-        opts.on("--help", "Shows this message") do
+          USAGE
+
+        opts.on("--help", "show this help") do
           puts opts
           exit
         end


### PR DESCRIPTION
Since heredocs support indentation, they do not have to have 0 indent which makes the code a bit unreadable.