### PR TITLE
Spec: Make it possible to use multiple formatters

### DIFF
--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -31,7 +31,8 @@ module Spec
     end
 
     def report(result)
-      Spec.formatter.report(result)
+      Spec.formatters.each(&.report(result))
+
       @results[result.kind] << result
     end
 
@@ -44,7 +45,7 @@ module Spec
     end
 
     def print_results(elapsed_time)
-      Spec.formatter.finish
+      Spec.formatters.each(&.finish)
 
       pendings = @results[:pending]
       unless pendings.empty?
@@ -133,9 +134,9 @@ module Spec
     def self.describe(description, file, line, &block)
       describe = Spec::NestedContext.new(description, file, line, @@contexts_stack.last)
       @@contexts_stack.push describe
-      Spec.formatter.push describe
+      Spec.formatters.each(&.push(describe))
       block.call
-      Spec.formatter.pop
+      Spec.formatters.each(&.pop)
       @@contexts_stack.pop
     end
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -11,7 +11,7 @@ module Spec::DSL
     return if Spec.aborted?
     return unless Spec.matches?(description, file, line)
 
-    Spec.formatter.before_example description
+    Spec.formatters.each(&.before_example(description))
 
     begin
       Spec.run_before_each_hooks
@@ -32,7 +32,7 @@ module Spec::DSL
     return if Spec.aborted?
     return unless Spec.matches?(description, file, line)
 
-    Spec.formatter.before_example description
+    Spec.formatters.each(&.before_example(description))
 
     Spec::RootContext.report(:pending, description, file, line)
   end

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -62,14 +62,11 @@ module Spec
     end
   end
 
-  @@formatter = DotFormatter.new
+  @@formatters = [] of Spec::Formatter
+  @@formatters << Spec::DotFormatter.new
 
   # :nodoc:
-  def self.formatter=(@@formatter)
-  end
-
-  # :nodoc:
-  def self.formatter
-    @@formatter
+  def self.formatters
+    @@formatters
   end
 end

--- a/src/spec/spec.cr
+++ b/src/spec/spec.cr
@@ -209,7 +209,7 @@ OptionParser.parse! do |opts|
     exit
   end
   opts.on("-v", "--verbose", "verbose output") do
-    Spec.formatter = Spec::VerboseFormatter.new
+    Spec.formatters.replace([Spec::VerboseFormatter.new])
   end
   opts.on("--no-color", "Disable colored output") do
     Spec.use_colors = false


### PR DESCRIPTION
First step on the attempt to implement multiple formatters.

The ideia is to make possible to add multiple formatters in order to create custom outputs for the specs.

Motivation:
* rspec/rspec-core#213
* http://www.rubydoc.info/gems/rspec-core/RSpec/Core/Formatters