### PR TITLE
HTTP::Headers#merge! returns self

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -121,4 +121,9 @@ describe HTTP::Headers do
     headers = HTTP::Headers{"Foo_quux": "bar", "Baz-Quux": ["a", "b"]}
     headers.to_s.should eq(%(HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}))
   end
+
+  it "merges and return self" do
+    headers = HTTP::Headers.new
+    headers.should be headers.merge!({"foo": "bar"})
+  end
 end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -120,6 +120,7 @@ struct HTTP::Headers
     other.each do |key, value|
       self[wrap(key)] = value
     end
+    self
   end
 
   def ==(other : self)
@@ -172,6 +173,10 @@ struct HTTP::Headers
 
   def clone
     dup
+  end
+
+  def same?(other : HTTP::Headers)
+    object_id == other.object_id
   end
 
   def to_s(io : IO)


### PR DESCRIPTION
I think, that better. For example:
```crystal
HTTP::Client.exec(
  "GET",
  "http://example.org/",
  HTTP::Headers.new.merge!({"User-Agent": "Foo-Bar"}) # or parent method Hash-parameter
)
```
But now I must do:
```crystal
http_headers = HTTP::Headers.new
http_headers.merge!({"User-Agent": "Foo-Bar"})
HTTP::Client.exec(
  "GET",
  "http://example.org/",
  http_headers
)
```