### PR TITLE
Fix multiple inner lists

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -74,8 +74,10 @@ describe Markdown do
   assert_render "* Hello", "<ul><li>Hello</li></ul>"
   assert_render "* Hello\n* World", "<ul><li>Hello</li><li>World</li></ul>"
   assert_render "* Hello\n* World\n  * Crystal", "<ul><li>Hello</li><li>World</li><ul><li>Crystal</li></ul></ul>"
+  assert_render "* Level1\n  * Level2\n  * Level2\n* Level1", "<ul><li>Level1</li><ul><li>Level2</li><li>Level2</li></ul><li>Level1</li></ul>"
+  assert_render "* Level1\n  * Level2\n  * Level2", "<ul><li>Level1</li><ul><li>Level2</li><li>Level2</li></ul></ul>"
   assert_render "* Hello\nWorld", "<ul><li>Hello</li></ul>\n\n<p>World</p>"
-  assert_render "Params:\n  * Foo\n  * Bar", "<p>Params:</p>\n\n<ul><li>Foo</li><li>Bar</li></ul>"
+  assert_render "Params:\n* Foo\n* Bar", "<p>Params:</p>\n\n<ul><li>Foo</li><li>Bar</li></ul>"
 
   assert_render "+ Hello", "<ul><li>Hello</li></ul>"
   assert_render "- Hello", "<ul><li>Hello</li></ul>"

--- a/src/markdown/parser.cr
+++ b/src/markdown/parser.cr
@@ -221,7 +221,7 @@ class Markdown::Parser
 
       break unless starts_with_bullet_list_marker?(line, prefix)
 
-      if line.starts_with?("  ") && previous_line_is_not_intended_and_starts_with_bullt_list_marker?(prefix)
+      if line.starts_with?("  ") && previous_line_is_not_intended_and_starts_with_bullet_list_marker?(prefix)
         @renderer.begin_unordered_list
       end
 
@@ -229,7 +229,7 @@ class Markdown::Parser
       process_line line.byte_slice(line.index(prefix).not_nil! + 1)
       @renderer.end_list_item
 
-      if line.starts_with?("  ") && previous_line_is_not_intended_and_starts_with_bullt_list_marker?(prefix)
+      if line.starts_with?("  ") && next_line_is_not_intended? 
         @renderer.end_unordered_list
       end
 
@@ -513,9 +513,16 @@ class Markdown::Parser
     str[pos].chr.whitespace?
   end
 
-  def previous_line_is_not_intended_and_starts_with_bullt_list_marker?(prefix)
+  def previous_line_is_not_intended_and_starts_with_bullet_list_marker?(prefix)
     previous_line = @lines[@line - 1]
     !previous_line.starts_with?("  ") && starts_with_bullet_list_marker?(previous_line, prefix)
+  end
+
+  def next_line_is_not_intended?
+    return true unless @line + 1 < @lines.size
+
+    next_line = @lines[@line + 1]
+    !next_line.starts_with?("  ")
   end
 
   def starts_with_backticks?(line)


### PR DESCRIPTION
Multiple inner lists should now work as expected:

```Markdown
* Level1
  * Level2
  * Level2
* Level1
```

results in

```html
<ul>
  <li>Level1</li>
  <ul>
    <li>Level2</li>
    <li>Level2</li>
  </ul>
  <li>Level1</li>
</ul>
```

Fixes #2169 