### PR TITLE
fix parse responses that begins with \r\n

### DIFF
--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -73,6 +73,14 @@ class HTTP::Client
       response.body.should eq("")
     end
 
+    it "parses response starting with \\r\\n" do
+      response = Response.from_io(MemoryIO.new("\r\n\r\nHTTP/1.1 200 OK\r\n\r\n"))
+      response.status_code.should eq(200)
+      response.status_message.should eq("OK")
+      response.headers.size.should eq(0)
+      response.body.should eq("")
+    end
+
     it "parses response with duplicated headers" do
       response = Response.from_io(MemoryIO.new("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nWarning: 111 Revalidation failed\r\nWarning: 110 Response is stale\r\n\r\nhelloworld"))
       response.headers.get("Warning").should eq(["111 Revalidation failed", "110 Response is stale"])

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -84,7 +84,15 @@ class HTTP::Client::Response
   end
 
   def self.from_io(io, ignore_body = false, decompress = true, &block)
-    line = io.gets
+    line = nil
+    # skip \r\n lines before protocol line
+    while buf = io.gets
+      if buf != "\r\n"
+        line = buf
+        break
+      end
+    end
+
     if line
       pieces = line.split(3)
       http_version = pieces[0]


### PR DESCRIPTION
New fix for parse http responses that begins with `\r\n` characters before http protocol line, plus tests.