### PR TITLE
fix json default case

### DIFF
--- a/spec/std/json/mapping_spec.cr
+++ b/spec/std/json/mapping_spec.cr
@@ -237,6 +237,16 @@ describe "JSON mapping" do
       typeof(json.c).should eq Bool
       json.d.should eq false
       typeof(json.d).should eq Bool
+
+      json = JsonWithDefaults.from_json(%({"c":false}))
+      json.c.should eq false
+      json = JsonWithDefaults.from_json(%({"c":true}))
+      json.c.should eq true
+
+      json = JsonWithDefaults.from_json(%({"d":false}))
+      json.d.should eq false
+      json = JsonWithDefaults.from_json(%({"d":true}))
+      json.d.should eq true
     end
 
     it "with nilable" do
@@ -250,6 +260,11 @@ describe "JSON mapping" do
 
       json.g.should eq nil
       typeof(json.g).should eq(Int32 | Nil)
+
+      json = JsonWithDefaults.from_json(%({"e":false}))
+      json.e.should eq false
+      json = JsonWithDefaults.from_json(%({"e":true}))
+      json.e.should eq true
     end
 
     it "create new array every time" do

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -99,8 +99,8 @@ module JSON
       end
 
       {% for key, value in properties %}
-        %temp = if !%var{key.id}.is_a?(Nil)
-          %var{key.id}.not_nil!
+        @{{key.id}} = if !%var{key.id}.is_a?(Nil)
+          %var{key.id}{% if !value[:nilable] %}.not_nil! {% end %}
         else
           {% if value[:default] != nil %}
             {{ value[:default] }}
@@ -108,8 +108,6 @@ module JSON
             raise JSON::ParseException.new("missing json attribute: {{(value[:key] || key).id}}", 0, 0)
           {% end %}
         end
-
-        @{{key.id}} = {% if value[:nilable] %} (1 == 1) ? {% end %} %temp {% if value[:nilable] %} : nil {% end %}
       {% end %}
     end
 

--- a/src/json/mapping.cr
+++ b/src/json/mapping.cr
@@ -99,15 +99,17 @@ module JSON
       end
 
       {% for key, value in properties %}
-        {% unless value[:nilable] || value[:default] != nil %}
-          if %var{key.id}.is_a?(Nil)
+        %temp = if !%var{key.id}.is_a?(Nil)
+          %var{key.id}.not_nil!
+        else
+          {% if value[:default] != nil %}
+            {{ value[:default] }}
+          {% elsif !value[:nilable] %}
             raise JSON::ParseException.new("missing json attribute: {{(value[:key] || key).id}}", 0, 0)
-          end
-        {% end %}
-      {% end %}
+          {% end %}
+        end
 
-      {% for key, value in properties %}
-        @{{key.id}} = {% if value[:nilable] %} (1 == 1) ? {% end %} %var{key.id} {% if value[:default] != nil %} || {{ value[:default] }} {% end %} {% if value[:nilable] %} : nil {% end %}
+        @{{key.id}} = {% if value[:nilable] %} (1 == 1) ? {% end %} %temp {% if value[:nilable] %} : nil {% end %}
       {% end %}
     end
 


### PR DESCRIPTION
fix missing case:
```ruby
require "json"

class A
  JSON.mapping({
    a: {type: Bool, default: true}
  })
end

p A.from_json(%({"a": false}))
```
