### PR TITLE
Make macros property, getter, setter, etc., declare instance variables

### DIFF
--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -121,29 +121,29 @@ module Benchmark
 
       # Number of cycles needed to run for approx 100ms
       # Calculated during the warmup stage
-      property! cycles : Int
+      property! cycles : Int32
 
       # Number of 100ms runs during the calculation stage
-      property! size : Int
+      property! size : Int32
 
       # Statistcal mean from calculation stage
-      property! mean : Float
+      property! mean : Float64
 
       # Statistcal variance from calculation stage
-      property! variance : Float
+      property! variance : Float64
 
       # Statistcal standard deviation from calculation stage
-      property! stddev : Float
+      property! stddev : Float64
 
       # Relative standard deviation as a percentage
-      property! relative_stddev : Float
+      property! relative_stddev : Float64
 
       # Multiple slower than the fastest entry
-      property! slower : Float
+      property! slower : Float64
 
       @ran = false
 
-      def initialize(@label, @action)
+      def initialize(@label, @action : ->)
       end
 
       def ran?

--- a/src/object.cr
+++ b/src/object.cr
@@ -197,9 +197,33 @@ class Object
   #   getter :name, "age"
   # end
   # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type.
+  #
+  # ```
+  # class Person
+  #   getter name : String
+  # end
+  # ```
+  #
+  # Is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @name : String
+  #
+  #   def name
+  #     @name
+  #   end
+  # end
+  # ```
   macro getter(*names)
     {% for name in names %}
-      {% name = name.var if name.is_a?(TypeDeclaration) %}
+      {% if name.is_a?(TypeDeclaration) %}
+        @{{name.id}}
+        {% name = name.var %}
+      {% end %}
 
       def {{name.id}}
         @{{name.id}}
@@ -238,9 +262,37 @@ class Object
   #   getter! :name, "age"
   # end
   # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type, as nilable.
+  #
+  # ```
+  # class Person
+  #   getter! name : String
+  # end
+  # ```
+  #
+  # is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @name : String?
+  #
+  #   def name?
+  #     @name
+  #   end
+  #
+  #   def name
+  #     @name.not_nil!
+  #   end
+  # end
+  # ```
   macro getter!(*names)
     {% for name in names %}
-      {% name = name.var if name.is_a?(TypeDeclaration) %}
+      {% if name.is_a?(TypeDeclaration) %}
+        @{{name}}?
+        {% name = name.var %}
+      {% end %}
 
       def {{name.id}}?
         @{{name.id}}
@@ -258,7 +310,7 @@ class Object
   #
   # ```
   # class Person
-  #   getter? name
+  #   getter? happy
   # end
   # ```
   #
@@ -266,8 +318,8 @@ class Object
   #
   # ```
   # class Person
-  #   def name?
-  #     @name
+  #   def happy?
+  #     @happy
   #   end
   # end
   # ```
@@ -276,12 +328,36 @@ class Object
   #
   # ```
   # class Person
-  #   getter? :name, "age"
+  #   getter? :happy, "famous"
+  # end
+  # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type.
+  #
+  # ```
+  # class Person
+  #   getter? happy : Bool
+  # end
+  # ```
+  #
+  # is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @happy : Bool
+  #
+  #   def happy?
+  #     @happy
+  #   end
   # end
   # ```
   macro getter?(*names)
     {% for name in names %}
-      {% name = name.var if name.is_a?(TypeDeclaration) %}
+      {% if name.is_a?(TypeDeclaration) %}
+        @{{name}}?
+        {% name = name.var %}
+      {% end %}
 
       def {{name.id}}?
         @{{name.id}}
@@ -315,9 +391,30 @@ class Object
   #   setter :name, "age"
   # end
   # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type.
+  #
+  # ```
+  # class Person
+  #   setter name : String
+  # end
+  # ```
+  #
+  # is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @name : String
+  #
+  #   def name=(@name)
+  #   end
+  # end
+  # ```
   macro setter(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
+        @{{name}}
         def {{name.var.id}}=(@{{name.var.id}} : {{name.type}})
         end
       {% else %}
@@ -355,6 +452,30 @@ class Object
   # ```
   # class Person
   #   property :name, "age"
+  # end
+  # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type.
+  #
+  # ```
+  # class Person
+  #   property name : String
+  # end
+  # ```
+  #
+  # Is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @name : String
+  #
+  #   def name=(@name)
+  #   end
+  #
+  #   def name
+  #     @name
+  #   end
   # end
   # ```
   macro property(*names)
@@ -396,9 +517,46 @@ class Object
   #   property! :name, "age"
   # end
   # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type, as nilable.
+  #
+  # ```
+  # class Person
+  #   property! name : String
+  # end
+  # ```
+  #
+  # Is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @name : String?
+  #
+  #   def name=(@name)
+  #   end
+  #
+  #   def name?
+  #     @name
+  #   end
+  #
+  #   def name
+  #     @name.not_nil!
+  #   end
+  # end
+  # ```
   macro property!(*names)
     getter! {{*names}}
-    setter {{*names}}
+
+    {% for name in names %}
+      {% if name.is_a?(TypeDeclaration) %}
+        def {{name.var.id}}=(@{{name.var.id}} : {{name.type}})
+        end
+      {% else %}
+        def {{name.id}}=(@{{name.id}})
+        end
+      {% end %}
+    {% end %}
   end
 
   # Defines query property methods for each of the given arguments.
@@ -407,7 +565,7 @@ class Object
   #
   # ```
   # class Person
-  #   property? name
+  #   property? happy
   # end
   # ```
   #
@@ -415,11 +573,11 @@ class Object
   #
   # ```
   # class Person
-  #   def name=(@name)
+  #   def happy=(@happy)
   #   end
   #
-  #   def name?
-  #     @name
+  #   def happy?
+  #     @happy
   #   end
   # end
   # ```
@@ -428,7 +586,35 @@ class Object
   #
   # ```
   # class Person
-  #   property? :name, "age"
+  #   property? :happy, "famous"
+  # end
+  # ```
+  #
+  # If a type declaration is given, an instance variable with that name
+  # is declared with that type.
+  #
+  # ```
+  # class Person
+  #   property? happy : Bool
+  # end
+  # ```
+  #
+  # Is the same as writing:
+  #
+  # ```
+  # class Person
+  #   @happy : Bool
+  #
+  #   def happy=(@happy)
+  #   end
+  #
+  #   def happy?
+  #     @happy
+  #   end
+  #
+  #   def happy
+  #     @happy.not_nil!
+  #   end
   # end
   # ```
   macro property?(*names)


### PR DESCRIPTION
Right now if you do:

```crystal
class Person
  property name : String
end
```

It expands to:

```crystal
class Person
  def name=(@name : String)
  end

  def name
    @name
  end
end
```

But since the name can only be set a String, it makes sense to restrict the type of the instance variable. So this PR changes that to expand it to:

```crystal
class Person
  @name : String

  def name=(@name : String)
  end

  def name
    @name
  end
end
```

The same applies to getter, setter and the other variants. The only thing to notice is that if you use `property!` or `getter!`, that will declare the type as nilable (check the changes and docs).

This also gets us a bit closer to mandatory types in instance variables: if you do use one of these macros the most natural place to write the type restriction is there. It also makes for more understandable code, as seen [here](https://github.com/manastech/crystal/blob/property_getter_setter_type_restrictions/src/benchmark/ips.cr#L115-L142).