### PR TITLE
Scope ECR macros inside the ECR module: `ecr_file` -> `ECR.def_to_s`, `embed_ecr` -> `ECR.embed`

### DIFF
--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -6,7 +6,7 @@ class ECRSpecHelloView
   def initialize(@msg)
   end
 
-  ecr_file "#{__DIR__}/../data/test_template.ecr"
+  ECR.def_to_s "#{__DIR__}/../data/test_template.ecr"
 end
 
 describe "ECR" do
@@ -28,7 +28,7 @@ describe "ECR" do
     program.should eq(pieces.join("\n") + "\n")
   end
 
-  it "does ecr_file" do
+  it "does ECR.def_to_s" do
     view = ECRSpecHelloView.new("world!")
     view.to_s.strip.should eq("Hello world! 012")
   end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -2,38 +2,38 @@ require "ecr/macros"
 
 module Crystal::Doc
   record TypeTemplate, type, types do
-    ecr_file "#{__DIR__}/html/type.html"
+    ECR.def_to_s "#{__DIR__}/html/type.html"
   end
 
   record ListItemsTemplate, types, current_type do
-    ecr_file "#{__DIR__}/html/list_items.html"
+    ECR.def_to_s "#{__DIR__}/html/list_items.html"
   end
 
   record MethodSummaryTemplate, title, methods do
-    ecr_file "#{__DIR__}/html/method_summary.html"
+    ECR.def_to_s "#{__DIR__}/html/method_summary.html"
   end
 
   record MethodDetailTemplate, title, methods do
-    ecr_file "#{__DIR__}/html/method_detail.html"
+    ECR.def_to_s "#{__DIR__}/html/method_detail.html"
   end
 
   record MethodsInheritedTemplate, type, ancestor, methods, label do
-    ecr_file "#{__DIR__}/html/methods_inherited.html"
+    ECR.def_to_s "#{__DIR__}/html/methods_inherited.html"
   end
 
   record OtherTypesTemplate, title, type, other_types do
-    ecr_file "#{__DIR__}/html/other_types.html"
+    ECR.def_to_s "#{__DIR__}/html/other_types.html"
   end
 
   record MainTemplate, body, types, repository_name do
-    ecr_file "#{__DIR__}/html/main.html"
+    ECR.def_to_s "#{__DIR__}/html/main.html"
   end
 
   struct JsTypeTemplate
-    ecr_file "#{__DIR__}/html/js/doc.js"
+    ECR.def_to_s "#{__DIR__}/html/js/doc.js"
   end
 
   struct StyleTemplate
-    ecr_file "#{__DIR__}/html/css/style.css"
+    ECR.def_to_s "#{__DIR__}/html/css/style.css"
   end
 end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -176,7 +176,7 @@ module Crystal
 
     macro template(name, template_path, full_path)
       class {{name.id}} < View
-        ecr_file "{{TEMPLATE_DIR.id}}/{{template_path.id}}"
+        ECR.def_to_s "{{TEMPLATE_DIR.id}}/{{template_path.id}}"
         def full_path
           "#{config.dir}/#{{{full_path}}}"
         end

--- a/src/ecr/ecr.cr
+++ b/src/ecr/ecr.cr
@@ -7,18 +7,19 @@
 #
 # Quick Example:
 #
-#     require "ecr"
+#     require "ecr/macros"
 #
 #     class Greeting
 #       def initialize(@name)
 #       end
-#       ecr_file "greeting.ecr"
+#
+#       ECR.def_to_s "greeting.ecr"
 #     end
 #
 #     # greeting.ecr
 #     Greeting, <%= @name %>!
 #
-#     Greeting.new("John")
+#     Greeting.new("John").to_s
 #     #=> Greeting, John!
 #
 # Using logical statements:
@@ -30,16 +31,19 @@
 #       Greeting!
 #     <% end %>
 #
-#     Greeting.new(nil)
+#     Greeting.new(nil).to_s
 #     #=> Greeting!
 #
 # Using loops:
+#
+#     require "ecr/macros"
 #
 #     class Greeting
 #       def initialize(*names)
 #        @names = names
 #       end
-#       ecr_file "greeting.ecr"
+#
+#       ECR.def_to_s "greeting.ecr"
 #     end
 #
 #     # greeting.ecr
@@ -47,7 +51,7 @@
 #       Hi, <%= name %>!
 #     <% end %>
 #
-#     Greeting.new("John","Zoe","Ben")
+#     Greeting.new("John", "Zoe", "Ben").to_s
 #     #=> Hi, John!
 #     #=> Hi, Zoe!
 #     #=> Hi, Ben!
@@ -58,10 +62,12 @@ module ECR
 
   DefaultBufferName = "__str__"
 
+  # :nodoc:
   def process_file(filename, buffer_name = DefaultBufferName)
     process_string File.read(filename), filename, buffer_name
   end
 
+  # :nodoc:
   def process_string(string, filename, buffer_name = DefaultBufferName)
     lexer = Lexer.new string
 

--- a/src/ecr/macros.cr
+++ b/src/ecr/macros.cr
@@ -1,9 +1,84 @@
+# :nodoc:
 macro embed_ecr(filename, io_name)
-  \{{ run("ecr/process", {{filename}}, {{io_name}}) }}
+  {{ puts "`embed_ecr` is deprecated, use `ECR.embed`".id }}
+  ECR.embed {{filename}}, {{io_name}}
 end
 
+# :nodoc:
 macro ecr_file(filename)
-  def to_s(__io__)
-    embed_ecr {{filename}}, "__io__"
+  {{ puts "`ecr_file` is deprecated, use `ECR.def_to_s`".id }}
+  ECR.def_to_s {{filename}}
+end
+
+module ECR
+  # Defines a `to_s(io)` method whose body is the ECR contained
+  # in *filename*, translated to Crystal code.
+  #
+  # ```text
+  # # greeting.ecr
+  # Hello <%= @name %>!
+  # ```
+  #
+  # ```
+  # require "ecr/macros"
+  #
+  # class Greeting
+  #   def initialize(@name)
+  #   end
+  #
+  #   ECR.def_to_s "greeting.ecr"
+  # end
+  #
+  # Greeting.new("World").to_s # => "Hello World!"
+  # ```
+  #
+  # The macro basically translates the text inside the given file
+  # to Crystal code that appends to the IO:
+  #
+  # ```
+  # class Greeting
+  #   def to_s(io)
+  #     io << "Hello "
+  #     io << @name
+  #     io << "!"
+  #   end
+  # end
+  # ```
+  macro def_to_s(filename)
+    def to_s(__io__)
+      embed_ecr {{filename}}, "__io__"
+    end
+  end
+
+  # Embeds an ECR file contained in *filename* into the program.
+  #
+  # The generated code is the result of translating the contents of
+  # the ECR file to Crystal, a program that appends to the IO
+  # with the given *io_name*.
+  #
+  # ```text
+  # # greeting.ecr
+  # Hello <%= name %>!
+  # ```
+  #
+  # ```
+  # require "ecr/macros"
+  #
+  # name = "World"
+  #
+  # io = MemoryIO.new
+  # ECR.embed "greeting.ecr", io
+  # io.to_s # => "Hello World!"
+  # ```
+  #
+  # The `ECR.embed` line basically generates this:
+  #
+  # ```
+  # io << "Hello "
+  # io << name
+  # io << "!"
+  # ```
+  macro embed(filename, io_name)
+    \{{ run("ecr/process", {{filename}}, {{io_name.id.stringify}}) }}
   end
 end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -70,7 +70,7 @@ class HTTP::StaticFileHandler < HTTP::Handler
       end
     end
 
-    ecr_file "#{__DIR__}/static_file_handler.html"
+    ECR.def_to_s "#{__DIR__}/static_file_handler.html"
   end
 
   private def directory_listing(io, request_path, path)


### PR DESCRIPTION
This is to avoid polluting the global namespace, since we have scoped macros for a while.

The old macros will still be available for one release, but produce a compile-time warning. Then we'll remove them.

I changed `ecr_file` to `ECR.def_to_s`, which is maybe more explicit: defines a `to_s` method whose contents are those of the ECR file. `ecr_file` told me nothing about a `to_s` method being generated, but maybe it's shorter and it's the one that is going to be used the most, so I'm open for suggestions to use `ECR.file` or something similar.