### PR TITLE
Minor tweak to Deflate close requirement

### DIFF
--- a/src/zlib/deflate.cr
+++ b/src/zlib/deflate.cr
@@ -3,8 +3,8 @@
 # Instances of this class wrap another IO object. When you write to this
 # instance, it compresses the data and writes it to the underlying IO.
 #
-# **Note**: for correct behavior, `close` must be invoked after all data
-# has been written to a Zlib::Deflate instance.
+# **Note**: unless created with a block, `close` must be invoked after all
+# data has been written to a Zlib::Deflate instance.
 #
 # ### Example: compress a file
 #


### PR DESCRIPTION
Attempt to match example with documentation to avoid confusion on
*why* `close` was not invoked even when the note stated it was
required.