### PR TITLE
Enhanced proc mangling

### DIFF
--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -104,22 +104,7 @@ module Crystal
         end
       end
 
-      # Windows only allows alphanumeric, dot, dollar and underscore
-      # for mangled names.
-      ifdef windows
-        name = name.gsub do |char|
-          case char
-          when '<', '>', '(', ')', '*', ':', ',', '#', ' '
-            "."
-          when '+'
-            ".."
-          else
-            char
-          end
-        end
-      end
-
-      name
+      Crystal.safe_mangling(name)
     end
 
     def varargs

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -709,7 +709,7 @@ class Crystal::Call
           a_def = Def.new("->", fun_args, block.body)
           a_def.captured_block = true
 
-          fun_literal = FunLiteral.new(a_def)
+          fun_literal = FunLiteral.new(a_def).at(self)
           fun_literal.force_void = true unless block_arg_restriction_output
           fun_literal.accept parent_visitor
         end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -24,15 +24,19 @@ module Crystal
       to_s(io)
     end
 
-    def original_filename
+    def original_location
       case filename = @filename
       when String
-        filename
+        self
       when VirtualFile
-        filename.expanded_location.try &.original_filename
+        filename.expanded_location.try &.original_location
       else
         nil
       end
+    end
+
+    def original_filename
+      original_location.try &.filename
     end
 
     def inspect


### PR DESCRIPTION
Given this code:

```crystal
# This is foo.cr
proc = ->(x : Int32) do
  if x == 1
    raise "OH NO!"
  end
  x + 2
end

proc.call(1)
```

Output before this PR:

```
OH NO! (Exception)
[4459731250] *CallStack::unwind:Array(Pointer(Void)) +82
[4459731153] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
[4459731112] *CallStack::new:CallStack +40
[4459733825] *Exception#initialize<Exception, String, Nil>:CallStack +33
[4459733756] *Exception::new<String>:Exception +92
[4459718761] *raise<String>:NoReturn +9
[4459725746] ~fun_literal_21 +34
[4459718374] __crystal_main +2374
[4459725560] main +40
```

With this PR:

```
OH NO! (Exception)
[4547955026] *CallStack::unwind:Array(Pointer(Void)) +82
[4547954929] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
[4547954888] *CallStack::new:CallStack +40
[4547957601] *Exception#initialize<Exception, String, Nil>:CallStack +33
[4547957532] *Exception::new<String>:Exception +92
[4547943113] *raise<String>:NoReturn +9
[4547949522] ~proc(Int32 -> Int32)@./foo.cr:2 +34
[4547942150] __crystal_main +2374
[4547949336] main +40
```

Note that the backtrace line for the proc has the type of the proc, filename and line number :-)

Since a name can be duplicated, as in the example below, we just add an increasing number to distinguish them:

```crystal
def foo(z)
  ->(x : Int32) do
    if x == 1
      raise "OH NO!"
    end
    x + 2
  end
end

begin
  foo(1).call(1)
rescue ex
  puts ex.inspect_with_backtrace
end

begin
  foo(1.5).call(1)
rescue ex
  puts ex.inspect_with_backtrace
end
```

Output:

```
OH NO! (Exception)
[4448441202] *CallStack::unwind:Array(Pointer(Void)) +82
[4448441105] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
[4448441064] *CallStack::new:CallStack +40
[4448443777] *Exception#initialize<Exception, String, Nil>:CallStack +33
[4448443708] *Exception::new<String>:Exception +92
[4448428729] *raise<String>:NoReturn +9
[4448435202] ~proc(Int32 -> Int32)@./foo.cr:2 +34
[4448427480] __crystal_main +2360
[4448434968] main +40
OH NO! (Exception)
[4448441202] *CallStack::unwind:Array(Pointer(Void)) +82
[4448441105] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
[4448441064] *CallStack::new:CallStack +40
[4448443777] *Exception#initialize<Exception, String, Nil>:CallStack +33
[4448443708] *Exception::new<String>:Exception +92
[4448428729] *raise<String>:NoReturn +9
[4448435410] ~proc2(Int32 -> Int32)@./foo.cr:2 +34
[4448427618] __crystal_main +2498
[4448434968] main +40
```

For captured blocks, the file and line number are of call related to the block:

```crystal
def foo(&block)
  block
end

f = foo do
  raise "OH NO!"
end
f.call
```

Output:

```
OH NO! (Exception)
[4408465698] *CallStack::unwind:Array(Pointer(Void)) +82
[4408465601] *CallStack#initialize<CallStack>:Array(Pointer(Void)) +17
[4408465560] *CallStack::new:CallStack +40
[4408468273] *Exception#initialize<Exception, String, Nil>:CallStack +33
[4408468204] *Exception::new<String>:Exception +92
[4408453801] *raise<String>:NoReturn +9
[4408460195] ~proc( -> Void)@./foo.cr:5 +19
[4408452851] __crystal_main +2371
[4408460008] main +40
```