### PR TITLE
Check AtomicWithMethodCheck in parse_call_block_arg

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -368,6 +368,9 @@ describe "Parser" do
   it_parses "foo &.each {\n}", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
   it_parses "foo &.each do\nend", Call.new(nil, "foo", block: Block.new(["__arg0".var], Call.new("__arg0".var, "each", block: Block.new)))
 
+  it_parses "foo.[0]", Call.new("foo".call, "[]", 0.int32)
+  it_parses "foo.[0] = 1", Call.new("foo".call, "[]=", [0.int32, 1.int32] of ASTNode)
+
   it_parses "foo(a: 1, b: 2)", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])
   it_parses "foo(1, a: 1, b: 2)", Call.new(nil, "foo", [1.int32] of ASTNode, named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])
   it_parses "foo a: 1, b: 2", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)])

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -550,7 +550,7 @@ module Crystal
 
     parse_operator :pow, :atomic_with_method, "Call.new left, method, [right] of ASTNode, name_column_number: method_column_number", ":\"**\""
 
-    AtomicWithMethodCheck = [:IDENT, :"+", :"-", :"*", :"/", :"%", :"|", :"&", :"^", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :"!~", :">>", :">", :">=", :"<=>", :"||", :"&&", :"===", :"[]", :"[]=", :"[]?", :"!"]
+    AtomicWithMethodCheck = [:IDENT, :"+", :"-", :"*", :"/", :"%", :"|", :"&", :"^", :"**", :"<<", :"<", :"<=", :"==", :"!=", :"=~", :"!~", :">>", :">", :">=", :"<=>", :"||", :"&&", :"===", :"[]", :"[]=", :"[]?", :"[", :"!"]
 
     def parse_atomic_with_method
       location = @token.location
@@ -620,6 +620,8 @@ module Crystal
             atomic = parse_is_a(atomic).at(location)
           elsif @token.value == :responds_to?
             atomic = parse_responds_to(atomic).at(location)
+          elsif @token.type == :"["
+            return parse_atomic_method_suffix(atomic, location)
           else
             name = @token.type == :IDENT ? @token.value.to_s : @token.type.to_s
             end_location = token_end_location
@@ -1289,6 +1291,8 @@ module Crystal
         next_token_skip_space
 
         location = @token.location
+
+        check AtomicWithMethodCheck
 
         if @token.value == :is_a?
           call = parse_is_a(obj).at(location)


### PR DESCRIPTION
And, this pull request added new syntax:

```crystal
foo.[index]
```

It correspond to `&.[index]` syntax. Crystal accepts `&.[index]`, but not accept `foo.[index]`. I am fearful.

I thought `'&.[index]` should be removed, however it is useful to manipulate array elements. For example:

```crystal
# Get first elements
foo.each &.[0]
# Set first elements
foo.each &.[0] = 1

# If `&.[index]` was removed
foo.each &.[](0)
foo.each &.[]=(0, 1)
```

