### PR TITLE
Introduce YAML::Any and return it in YAML.parse (renamed from YAML.load)

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -85,16 +85,15 @@ dependencies:
     end
 
     describe_file "example/shard.yml" do |shard_yml|
-      parsed = YAML.load(shard_yml) as Hash
+      parsed = YAML.parse(shard_yml)
       parsed["name"].should eq("example")
       parsed["version"].should eq("0.1.0")
-      authors = (parsed["authors"] as Array)
-      authors.should eq(["John Smith <john@smith.com>"])
+      parsed["authors"].should eq(["John Smith <john@smith.com>"])
       parsed["license"].should eq("MIT")
     end
 
     describe_file "example/.travis.yml" do |travis|
-      parsed = YAML.load(travis) as Hash
+      parsed = YAML.parse(travis)
 
       parsed["language"].should eq("crystal")
     end

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -1,0 +1,89 @@
+require "spec"
+require "yaml"
+
+describe YAML::Any do
+  describe "casts" do
+    it "gets nil" do
+      YAML.parse("").as_nil.should be_nil
+    end
+
+    it "gets string" do
+      YAML.parse("hello").as_s.should eq("hello")
+    end
+
+    it "gets array" do
+      YAML.parse("- foo\n- bar\n").as_a.should eq(["foo", "bar"])
+    end
+
+    it "gets hash" do
+      YAML.parse("foo: bar").as_h.should eq({"foo": "bar"})
+    end
+  end
+
+  describe "#size" do
+    it "of array" do
+      YAML.parse("- foo\n- bar\n").size.should eq(2)
+    end
+
+    it "of hash" do
+      YAML.parse("foo: bar").size.should eq(1)
+    end
+  end
+
+  describe "#[]" do
+    it "of array" do
+      YAML.parse("- foo\n- bar\n")[1].raw.should eq("bar")
+    end
+
+    it "of hash" do
+      YAML.parse("foo: bar")["foo"].raw.should eq("bar")
+    end
+  end
+
+  describe "#[]?" do
+    it "of array" do
+      YAML.parse("- foo\n- bar\n")[1]?.not_nil!.raw.should eq("bar")
+      YAML.parse("- foo\n- bar\n")[3]?.should be_nil
+    end
+
+    it "of hash" do
+      YAML.parse("foo: bar")["foo"]?.not_nil!.raw.should eq("bar")
+      YAML.parse("foo: bar")["fox"]?.should be_nil
+    end
+  end
+
+  describe "each" do
+    it "of array" do
+      elems = [] of String
+      YAML.parse("- foo\n- bar\n").each do |any|
+        elems << any.as_s
+      end
+      elems.should eq(%w(foo bar))
+    end
+
+    it "of hash" do
+      elems = [] of String
+      YAML.parse("foo: bar").each do |key, value|
+        elems << key.to_s << value.to_s
+      end
+      elems.should eq(%w(foo bar))
+    end
+  end
+
+  it "traverses big structure" do
+    obj = YAML.parse("--- \nfoo: \n  bar: \n    baz: \n      - qux\n      - fox")
+    obj["foo"]["bar"]["baz"][1].as_s.should eq("fox")
+  end
+
+  it "compares to other objects" do
+    obj = YAML.parse("- foo\n- bar \n")
+    obj.should eq(%w(foo bar))
+    obj[0].should eq("foo")
+  end
+
+  it "returns array of any when doing parse all" do
+    docs = YAML.parse_all("---\nfoo\n---\nbar\n")
+    docs[0].as_s.should eq("foo")
+    docs[1].as_s.should eq("bar")
+  end
+end

--- a/spec/std/yaml/mapping_spec.cr
+++ b/spec/std/yaml/mapping_spec.cr
@@ -53,6 +53,15 @@ class YAMLWithDefaults
   })
 end
 
+class YAMLWithAny
+  YAML.mapping({
+    obj: YAML::Any,
+  })
+
+  def initialize(@obj)
+  end
+end
+
 describe "YAML mapping" do
   it "parses person" do
     person = YAMLPerson.from_yaml("---\nname: John\nage: 30\n")
@@ -120,7 +129,7 @@ describe "YAML mapping" do
     yaml.pull.should eq(2)
   end
 
-  describe "parses json with defaults" do
+  describe "parses YAML with defaults" do
     it "mixed" do
       json = YAMLWithDefaults.from_yaml(%({"a":1,"b":"bla"}))
       json.a.should eq 1
@@ -189,5 +198,16 @@ describe "YAML mapping" do
       json = YAMLWithDefaults.from_yaml(%({}))
       json.h.should eq [1, 2, 3]
     end
+  end
+
+  it "parses YAML with any" do
+    yaml = YAMLWithAny.from_yaml("obj: hello")
+    yaml.obj.as_s.should eq("hello")
+
+    yaml = YAMLWithAny.from_yaml({obj: %w(foo bar)}.to_yaml)
+    yaml.obj[1].as_s.should eq("bar")
+
+    yaml = YAMLWithAny.from_yaml({obj: {foo: :bar}}.to_yaml)
+    yaml.obj["foo"].as_s.should eq("bar")
   end
 end

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -3,30 +3,30 @@ require "yaml"
 
 describe "YAML" do
   describe "parser" do
-    assert { YAML.load("foo").should eq("foo") }
-    assert { YAML.load("- foo\n- bar").should eq(["foo", "bar"]) }
-    assert { YAML.load_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
-    assert { YAML.load("foo: bar").should eq({"foo" => "bar"}) }
-    assert { YAML.load("--- []\n").should eq([] of YAML::Type) }
-    assert { YAML.load("---\n...").should eq("") }
+    assert { YAML.parse("foo").should eq("foo") }
+    assert { YAML.parse("- foo\n- bar").should eq(["foo", "bar"]) }
+    assert { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
+    assert { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
+    assert { YAML.parse("--- []\n").should eq([] of YAML::Type) }
+    assert { YAML.parse("---\n...").should eq("") }
 
     it "parses recursive sequence" do
-      doc = YAML.load("--- &foo\n- *foo\n") as Array
-      doc[0].should be(doc)
+      doc = YAML.parse("--- &foo\n- *foo\n")
+      doc[0].raw.should be(doc.raw)
     end
 
     it "parses recursive mapping" do
-      doc = YAML.load(%(--- &1
+      doc = YAML.parse(%(--- &1
         friends:
         - *1
-        )) as Hash
-      (doc["friends"] as Array)[0].should be(doc)
+        ))
+      doc["friends"][0].raw.should be(doc.raw)
     end
 
     it "parses alias to scalar" do
-      doc = YAML.load("---\n- &x foo\n- *x\n") as Array
+      doc = YAML.parse("---\n- &x foo\n- *x\n")
       doc.should eq(["foo", "foo"])
-      doc[0].should be(doc[1])
+      doc[0].raw.should be(doc[1].raw)
     end
   end
 

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -1,0 +1,190 @@
+# `YAML::Any` is a convenient wrapper around all possible YAML types (`YAML::Type`)
+# and can be used for traversing dynamic or unknown YAML structures.
+#
+# ```
+# require "yaml"
+#
+# data = YAML.parse <<-END
+#          ---
+#          foo:
+#            bar:
+#              baz:
+#                - qux
+#                - fox
+#          END
+# data["foo"]["bar"]["baz"][1].as_s # => "qux"
+# data["foo"]["bar"]["baz"].as_a    # => ["qux", "fox"]
+# ```
+#
+# Note that methods used to traverse a YAML structure, `#[]`, `#[]?` and `#each`,
+# always return a `YAML::Any` to allow further traversal. To convert them to `String`,
+# `Array`, etc., use the "as_" methods, such as `#as_s`, `#as_a`, which perform
+# a type check against the raw underlying value. This means that invoking `#as_s`
+# when the underlying value is not a String will raise: the value won't automatically
+# be converted (parsed) to a String.
+struct YAML::Any
+  # Reads a `YAML::Any` value from the given pull parser.
+  def self.new(pull : YAML::PullParser)
+    case pull.kind
+    when .scalar?
+      new pull.read_scalar
+    when .sequence_start?
+      ary = [] of Type
+      pull.read_sequence do
+        while pull.kind != YAML::EventKind::SEQUENCE_END
+          ary << new(pull).raw
+        end
+      end
+      new ary
+    when .mapping_start?
+      hash = {} of Type => Type
+      pull.read_mapping do
+        while pull.kind != YAML::EventKind::MAPPING_END
+          hash[new(pull).raw] = new(pull).raw
+        end
+      end
+      new hash
+    else
+      raise "Unknown pull kind: #{pull.kind}"
+    end
+  end
+
+  # Returns the raw underlying value, a `YAML::Type`.
+  getter raw
+
+  # Creates a `YAML::Any` that wraps the given `YAML::Type`.
+  def initialize(@raw : YAML::Type)
+  end
+
+  # Assumes the underlying value is an `Array` or `Hash` and returns
+  # its size.
+  # Raises if the underlying value is not an `Array` or `Hash`.
+  def size : Int
+    case object = @raw
+    when Array
+      object.size
+    when Hash
+      object.size
+    else
+      raise "expected Array or Hash for #size, not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an Array and returns the element
+  # at the given index.
+  # Raises if the underlying value is not an Array.
+  def [](index : Int) : YAML::Any
+    case object = @raw
+    when Array
+      Any.new object[index]
+    else
+      raise "expected Array for #[](index : Int), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an Array and returns the element
+  # at the given index, or nil if out of bounds.
+  # Raises if the underlying value is not an Array.
+  def []?(index : Int) : YAML::Any?
+    case object = @raw
+    when Array
+      value = object[index]?
+      value ? Any.new(value) : nil
+    else
+      raise "expected Array for #[]?(index : Int), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is a Hash and returns the element
+  # with the given key.
+  # Raises if the underlying value is not a Hash.
+  def [](key : String) : YAML::Any
+    case object = @raw
+    when Hash
+      Any.new object[key]
+    else
+      raise "expected Hash for #[](key : String), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is a Hash and returns the element
+  # with the given key, or nil if the key is not present.
+  # Raises if the underlying value is not a Hash.
+  def []?(key : String) : YAML::Any?
+    case object = @raw
+    when Hash
+      value = object[key]?
+      value ? Any.new(value) : nil
+    else
+      raise "expected Hash for #[]?(key : String), not #{object.class}"
+    end
+  end
+
+  # Assumes the underlying value is an `Array` or `Hash` and yields each
+  # of the elements or key/values, always as `YAML::Any`.
+  # Raises if the underlying value is not an `Array` or `Hash`.
+  def each
+    case object = @raw
+    when Array
+      object.each do |elem|
+        yield Any.new(elem), Any.new(nil)
+      end
+    when Hash
+      object.each do |key, value|
+        yield Any.new(key), Any.new(value)
+      end
+    else
+      raise "expected Array or Hash for #each, not #{object.class}"
+    end
+  end
+
+  # Checks that the underlying value is `Nil`, and returns `nil`. Raises otherwise.
+  def as_nil : Nil
+    @raw as Nil
+  end
+
+  # Checks that the underlying value is `String`, and returns its value. Raises otherwise.
+  def as_s : String
+    @raw as String
+  end
+
+  # Checks that the underlying value is `Array`, and returns its value. Raises otherwise.
+  def as_a : Array(Type)
+    @raw as Array
+  end
+
+  # Checks that the underlying value is `Hash`, and returns its value. Raises otherwise.
+  def as_h : Hash(Type, Type)
+    @raw as Hash
+  end
+
+  # :nodoc:
+  def inspect(io)
+    @raw.inspect(io)
+  end
+
+  # :nodoc:
+  def to_s(io)
+    @raw.to_s(io)
+  end
+
+  # Returns true if both `self` and *other*'s raw object are equal.
+  def ==(other : YAML::Any)
+    raw == other.raw
+  end
+
+  # Returns true if the raw object is equal to *other*.
+  def ==(other)
+    raw == other
+  end
+
+  # :nodoc:
+  def hash
+    raw.hash
+  end
+
+  # :nodoc:
+  def to_yaml(io)
+    raw.to_yaml(io)
+  end
+end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -9,13 +9,13 @@ class YAML::Parser
   end
 
   def parse_all
-    documents = [] of YAML::Type
+    documents = [] of YAML::Any
     loop do
       case @pull_parser.read_next
       when EventKind::STREAM_END
         return documents
       when EventKind::DOCUMENT_START
-        documents << parse_document
+        documents << YAML::Any.new(parse_document)
       else
         unexpected_event
       end
@@ -23,14 +23,15 @@ class YAML::Parser
   end
 
   def parse
-    case @pull_parser.read_next
-    when EventKind::STREAM_END
-      nil
-    when EventKind::DOCUMENT_START
-      parse_document
-    else
-      unexpected_event
-    end
+    value = case @pull_parser.read_next
+            when EventKind::STREAM_END
+              nil
+            when EventKind::DOCUMENT_START
+              parse_document
+            else
+              unexpected_event
+            end
+    YAML::Any.new(value)
   end
 
   def parse_document

--- a/src/yaml/yaml.cr
+++ b/src/yaml/yaml.cr
@@ -2,17 +2,24 @@ require "./*"
 
 # The YAML module provides serialization and deserialization of YAML to/from native Crystal data structures.
 #
-# ### Parsing with `#load` and `#load_all`
+# ### Parsing with `#parse` and `#parse_all`
 #
-# Deserializes a YAML document into a `Type`.
-# A `Type` is a union of all possible YAML types, so casting to a specific type is necessary
-# before the value is practically usable.
+# `YAML#parse` will return an `Any`, which is a convenient wrapper around all possible YAML types,
+# making it easy to traverse a complex YAML structure but requires some casts from time to time,
+# mostly via some method invocations.
 #
 # ```crystal
 # require "yaml"
 #
-# data = YAML.load("foo: bar")
-# (data as Hash)["foo"] # => "bar"
+# data = YAML.parse <<-END
+#          ---
+#          foo:
+#            bar:
+#              baz:
+#                - qux
+#                - fox
+#          END
+# data["foo"]["bar"]["baz"][1].as_s # => "qux"
 # ```
 #
 # ### Parsing with `YAML#mapping`
@@ -64,7 +71,8 @@ module YAML
   #
   # ```crystal
   # require "yaml"
-  # YAML.load(File.read("./foo.yml"))
+  #
+  # YAML.parse(File.read("./foo.yml"))
   # # => {
   # # => "data" => {
   # # => "string" => "foobar",
@@ -73,7 +81,7 @@ module YAML
   # # => "paragraph" => "foo\nbar\n"
   # # => }
   # ```
-  def self.load(data : String)
+  def self.parse(data : String) : Any
     parser = YAML::Parser.new(data)
     begin
       parser.parse
@@ -93,10 +101,11 @@ module YAML
   #
   # ```crystal
   # require "yaml"
-  # YAML.load_all(File.read("./foo.yml"))
+  #
+  # YAML.parse_all(File.read("./foo.yml"))
   # # => [{"foo" => "bar"}, {"hello" => "world"}]
   # ```
-  def self.load_all(data : String)
+  def self.parse_all(data : String) : Array(Any)
     parser = YAML::Parser.new(data)
     begin
       parser.parse_all


### PR DESCRIPTION
This change is similar to #1832 but from YAML instead of JSON.

This is a breaking change, but I think it's the way to go. It makes it super simple to traverse random YAML structures with minimal casting methods. Unlike JSON::Any, YAML::Any only knows about Array, Hash and String. This might improve in the future if and when we support YAML schemas.

Additionally, `YAML::Any` can be used with `YAML.mapping`, just like with `JSON.mapping`.

Finally, `YAML.load` and `YAML.load_all` were renamed to `YAML.parse` and `YAML.parse_all` to match `JSON.parse` so we keep consistency.