### PR TITLE
Adjust YAML spec to use `parse` instead of `load`

### DIFF
--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -31,17 +31,17 @@ describe "YAML" do
 
     describe "merging with << key" do
       it "merges other mapping" do
-        doc = YAML.load(%(---
+        doc = YAML.parse(%(---
           foo: bar
           <<:
             baz: foobar
-          )) as Hash
+          ))
         doc["baz"]?.should eq("foobar")
       end
 
       it "raises if merging with missing alias" do
         expect_raises do
-          YAML.load(%(---
+          YAML.parse(%(---
             foo:
               <<: *bar
           ))
@@ -49,7 +49,7 @@ describe "YAML" do
       end
 
       it "doesn't merge explicit string key <<" do
-        doc = YAML.load(%(---
+        doc = YAML.parse(%(---
           foo: &foo
             hello: world
           bar:
@@ -59,21 +59,21 @@ describe "YAML" do
       end
 
       it "doesn't merge empty mapping" do
-        doc = YAML.load(%(---
+        doc = YAML.parse(%(---
           foo: &foo
           bar:
             <<: *foo
-        )) as Hash
+        ))
         doc["bar"].should eq({"<<": ""})
       end
 
       it "doesn't merge arrays" do
-        doc = YAML.load(%(---
+        doc = YAML.parse(%(---
           foo: &foo
             - 1
           bar:
             <<: *foo
-        )) as Hash
+        ))
         doc["bar"].should eq({"<<": ["1"]})
       end
     end


### PR DESCRIPTION
`YAML.load` has been removed due recent `YAML::Any` merges and it
no longer exists, causing the build to fail.

This corrects the issue by using `YAML.parse` and removes the
Hash casting from the examples since is no longer necessary when
using `YAML::Any`.

Ref: #1887 