### PR TITLE
HTTP::Client: assume http scheme if none given. Fixes #2117

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -59,8 +59,14 @@ module HTTP
     end
 
     it "raises if URI is missing scheme" do
-      expect_raises(ArgumentError) do
-        HTTP::Client.get "www.example.com"
+      expect_raises(ArgumentError, "must have scheme") do
+        HTTP::Client.get URI.parse("www.example.com")
+      end
+    end
+
+    it "raises if URI is missing host" do
+      expect_raises(ArgumentError, "must have host") do
+        HTTP::Client.get URI.parse("localhost:3000")
       end
     end
 

--- a/src/http/client/client.cr
+++ b/src/http/client/client.cr
@@ -434,27 +434,43 @@ class HTTP::Client
     end
   end
 
-  private def self.exec(uri)
-    uri = URI.parse(uri) if uri.is_a?(String)
+  private def self.exec(string : String)
+    uri = URI.parse(string)
 
-    unless uri.scheme
-      raise ArgumentError.new %(Request URI must have schema. Possibly add "http://" to the request URI?)
+    unless uri.scheme && uri.host
+      # Assume http if no scheme and host are specified
+      uri = URI.parse("http://#{string}")
     end
 
-    host = uri.host.not_nil!
+    exec(uri) do |client, path|
+      yield client, path
+    end
+  end
+
+  private def self.exec(uri : URI)
+    scheme = uri.scheme
+    unless scheme
+      raise ArgumentError.new %(Request URI must have scheme. Possibly add "http://" to the request URI? (URI is: #{uri}))
+    end
+
+    host = uri.host
+    unless host
+      raise ArgumentError.new %(Request URI must have host (URI is: #{uri}))
+    end
+
     port = uri.port
     path = uri.full_path
     user = uri.user
     password = uri.password
     ssl = false
 
-    case uri.scheme
+    case scheme
     when "http"
       # Nothing
     when "https"
       ssl = true
     else
-      raise "Unsuported scheme: #{uri.scheme}"
+      raise "Unsuported scheme: #{scheme}"
     end
 
     HTTP::Client.new(host, port, ssl) do |client|


### PR DESCRIPTION
To do it, we do `URI.parse(string)`. If the resulting URI doesn't have a scheme and a host, add "http://" to the beginning of the string and try again.

This is probably faster than always checking the string with a regex or with starts_with?, at least it's faster in the happy path, where a scheme is provided.