### PR TITLE
Add support to markdown task lists

### DIFF
--- a/spec/std/markdown/markdown_spec.cr
+++ b/spec/std/markdown/markdown_spec.cr
@@ -84,6 +84,9 @@ describe Markdown do
 
   assert_render "* Hello\n+ World\n- Crystal", "<ul><li>Hello</li></ul>\n\n<ul><li>World</li></ul>\n\n<ul><li>Crystal</li></ul>"
 
+  assert_render "- [ ] Todo",  %(<ul><li><input type="checkbox" disabled> Todo</li></ul>)
+  assert_render "- [x] Done",  %(<ul><li><input type="checkbox" disabled checked> Done</li></ul>)
+
   assert_render "1. Hello", "<ol><li>Hello</li></ol>"
   assert_render "2. Hello", "<ol><li>Hello</li></ol>"
   assert_render "01. Hello\n02. World", "<ol><li>Hello</li><li>World</li></ol>"

--- a/src/markdown/html_renderer.cr
+++ b/src/markdown/html_renderer.cr
@@ -115,4 +115,10 @@ class Markdown::HTMLRenderer
   def horizontal_rule
     @io << "<hr/>"
   end
+
+ def checkbox(checked? = false)
+    @io << %(<input type="checkbox" disabled)
+    @io << %( checked) if checked?
+    @io << %(> )
+  end
 end


### PR DESCRIPTION
Following github's [markdown](https://guides.github.com/features/mastering-markdown/) parser, add support to use task lists items.

Basically it converts a `[ ]` or `[x]` inside a list item to a read-only
checkbox.

Eg.

```markdown
- [x] Foo
- [ ] Bar 
```

Renders something like:
```html
<ul>
 <li><input type="checkbox" disabled checked> Foo</li>
 <li><input type="checkbox" disabled> Bar</li>
</ul>
```

**This is only available on unordered lists**

I would appreciate some code-review / feedback on this, I know there is a lot to improve, still it is a proposal and a work in progress.

