### PR TITLE
CSV Extensions

### DIFF
--- a/spec/std/csv/csv_lex_spec.cr
+++ b/spec/std/csv/csv_lex_spec.cr
@@ -108,6 +108,19 @@ describe CSV do
       lexer.expect_eof
     end
 
+    it "lexes with a given separator" do
+      lexer = CSV::Lexer.new("hello;world\n", separator: ';')
+      lexer.expect_cell "hello"
+      lexer.expect_cell "world"
+      lexer.expect_eof
+    end
+
+    it "lexes with a given quote char" do
+      lexer = CSV::Lexer.new("'hello,world'\n", quote_char: '\'')
+      lexer.expect_cell "hello,world"
+      lexer.expect_eof
+    end
+
     it "raises if single quote in the middle" do
       expect_raises CSV::MalformedCSVError, "unexpected quote at 1:4" do
         lexer = CSV::Lexer.new %(hel"lo)

--- a/spec/std/csv/csv_parse_spec.cr
+++ b/spec/std/csv/csv_parse_spec.cr
@@ -70,6 +70,14 @@ describe CSV do
     it "parses from IO" do
       CSV.parse(MemoryIO.new(%("hel""lo",world))).should eq([[%(hel"lo), %(world)]])
     end
+
+    it "takes an optional separator argument" do
+      CSV.parse("foo;bar", separator: ';').should eq([["foo", "bar"]])
+    end
+
+    it "takes an optional quote char argument" do
+      CSV.parse("'foo,bar'", quote_char: '\'').should eq([["foo,bar"]])
+    end
   end
 
   it "parses row by row" do

--- a/src/csv/csv.cr
+++ b/src/csv/csv.cr
@@ -1,4 +1,7 @@
-class CSV; end
+class CSV
+  DEFAULT_SEPARATOR = ','
+  DEFAULT_QUOTE_CHAR = '"'
+end
 
 require "./**"
 
@@ -61,15 +64,21 @@ require "./**"
 # To create CSV data, check `CSV#build` and the `CSV::Builder` class.
 class CSV
   # Parses a CSV or IO into an array.
+  # takes optional *separator* and *quote_char* arguments for defining
+  # non-standard csv cell separators and quote characters
   #
   # ```
-  # CSV.parse("one,two\nthree") # => [["one", "two"], ["three"]]
+  # CSV.parse("one,two\nthree")
+  # # => [["one", "two"], ["three"]]
+  # CSV.parse("one;two\n'three;'", separator: ';', quote_char: '\'')
+  # # => [["one", "two"], ["three;"]]
   # ```
-  def self.parse(string_or_io : String | IO) : Array(Array(String))
-    Parser.new(string_or_io).parse
+  def self.parse(string_or_io : String | IO, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char) : Array(Array(String))
+    Parser.new(string_or_io, separator, quote_char).parse
   end
 
   # Yields each of a CSV's rows as an `Array(String)`.
+  # see `CSV.parse` about the *separator* and *quote_char* arguments
   #
   # ```
   # CSV.each_row("one,two\nthree") do |row|
@@ -83,20 +92,21 @@ class CSV
   # ["one", "two"]
   # ["three"]
   # ```
-  def self.each_row(string_or_io : String | IO)
+  def self.each_row(string_or_io : String | IO, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char)
     Parser.new(string_or_io).each_row do |row|
       yield row
     end
   end
 
   # Returns an `Iterator` of `Array(String)` over a CSV's rows.
+  # see `CSV.parse` about the *separator* and *quote_char* arguments
   #
   # ```
   # rows = CSV.each_row("one,two\nthree")
   # rows.next # => ["one", "two"]
   # rows.next # => ["three"]
   # ```
-  def self.each_row(string_or_io : String | IO)
+  def self.each_row(string_or_io : String | IO, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char)
     Parser.new(string_or_io).each_row
   end
 
@@ -139,8 +149,10 @@ class CSV
   #
   # If *headers* is true, row values can be accesed with header names or patterns.
   # Headers are always stripped.
-  def initialize(string_or_io : String | IO, headers = false, @strip = false)
-    @parser = Parser.new(string_or_io)
+  #
+  # see `CSV.parse` about the *separator* and *quote_char* arguments
+  def initialize(string_or_io : String | IO, headers = false, @strip = false, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char)
+    @parser = Parser.new(string_or_io, separator, quote_char)
     if headers
       headers = @parser.next_row || ([] of String)
       headers = @headers = headers.map &.strip
@@ -160,8 +172,10 @@ class CSV
   #
   # If *headers* is true, row values can be accesed with header names or patterns.
   # Headers are always stripped.
-  def self.new(string_or_io : String | IO, headers = false, strip = false)
-    csv = new(string_or_io, headers, strip)
+  #
+  # see `CSV.parse` about the *separator* and *quote_char* arguments
+  def self.new(string_or_io : String | IO, headers = false, strip = false, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char)
+    csv = new(string_or_io, headers, strip, separator, quote_char)
     csv.each do
       yield csv
     end

--- a/src/csv/lexer/io_based.cr
+++ b/src/csv/lexer/io_based.cr
@@ -1,7 +1,7 @@
 # :nodoc:
 class CSV::Lexer::IOBased < CSV::Lexer
-  def initialize(io)
-    super()
+  def initialize(io, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+    super(separator, quote_char)
     @io = io
     @current_char = @io.read_char || '\0'
   end
@@ -15,12 +15,12 @@ class CSV::Lexer::IOBased < CSV::Lexer
     @buffer.clear
     while true
       case current_char
-      when ','
+      when @separator
         check_last_empty_column
         break
       when '\r', '\n', '\0'
         break
-      when '"'
+      when @quote_char
         raise "unexpected quote"
       else
         @buffer << current_char

--- a/src/csv/lexer/string_based.cr
+++ b/src/csv/lexer/string_based.cr
@@ -1,7 +1,7 @@
 # :nodoc:
 class CSV::Lexer::StringBased < CSV::Lexer
-  def initialize(string)
-    super()
+  def initialize(string, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+    super(separator, quote_char)
     @reader = Char::Reader.new(string)
     if @reader.current_char == '\n'
       @line_number += 1
@@ -18,14 +18,14 @@ class CSV::Lexer::StringBased < CSV::Lexer
     end_pos = start_pos
     while true
       case next_char
-      when ','
+      when @separator
         end_pos = @reader.pos
         check_last_empty_column
         break
       when '\r', '\n', '\0'
         end_pos = @reader.pos
         break
-      when '"'
+      when @quote_char
         raise "unexpected quote"
       end
     end

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -3,8 +3,10 @@
 # Most of the time `CSV#parse` and `CSV#each_row` are more convenient.
 class CSV::Parser
   # Creates a parser from a `String` or `IO`.
-  def initialize(string_or_io : String | IO)
-    @lexer = CSV::Lexer.new(string_or_io)
+  # Optionally takes the optional *separator* and *quote_char* arguments for
+  # specifying non-standard cell separators and quote characters
+  def initialize(string_or_io : String | IO, separator = DEFAULT_SEPARATOR : Char, quote_char = DEFAULT_QUOTE_CHAR : Char)
+    @lexer = CSV::Lexer.new(string_or_io, separator, quote_char)
     @max_row_size = 3
   end
 


### PR DESCRIPTION
This adds optional `separator` and `quote_char` arguments to CSV parsing methods and initializers. While I don't think we should encourage producing non-standard csv with the builder I think _parsing_ non-standard csv is something we should allow since it's fairly common, unfortunately.