### PR TITLE
String: handle printf's dynamic width and precision

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1025,6 +1025,11 @@ describe "String" do
     ("%-s" % 'a').should eq("a")
     ("%20s" % 'a').should eq("                   a")
     ("%-20s" % 'a').should eq("a                   ")
+    ("%*s" % [10, 123]).should eq("       123")
+    ("%.5s" % "foo bar baz").should eq("foo b")
+    ("%.*s" % [5, "foo bar baz"]).should eq("foo b")
+    ("%*.*s" % [20, 5, "foo bar baz"]).should eq("               foo b")
+    ("%-*.*s" % [20, 5, "foo bar baz"]).should eq("foo b               ")
 
     ("%%%d" % 1).should eq("%1")
     ("foo %d bar %s baz %d goo" % [1, "hello", 2]).should eq("foo 1 bar hello baz 2 goo")
@@ -1071,6 +1076,8 @@ describe "String" do
     ("%.f" % 1234.56).should eq("1235")
     ("%.2f" % 1234.5678).should eq("1234.57")
     ("%10.2f" % 1234.5678).should eq("   1234.57")
+    ("%*.2f" % [10, 1234.5678]).should eq("   1234.57")
+    ("%0*.2f" % [10, 1234.5678]).should eq("0001234.57")
     ("%e" % 123.45).should eq("1.234500e+02")
     ("%E" % 123.45).should eq("1.234500E+02")
     ("%G" % 12345678.45).should eq("1.23457E+07")
@@ -1078,10 +1085,14 @@ describe "String" do
     ("%A" % 12345678.45).should eq("0X1.78C29CE666666P+23")
     ("%100.50g" % 123.45).should eq("                                                  123.4500000000000028421709430404007434844970703125")
 
-    ("%.2f" % 2.536_f32).should eq("2.54")
-
     span = 1.second
     ("%s" % span).should eq(span.to_s)
+
+    ("%.2f" % 2.536_f32).should eq("2.54")
+    ("%0*.*f" % [10, 2, 2.536_f32]).should eq("0000002.54")
+    expect_raises(ArgumentError, "expected dynamic value '*' to be an Int - \"not a number\" (String)") do
+      "%*f" % ["not a number", 2.536_f32]
+    end
   end
 
   it "escapes chars" do


### PR DESCRIPTION
Width field:
------------

The Width field specifies a minimum number of characters to output, and
is typically used to pad fixed-width fields in tabulated output, where
the fields would otherwise be smaller, although it does not cause
truncation of oversized fields.

The width field may be omitted, or a numeric integer value, or a dynamic
value when passed as another argument when indicated by an asterisk "`*`".
For example, `printf("%*d", 5, 10)` will result in "`   10`" being printed,
with a total width of 5 characters.

Though not part of the width field, a leading zero is interpreted as the
zero-padding flag mentioned above, and a negative value is treated as
the positive value in conjunction with the left-alignment "`-`" flag also
mentioned above.

Precision field:
----------------

The Precision field usually specifies a maximum limit on the output,
depending on the particular formatting type. For floating point numeric
types, it specifies the number of digits to the right of the decimal
point that the output should be rounded. For the string type, it limits
the number of characters that should be output, after which the string
is truncated.

The precision field may be omitted, or a numeric integer value, or a
dynamic value when passed as another argument when indicated by an
asterisk "`*`". For example, `printf("%.*s", 3, "abcdef")` will result in
"`abc`" being printed.

-- Source: https://en.wikipedia.org/wiki/Printf_format_string

Closes #2137